### PR TITLE
Update mb-chr.xml

### DIFF
--- a/reference/mbstring/functions/mb-chr.xml
+++ b/reference/mbstring/functions/mb-chr.xml
@@ -47,7 +47,7 @@
   &reftitle.returnvalues;
   <para>
    Строка, содержащая запрошенный символ, если она может быть представлена в указанной
-   кодировке&return.falseforfailure;.
+   кодировке,&return.falseforfailure;.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Пропущена запятая после придаточного условия «если она может быть представлена в указанной кодировке».

Без запятой предложение читается так, как будто строка может быть представлена либо в указанной кодировке, либо в виде false.
