### PR TITLE
Added extended examples for Object To Array

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -796,27 +796,70 @@ $error_descriptions[8] = "Это лишь неофициальное замеч�
    к закрытым полям класса (private) спереди будет дописано имя класса;
    к защищённым полям класса (protected) спереди будет добавлен символ '*'.
    Эти добавленные значения с обоих сторон также имеют нулевые байты.
-   Это может вызвать несколько неожиданное поведение:
   </para>
 
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+class A {
+    private $B;
+    protected $C;
+    public $D;
+    function __construct()
+    {
+        $this->{1} = null;
+    }
+}
+var_export((array) new A());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+array (
+  '' . "\0" . 'A' . "\0" . 'B' => NULL,
+  '' . "\0" . '*' . "\0" . 'C' => NULL,
+  'D' => NULL,
+  1 => NULL,
+)
+]]>
+   </screen>
+  </informalexample>
 
+  <para>
+   Это может вызвать несколько неожиданное поведение:
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+    <![CDATA[
+<?php
 class A {
     private $A; // Это станет '\0A\0A'
 }
-
 class B extends A {
     private $A; // Это станет '\0B\0A'
     public $AA; // Это станет 'AA'
 }
-
 var_dump((array) new B());
 ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+array(3) {
+  ["BA"]=>
+  NULL
+  ["AA"]=>
+  NULL
+  ["AA"]=>
+  NULL
+}
+]]>
+   </screen>
   </informalexample>
 
   <para>


### PR DESCRIPTION
Добавлен пример в соответствии с https://github.com/php/doc-en/pull/453 и https://www.php.net/manual/en/language.types.array.php