### PR TITLE
Упрощение editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,17 +3,14 @@
 
 root = true
 
-[*.xml]
+[*]
 charset = utf-8
-indent_size = 1
-indent_style = space
 end_of_line = lf
-insert_final_newline = true
-
-
-[*.js]
-charset = utf-8
+indent_style = space
 indent_size = 2
-indent_style = space
-end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.xml]
+indent_size = 1
+trim_trailing_whitespace = false


### PR DESCRIPTION
В общем-то применяем ко всем файлам одни и те же правила. Вроде это не должно ничего сломать, единственно мне непонятно, можно ли удалять пробелы в конце строки (trim_trailing_whitespace) в XML-файлах? Я бы удалил, если бы знал наверняка, что после этого они пропадут (например) из сгенерированных страниц. Но как я понимаю, они не играют роли, если есть табуляция?

```
 <para>
  Начиная с этого момента мы будем описывать установку PHP для веб-серверов**(пробел в конце)**
  на Unix и Windows, как модуля сервера и как CGI.
 </para>
``` 

Результат:

> Начиная с этого момента мы будем описывать установку PHP для веб-серверов_**пробел**_на Unix и Windows, как модуля сервера и как CGI.

Верно?