### PR TITLE
Fix typo in zip configure.xml

### DIFF
--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -10,7 +10,7 @@
    <title>Системы Linux</title>
    <para>
     Начиная с PHP 7.4.0, чтобы использовать эти функции, вы должны скомпилировать PHP с поддержкой zip
-    с помощью <option role="configure">--enable-zip</option>.
+    с помощью <option role="configure">--with-zip</option>.
     Ранее поддержку zip нужно было включать с помощью параметра конфигурации <option role="configure">--enable-zip</option>.
     Начиная с PHP 7.4.0, пакет libzip удалён.
    </para>


### PR DESCRIPTION
In fact, as of PHP 7.4 zip support is enabled with the --with-zip flag. In russian translation it's --enable-zip