### PR TITLE
Исправление опечатки

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -113,7 +113,7 @@
     </listitem>
     <listitem>
      <para>
-      <literal>time_cost</literal> (<type>int</type>) - Максимально возможное время^
+      <literal>time_cost</literal> (<type>int</type>) - Максимально возможное время,
       которое можно потратить для вычисления хеша Argon2.
       По умолчанию <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
      </para>


### PR DESCRIPTION
Была допущена опечатка, должна быть запятая, вместо ^