### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @saundefined @lex111

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,1 @@
-* @saundefined @lex111
+* @php/doc-ru-team


### PR DESCRIPTION
## Motivation

I want to take advantage of [CODEOWNERS mechanism](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) to stay on top of new PRs and respond to them faster. This increases the rate of feedback and allows all active maintainers to be aware of all incoming PRs.

But to make it work, me and @saundefined (for now) needs to be added to the collaborators of this repository, as described in docs:

> **The people you choose as code owners must have write permissions for the repository**. When the code owner is a team, that team must have write permissions, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.

@nikic could you please help with this or suggest who can do it?

P.S. Ideally, of course, it is better to have a GitHub team for each translation, this would avoid listing individual maintainers in CODEOWNERS file, and just make things in more organized way. I mean something like this (on example the Symfony book repo):

![image](https://user-images.githubusercontent.com/4408379/103474350-12375400-4db4-11eb-8cb8-30eb79044fb4.png)

Then in CODEOWNERS it was enough just to indicate the name of corresponding team (eg. `* @php/russian-translators`). As another advantage, we have a place for (internal) discussions. So I would certainly recommend to go this way, if possible.