### PR TITLE
Update mb-strtolower.xml

### DIFF
--- a/reference/mbstring/functions/mb-strtolower.xml
+++ b/reference/mbstring/functions/mb-strtolower.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <parameter>str</parameter>, буквы в которой приведены к нижнему регистру.
+   <parameter>string</parameter>, буквы в которой приведены к нижнему регистру.
   </para>
  </refsect1>
 


### PR DESCRIPTION
В описании функции mb_strtoupper в описании возвращаемого значения слово string написано полностью, а здесь почему-то сокращенно: str

https://www.php.net/manual/ru/function.mb-strtoupper.php

При этом сокращенное написание str не встречается в других частях описания функции. Начинаешь сомневаться: та ли это string, которая указана в сигнатуре, или какая-то другая?