### PR TITLE
Исправление неточностей в описании `exit()`

### DIFF
--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -37,7 +37,7 @@
      <listitem>
       <para>
        Если <parameter>status</parameter> задан в виде строки, то эта
-       функция выведет содержимое <parameter>status</parameter> перед выходом.
+       конструкция выведет содержимое <parameter>status</parameter> перед выходом.
       </para>
       <para>
        Если <parameter>status</parameter> задан в виде целого числа (<type>int</type>),
@@ -143,7 +143,7 @@ echo 'Эта строка не будет выведена.';
 
   <note>
    <para>
-    Эта языковая конструкция эквивалентна функции <function>die</function>, однако в отличие от неё соединение не объявляется закрытым.
+    Эта языковая конструкция эквивалентна конструкции <function>die</function>.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
По поводу die: в английской версии отсутствует эквивалент "однако в отличие от неё соединение не объявляется закрытым".