### PR TITLE
Array intersect .xml

### DIFF
--- a/reference/array/functions/array-intersect-assoc.xml
+++ b/reference/array/functions/array-intersect-assoc.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.array-intersect-assoc">
  <refnamediv>
   <refname>array_intersect_assoc</refname>
-  <refpurpose>Вычисляет схождение массивов с дополнительной проверкой индекса</refpurpose>
+  <refpurpose>Вычисляет пересечение массивов с дополнительной проверкой индекса</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    Функция <function>array_intersect_assoc</function> возвращает массив,
    содержащий все значения массива <parameter>array</parameter>,
    которые содержатся во всех указанных аргументах.
-   Обратите внимание, что при сравнении используются ключи, в отличие
+   Обратите внимание, что сравниваются ключи, в отличие
    от функции <function>array_intersect</function>.
   </simpara>
  </refsect1>
@@ -78,7 +78,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>array_intersect_assoc</function></title>
+    <title>Пример использования функции <function>array_intersect_assoc</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/array/functions/array-intersect-key.xml
+++ b/reference/array/functions/array-intersect-key.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.array-intersect-key">
  <refnamediv>
   <refname>array_intersect_key</refname>
-  <refpurpose>Вычислить пересечение массивов, сравнивая ключи</refpurpose>
+  <refpurpose>Вычисляет пересечение массивов, сравнивая ключи</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +15,9 @@
    <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_intersect_key</function> возвращает массив,
-   содержащий все элементы <parameter>array</parameter>,
-   имеющие ключи, содержащиеся во всех последующих параметрах.
+   Функция <function>array_intersect_key</function> возвращает массив,
+   содержащий все элементы массива <parameter>array</parameter>,
+   имеющие ключи, содержащиеся во всех других параметрах.
   </para>
  </refsect1>
 
@@ -49,7 +49,7 @@
   &reftitle.returnvalues;
   <para>
    Возвращает ассоциативный массив, содержащий все элементы
-   <parameter>array</parameter>, имеющие ключи, содержащиеся во всех остальных
+   массива <parameter>array</parameter>, имеющие ключи, содержащиеся во всех остальных
    параметрах.
   </para>
  </refsect1>
@@ -77,7 +77,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>array_intersect_key</function></title>
+    <title>Пример использования функции <function>array_intersect_key</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -103,16 +103,16 @@ array(2) {
   </para>
   <para>
    В данном примере только ключи <literal>'blue'</literal>
-   и <literal>'green'</literal> содержатся в обоих массивах и поэтому
-   возвращаются. Также обратите внимание, что значения, соответствующие ключам
-   <literal>'blue'</literal> и <literal>'green'</literal>, различны в исходных
-   массивах. Совпадение всё равно происходит, так как сравниваются только ключи.
-   Возвращаемые значения берутся из <parameter>array</parameter>.
+   и <literal>'green'</literal> содержатся в обоих массивах, и поэтому
+   возвращаются. Обратите внимание, что значения клюей
+   <literal>'blue'</literal> и <literal>'green'</literal> неодинаковые в двух
+   массивах. Совпадение всё равно есть, так как сравниваются только ключи.
+   Возвращаемые значения берутся из массива <parameter>array</parameter>.
   </para>
   <para>
-   Два ключа пар <literal>key =&gt; value</literal> считаются равными, только если
-   <literal>(string) $key1 === (string) $key2 </literal>. Другими словами,
-   применяется строгая проверка, означающая, что строковые представления должны
+   Два ключа пар <literal>key =&gt; value</literal> признаются равными, только если
+   выражение <literal>(string) $key1 === (string) $key2 </literal> истинно. Проще говоря,
+   выполняется строгая проверка строковых представлений, которые должны
    быть одинаковыми.
   </para>
  </refsect1>

--- a/reference/array/functions/array-intersect-uassoc.xml
+++ b/reference/array/functions/array-intersect-uassoc.xml
@@ -66,7 +66,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>array_intersect_uassoc</function></title>
+    <title>Пример использования функции <function>array_intersect_uassoc</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/array/functions/array-intersect-ukey.xml
+++ b/reference/array/functions/array-intersect-ukey.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.array-intersect-ukey">
  <refnamediv>
   <refname>array_intersect_ukey</refname>
-  <refpurpose>Вычисляет схождение массивов, используя callback-функцию для сравнения ключей</refpurpose>
+  <refpurpose>Вычисляет пересечение массивов, используя callback-функцию для сравнения ключей</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Возвращает все элементы <parameter>array</parameter>, чьи ключи
+   Возвращает все элементы массива <parameter>array</parameter>, чьи ключи
    существуют во всех переданных аргументах.
   </para>
  </refsect1>
@@ -63,7 +63,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>array_intersect_ukey</function></title>
+    <title>Пример использования фукции <function>array_intersect_ukey</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -99,11 +99,11 @@ array(2) {
   </para>
   <para>
    В нашем примере только ключи <literal>'blue'</literal>
-   и <literal>'green'</literal> содержатся в обоих массивах и поэтому
-   возвращаются. Также обратите внимание, что значения, соответствующие ключам
-   <literal>'blue'</literal> и <literal>'green'</literal> отличаются между
-   массивами. Совпадение всё равно происходит, так как сравниваются только ключи.
-   Возвращаемые значения берутся из <parameter>array</parameter>.
+   и <literal>'green'</literal> содержатся в обоих массивах, и поэтому
+   возвращаются. Обратите внимание, что значения, которые соответствуют ключам
+   <literal>'blue'</literal> и <literal>'green'</literal>, неодинаковые в двух
+   массивах. Совпадение всё равно есть, так как сравниваются только ключи.
+   Возвращаемые значения берутся из массива <parameter>array</parameter>.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-intersect.xml
+++ b/reference/array/functions/array-intersect.xml
@@ -77,7 +77,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>array_intersect</function></title>
+    <title>Пример использования функции <function>array_intersect</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/array/functions/array-intersect.xml
+++ b/reference/array/functions/array-intersect.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.array-intersect">
  <refnamediv>
   <refname>array_intersect</refname>
-  <refpurpose>Вычисляет схождение массивов</refpurpose>
+  <refpurpose>Вычисляет пересечение массивов</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/array/functions/array-intersect.xml
+++ b/reference/array/functions/array-intersect.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Возвращает массив, содержащий все значения <parameter>array</parameter>,
+   Возвращает массив, содержащий все значения параметра <parameter>array</parameter>,
    которые существуют во всех переданных аргументах.
   </para>
  </refsect1>
@@ -106,8 +106,8 @@ Array
   &reftitle.notes;
   <note>
    <simpara>
-    Два элемента считаются одинаковыми тогда и только тогда, когда
-    <literal>(string) $elem1 === (string) $elem2</literal>. Другими словами,
+    Два элемента признаются одинаковыми тогда и только тогда, когда выражение
+    <literal>(string) $elem1 === (string) $elem2</literal> истинно. Проще говоря:
     когда их строковые представления идентичны.
     <!-- TODO: example of it... -->
    </simpara>


### PR DESCRIPTION
Было: «схождение» и «пересечение» для разных array_intersect_*-функций. Для всех употребил слово «пересечение». Другие правки, упрощающие восприятие текста