### PR TITLE
Удаление инструкции про принятие PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,3 @@
 ## Помощь
 
 Если вы хотите поучаствовать в переводе, пожалуйста, ознакомьтесь с [данным руководством](CONTRIBUTING.md).
-
-## Принятие пулреквестов
-
-Для пользователей с кармой `doc/ru` команда для принятия пулреквеста:
-
-```shell
-# В качестве origin используется git@git.php.net:/doc/ru.git
-# git remote add origin git@git.php.net:/doc/ru.git
-
-bash scripts/apply_patch.sh %PR_NUM%
-
-# То же самое, но вручную:
-curl -L "http://url_of_github_patch.patch" | git am
-git commit --am # Добавить в конец "Closes GH-%PR_NUM%"
-git push origin
-```

--- a/scripts/apply_patch.sh
+++ b/scripts/apply_patch.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-
-curl -L "https://github.com/php/doc-ru/pull/$1.patch" | git am
-git commit --amend -m "$(git log --format=%B -n 1)" -m "Closes GH-$1"
-git push origin master


### PR DESCRIPTION
В связи с [изменением рабочего процесса](https://news-web.php.net/php.internals/113838), инструкция становится неактуальной.

PR принимаются и закрываются через интерфейс GitHub командой @php/doc-ru-team.
