### PR TITLE
Update filters.xml

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -231,17 +231,10 @@
       </thead>
       <tbody>
        <row>
-        <entry>8.1.0</entry>
-        <entry>
-         Константа <constant>FILTER_SANITIZE_STRING</constant> и
-         <constant>FILTER_SANITIZE_STRIPPED</constant> объявлены устаревшими.
-        </entry>
-       </row>
-       <row>
         <entry>8.0.0</entry>
         <entry>
-         Флаг <constant>FILTER_FLAG_SCHEME_REQUIRED</constant>,
-         <constant>FILTER_FLAG_HOST_REQUIRED</constant> и
+         Флаги <constant>FILTER_FLAG_SCHEME_REQUIRED</constant> и
+         <constant>FILTER_FLAG_HOST_REQUIRED</constant> для фильтра
          <constant>FILTER_VALIDATE_URL</constant> были удалены.
          Флаги <literal>scheme</literal> и <literal>host</literal>
          являются (и были) всегда обязательными.
@@ -470,6 +463,13 @@ filter.default_flags = 0
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.1.0</entry>
+        <entry>
+         Константа <constant>FILTER_SANITIZE_STRING</constant> и
+         <constant>FILTER_SANITIZE_STRIPPED</constant> объявлены устаревшими.
+        </entry>
+       </row>
        <row>
         <entry>8.0.0</entry>
         <entry>


### PR DESCRIPTION
На странице [Фильтры валидации данных](https://www.php.net/manual/ru/filter.filters.validate.php) исправлены неточности и перенесено изменение на страницу [Очищающие фильтры](https://www.php.net/manual/ru/filter.filters.sanitize.php).

Теперь должно быть как в оригинальной версии на текущий момент.