### PR TITLE
Исправлено описание возвращаемых значений array_diff_key

### DIFF
--- a/reference/array/functions/array-diff-key.xml
+++ b/reference/array/functions/array-diff-key.xml
@@ -53,8 +53,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Возвращает массив (<type>array</type>), содержащий все элементы
-   <parameter>arrays</parameter> с ключами, которых нет во всех последующих
+   Возвращает массив, содержащий все элементы
+   <parameter>array</parameter> с ключами, которых нет во всех последующих
    массивах.
   </para>
  </refsect1>

--- a/reference/array/functions/array-diff-key.xml
+++ b/reference/array/functions/array-diff-key.xml
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Возвращает массив, содержащий все элементы
+   Возвращает массив (<type>array</type>), содержащий все элементы
    <parameter>array</parameter> с ключами, которых нет во всех последующих
    массивах.
   </para>


### PR DESCRIPTION
В описании функции array_diff_key в возвращаемых значениях некорректное описание и ошибочное указание параметра. Поправил в соответствии с английской документацией. И теперь более понятно.