### PR TITLE
Update query.xml

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -38,13 +38,14 @@
   </para>
   <note>
    <para>
-    В случае, если длина выражения, которое передаётся в
-    <function>mysqli_query</function>, больше, чем
-    <literal>max_allowed_packet</literal> сервера, возвращаемые коды ошибки могут
-    различаться в зависимости от используемого драйвера. А это может быть либо
-    родной MySQL драйвер (<literal>mysqlnd</literal>), либо клиентская библиотека
-    MySQL (<literal>libmysqlclient</literal>). Поведение функции будет следующим:
+    Если длина передаваемого в функцию
+    <function>mysqli_query</function> выражения больше
+    значения системной переменной <literal>max_allowed_packet</literal> сервера, будет сгенерирована ошибка.
+    MySQL-драйвер (<literal>mysqlnd</literal>) и клиентская библиотека
+    MySQL (<literal>libmysqlclient</literal>) выбрасывают разные коды ошибок.
+    Поведение функции будет следующим:
    </para>
+
    <itemizedlist>
     <listitem>
      <para>
@@ -90,20 +91,20 @@
        как результат будет возвращён сервером MySQL.
       </para>
       <para>
-       <constant>MYSQLI_STORE_RESULT</constant> (по умолчанию) - возвращает объект
+       <constant>MYSQLI_STORE_RESULT</constant> (по умолчанию) — возвращает объект
        <classname>mysqli_result</classname> с буферизованным набором результатов.
       </para>
       <para>
-       <constant>MYSQLI_USE_RESULT</constant> - возвращает объект
+       <constant>MYSQLI_USE_RESULT</constant> — возвращает объект
        <classname>mysqli_result</classname> с небуферизованным набором результатов.
        Пока есть отложенные записи, ожидающие выборки, линия соединения будет занята
        и все последующие вызовы будут возвращать ошибку <literal>Commands out of sync</literal>.
        Чтобы избежать ошибки, все записи должны быть получены с сервера или набор результатов должен быть отброшен путём вызова <function>mysqli_free_result</function>.
       </para>
       <para>
-       <constant>MYSQLI_ASYNC</constant> (доступно с mysqlnd) - запрос выполняется асинхронно, набор результатов сразу не возвращается.
-       Затем используется <function>mysqli_poll</function> для получения результатов по этим запросам.
-       Используется в сочетании с константой
+       <constant>MYSQLI_ASYNC</constant> (доступно с mysqlnd) — запрос выполняется асинхронно, набор результатов сразу не возвращается.
+       Затем вызывают функцию <function>mysqli_poll</function> для получения результатов по этим запросам.
+       Можно использовать в сочетании с константой
        <constant>MYSQLI_STORE_RESULT</constant> или
        <constant>MYSQLI_USE_RESULT</constant>.
       </para>
@@ -118,7 +119,7 @@
   <para>
    Возвращает &false; в случае возникновения ошибки. В случае успешного выполнения запросов,
    которые создают набор результатов, таких как <literal>SELECT, SHOW, DESCRIBE</literal> или
-   <literal>EXPLAIN</literal>, <function>mysqli_query</function> вернёт объект <classname>mysqli_result</classname>.
+   <literal>EXPLAIN</literal>, функция <function>mysqli_query</function> вернёт объект <classname>mysqli_result</classname>.
    Для остальных успешных запросов <function>mysqli_query</function> вернёт &true;.
   </para>
  </refsect1>


### PR DESCRIPTION
Правки синтаксиса (дефис → тире); переформулирование некоторых предложений.

P. S. Не нашел, где я могу предложить изменение для переменной:

&mysqli.sqlinjection.warning

Текущее:

Если запрос содержит какие-либо входные переменные, вместо этого (вместо чего? — прим. мое) следует использовать подготавливаемые запросы. В качестве альтернативы данные должны быть правильно отформатированы и все строки должны быть экранированы с помощью функции mysqli_real_escape_string().


Предложение:

Вместо составления строки запроса с включением переменных значений необходимо <подготавливать запросы>. Либо строки запроса должны быть экранированы функцией mysqli_real_escape_string() и правильно отформатированы.


Аргументация:

Слова "вместо этого" не согласнованы с другими членами предложения.

Местоимения часто (почти всегда) созадают шум и могут быть опущены без потери смысла.

Полагаю, слова any variable input подразумевают "любой переменный ввод", а не "входные переменные", которые встречаются в описании принимаемых функциями параметров.

Вызов функции real_escape_string происходит внутри функции sprinft, поэтому такой вызов вначале экранирует, а затем форматирует строку: поэтому в предложении изменен порядок действий :-)