### PR TITLE
Updated actual functions using in examples of get_resource_type

### DIFF
--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -60,17 +60,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// выводит: mysql link
-$c = mysql_connect();
-echo get_resource_type($c) . "\n";
-
 // выводит: stream
 $fp = fopen("foo", "w");
 echo get_resource_type($fp) . "\n";
 
-// выводит: domxml document
-$doc = new_xmldoc("1.0");
-echo get_resource_type($doc->doc) . "\n";
+// prints: curl
+$c = curl_init ();
+echo get_resource_type($c) . "\n"; // это работает до версии PHP 8.0.0 так как с версии 8.0 curl_init возвращает объект CurlHandle, а не ресурс
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
В примерах к get_resource_type используются функции mysql_connect, которая deprecated c PHP 5.5, а также функция new_xmldoc, которая уже удалена.
В примерах использования хорошо указывать актуальные функции.
Данный MR сделан в соответствии с принятым MR https://github.com/php/doc-en/pull/454