### PR TITLE
Исправление ошибки в reference/datetime/formats.xml

### DIFF
--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -737,12 +737,12 @@
      </row>
      <row>
       <entry>'back of' <literal>hour</literal></entry>
-      <entry>Без 15 минут заданный час</entry>
+      <entry>15 минут заданного часа</entry>
       <entry>"back of 7pm", "back of 15"</entry>
      </row>
      <row>
       <entry>'front of' <literal>hour</literal></entry>
-      <entry>15 минут заданного часа</entry>
+      <entry>Без 15 минут заданный час</entry>
       <entry>"front of 5am", "front of 23"</entry>
      </row>
      <row>


### PR DESCRIPTION
Привет, исправил ошибку в переводе "front of" и "back of" на странице reference/datetime/formats.xml

```php
<?php 
$date = new DateTime('front of 7pm');
echo $date->format('H:i'); // "18:45" - что соответственно без 15
```
в английской версии ошибки нет