### PR TITLE
Сомнительный параметр в crypt

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -17,7 +17,7 @@
   <methodsynopsis>
    <type>string</type><methodname>crypt</methodname>
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>salt</parameter></methodparam>
+   <methodparam><type>string</type><parameter>salt</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>crypt</function> возвращает хешированную строку,


### PR DESCRIPTION
В документации метод `crypt` имеет вид:
```
<methodparam><type>string</type><parameter>salt</parameter></methodparam>
```
https://github.com/php/doc-en/blob/master/reference/strings/functions/crypt.xml#L18

Можно сказать, что этот параметр опциональный, но строка из документации намекает, что лучше считать этот параметр обязательным.

>  Параметр salt является необязательным. Однако без salt функция crypt() создаёт слабый пароль. PHP 5.6 и новее вызывают ошибку E_NOTICE, если не использовать соль.