### PR TITLE
Исправление описания session.lazy_write

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -991,8 +991,8 @@
     </term>
     <listitem>
      <simpara>
-      Если <literal>session.lazy_write</literal> установлен в 1, то при
-      изменении данных сессии они будут только перезаписываться. По умолчанию 1, включено.
+      Если <literal>session.lazy_write</literal> установлен в 1, то данные сессии
+      будут перезаписываться только при их изменении. По умолчанию 1, включено.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Дословный перевод неправильно передаёт суть опции.