### PR TITLE
Удалено определение не использующейся затем в примере константы

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -742,7 +742,6 @@ He drank some juice made of apples.
      <programlisting role="php">
 <![CDATA[
 <?php
-define('KOOLAID', 'koolaid1');
 $juices = array("apple", "orange", "koolaid1" => "purple");
 
 echo "He drank some $juices[0] juice.".PHP_EOL;


### PR DESCRIPTION
В английской версии отсутствует определение константы и поэтому более понятно использование строки без кавычек в качестве ключа массива.