### PR TITLE
Deleted duplication of example

### DIFF
--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -58,14 +58,8 @@ $bar->do_foo();
 <![CDATA[
 <?php
 $obj = (object) array('1' => 'foo');
-var_dump(isset($obj->{'1'})); // выводит 'bool(false)'
-var_dump(key($obj)); // выводит 'int(1)'
-
-$obj = (object) array('1' => 'foo');
 var_dump(isset($obj->{'1'})); // выводит 'bool(true)', начиная с PHP 7.2.0; 'bool(false)' ранее
 var_dump(key($obj)); // выводит 'string(1) "1"', начиная с PHP 7.2.0; 'int(1)' ранее
-
-
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Удалено дублирование примера в статье об объектах в соотвествии с https://www.php.net/manual/en/language.types.object.php