### PR TITLE
Fixes in Language Reference

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1768,18 +1768,6 @@ function standard_array_compare($op1, $op2)
    </para>
   </warning>
 
-  <sect2 role="seealso">
-   &reftitle.seealso;
-   <para>
-    <simplelist>
-     <member><function>strcasecmp</function></member>
-     <member><function>strcmp</function></member>
-     <member><link linkend="language.operators.array">Операторы, работающие с массивами</link></member>
-     <member><link linkend="language.types">Типы</link></member>
-    </simplelist>
-   </para>
-  </sect2>
-
   <sect2 xml:id="language.operators.comparison.ternary">
    <title>Тернарный оператор</title>
    <para>
@@ -1829,7 +1817,7 @@ if (empty($_POST['action'])) {
     <para>
      Рекомендуется избегать "нагромождения" тернарных выражений.
      Поведение PHP неочевидно при использовании более чем одного тернарного оператора без скобок
-     в одном выражении неочевидно по сравнению с другими языками.
+     в одном выражении по сравнению с другими языками.
      Действительно, до PHP 8.0.0 троичные выражения оценивались лево-ассоциативными, а не право-ассоциативными, как в большинстве других языков программирования.
      Использование лево-ассоциативности устарело в PHP 7.4.0.
      Начиная с PHP 8.0.0, тернарный оператор неассоциативен.
@@ -1857,6 +1845,7 @@ echo ((true ? 'true' : false) ? 't' : 'f');
     </para>
    </note>
   </sect2>
+
   <sect2 xml:id="language.operators.comparison.coalesce">
    <title>Оператор объединения с null</title>
    <para>
@@ -1918,6 +1907,18 @@ echo $foo ?? $bar ?? $baz ?? $qux; // выведет 1
      </example>
     </para>
    </note>
+  </sect2>
+
+  <sect2 role="seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><function>strcasecmp</function></member>
+     <member><function>strcmp</function></member>
+     <member><link linkend="language.operators.array">Операторы, работающие с массивами</link></member>
+     <member><link linkend="language.types">Типы</link></member>
+    </simplelist>
+   </para>
   </sect2>
  </sect1>
 

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -34,7 +34,7 @@
     <literal>$this</literal> - это специальная переменная, которой
     нельзя ничего присваивать.
     До PHP 7.1.0 было возможно косвенное присвоение (например, с использованием
-    <link linkend="language.variables.variable">переменных переменных</link>)).
+    <link linkend="language.variables.variable">переменных переменных</link>).
    </simpara>
   </note>
 
@@ -885,7 +885,7 @@ if ($_POST) {
      Если внешнее имя переменной начинается с корректного синтаксиса массива,
      завершающие символы молча игнорируются.
      Например, <literal>&lt;input name="foo[bar]baz"&gt;</literal>
-     becomes <literal>$_REQUEST['foo']['bar']</literal>.
+     станет <literal>$_REQUEST['foo']['bar']</literal>.
     </simpara>
    </note>
 


### PR DESCRIPTION
Возможно operators.xml стоит запушить в англоязычную версию, т.к. блок "See Also" обычно находится перед "User Contributed Notes"