### PR TITLE
Update to English pgsql/constants.xml

### DIFF
--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: aur Status: ready -->
+<!-- EN-Revision: 3f2e2d4a8c98368d8cd5dcf73d4728dfb4517f6d Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pgsql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -13,7 +13,7 @@
    </term>
    <listitem>
     <simpara>
-     Короткое обозначение версии libpq, содержащее только цифры и точки.
+     Короткое обозначение версии модуля libpq, содержащее только цифры и точки.
     </simpara>
    </listitem>
   </varlistentry>
@@ -24,7 +24,7 @@
    </term>
    <listitem>
     <simpara>
-     До PHP 8.0.0 - длинное обозначение версии libpq, которое включает информацию о компиляторе.
+     До PHP 8.0.0 — длинное обозначение версии модуля libpq, которое включает информацию о компиляторе.
      Начиная с PHP 8.0.0, значение идентично <constant>PGSQL_LIBPQ_VERSION</constant>,
      а использование <constant>PGSQL_LIBPQ_VERSION_STR</constant> устарело.
     </simpara>
@@ -85,7 +85,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_connect</function> для создания асинхронного соединения.
+     Передаётся в функцию <function>pg_connect</function> для создания асинхронного соединения.
     </simpara>
    </listitem>
   </varlistentry>
@@ -386,7 +386,7 @@
      <literal>FATAL</literal>, или <literal>PANIC</literal> (в сообщении об ошибке), либо
      <literal>WARNING</literal>, <literal>NOTICE</literal>, <literal>DEBUG</literal>,
      <literal>INFO</literal>, или <literal>LOG</literal> (в уведомлении), либо перевод
-     перечисленных значений в соответствии с используемой локализацией. Поле всегда определено.
+     перечисленных значений в соответствии с текущей локализацией. Поле всегда определено.
     </simpara>
    </listitem>
   </varlistentry>
@@ -397,7 +397,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Код ошибки SQLSTATE. Код SQLSTATE определяет тип произошедшей ошибки; он может быть использован
      прикладной программой при выполнении специфических операций (таких как обработка ошибки)
      в ответ на ошибку базы данных.
@@ -412,7 +412,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Основное удобочитаемое сообщение об ошибке (обычно одна строка). Поле всегда определено.
     </simpara>
    </listitem>
@@ -424,7 +424,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Детализация: дополнительное сообщение об ошибке, содержащее более подробную
      информацию о проблеме. Может содержать несколько строк.
     </simpara>
@@ -437,7 +437,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Подсказка: указание на возможные пути устранения ошибки. Отличается от детализации ошибки тем, что
      это просто предложения (возможно ошибочные), а не точная информация. Может содержать несколько строк.
     </simpara>
@@ -450,9 +450,10 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
-     Строка, содержащая десятичное целое число, указывающее на позицию курсора в исходном выражении, где произошла
-     ошибка. Первый символ имеет индекс 1, позиции исчисляются в символах, а не в байтах.
+     Передаётся в функцию <function>pg_result_error_field</function>.
+     Строка, содержащая целое десятичное число, указывающее на позицию курсора в исходном выражении,
+     в котором произошла ошибка.
+     Первый символ имеет индекс 1, позиции измеряются в символах, а не в байтах.
     </simpara>
    </listitem>
   </varlistentry>
@@ -463,10 +464,10 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
-     Определение тоже, что и для поля <constant>PG_DIAG_STATEMENT_POSITION</constant>, но
-     используется в случаях, когда курсор указывает на команду, сгенерированную сервером БД.
-     В таких случаях всегда появляется поле <constant>PG_DIAG_INTERNAL_QUERY</constant>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
+     Эта константа определена так же, как поле <constant>PG_DIAG_STATEMENT_POSITION</constant>,
+     но эту константу применяют, когда позиция курсора указывает на команду, сгенерированную сервером БД.
+     Поле <constant>PG_DIAG_INTERNAL_QUERY</constant> будет появляться каждый раз, когда появляется это поле.
     </simpara>
    </listitem>
   </varlistentry>
@@ -477,7 +478,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Текст ошибки, сгенерированной внутренней командой СУБД, в которой произошла ошибка. Это может быть,
      например, SQL-запрос, сформированный функцией PL/pgSQL.
     </simpara>
@@ -490,7 +491,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Указание на контекст, где произошла ошибка. В основном содержит трассировку
      запрограммированных функций и автоматически сгенерированных запросов. Трассировка
      выводится построчно, начиная с последней строки.
@@ -504,7 +505,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Имя файла исходного кода PostgreSQL, в котором отмечена ошибка.
     </simpara>
    </listitem>
@@ -516,7 +517,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Номер строки файла исходного кода PostgreSQL, где отмечена ошибка.
     </simpara>
    </listitem>
@@ -528,7 +529,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_error_field</function>.
+     Передаётся в функцию <function>pg_result_error_field</function>.
      Имя функции в исходном коде PostgreSQL, сообщающей об ошибке.
     </simpara>
    </listitem>
@@ -596,7 +597,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_set_error_verbosity</function>.
+     Передаётся в функцию <function>pg_set_error_verbosity</function>.
      Даёт предписание, что выдаваемые сообщения будут содержать только важность ошибки, основной текст
      и указатель на место, где она произошла; эта информация обычно умещается в одну строку.
     </simpara>
@@ -609,7 +610,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_set_error_verbosity</function>.
+     Передаётся в функцию <function>pg_set_error_verbosity</function>.
      В режиме по умолчанию сообщения об ошибках содержат описанную выше информацию, а также
      детализацию, подсказку или поля с контекстом ошибки (могут занимать несколько строк).
     </simpara>
@@ -622,7 +623,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_set_error_verbosity</function>.
+     Передаётся в функцию <function>pg_set_error_verbosity</function>.
      Задаёт режим, в котором в сообщения будут включены все возможные поля.
     </simpara>
    </listitem>
@@ -635,7 +636,7 @@
    </term>
    <listitem>
     <simpara>
-     Используется <function>pg_last_notice</function>.
+     Указывается в функции <function>pg_last_notice</function>.
      Доступно с PHP 7.1.0.
     </simpara>
    </listitem>
@@ -672,7 +673,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_status</function>. Указывает на то, что в качестве
+     Передаётся в функцию <function>pg_result_status</function>. Указывает на то, что в качестве
      возвращаемого значения ожидается числовой код.
     </simpara>
    </listitem>
@@ -684,7 +685,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_result_status</function>.  Указывает на то, что в качестве
+     Передаётся в функцию <function>pg_result_status</function>.  Указывает на то, что в качестве
      возвращаемого значения ожидается текстовое представление статуса.
     </simpara>
    </listitem>
@@ -697,7 +698,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_convert</function>.
+     Передаётся в функцию <function>pg_convert</function>.
      Игнорировать значения по умолчанию в таблице в процессе преобразования.
     </simpara>
    </listitem>
@@ -709,7 +710,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_convert</function>.
+     Передаётся в функцию <function>pg_convert</function>.
      Заменять пустые строки  <type>string</type> на SQL <literal>NULL</literal> при преобразовании.
     </simpara>
    </listitem>
@@ -721,7 +722,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_convert</function>.
+     Передаётся в функцию <function>pg_convert</function>.
      Указывает, что не нужно конвертировать &null; в столбцы SQL <literal>NOT NULL</literal>.
     </simpara>
    </listitem>
@@ -734,7 +735,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_insert</function>, <function>pg_select</function>,
+     Передаётся в функцию <function>pg_insert</function>, <function>pg_select</function>,
      <function>pg_update</function> и <function>pg_delete</function>.
      Все параметры передаются в исходном виде. Ручное экранирование обязательно,
      если параметры содержат пользовательские данные. Используйте для этих
@@ -749,7 +750,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_insert</function>, <function>pg_select</function>,
+     Передаётся в функцию <function>pg_insert</function>, <function>pg_select</function>,
      <function>pg_update</function> и <function>pg_delete</function>.
      Выполнить запрос с помощью этих функций.
     </simpara>
@@ -762,7 +763,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_insert</function>, <function>pg_select</function>,
+     Передаётся в функцию <function>pg_insert</function>, <function>pg_select</function>,
      <function>pg_update</function> и <function>pg_delete</function>.
      Выполнить асинхронный запрос с помощью этих функций.
     </simpara>
@@ -775,7 +776,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_insert</function>, <function>pg_select</function>,
+     Передаётся в функцию <function>pg_insert</function>, <function>pg_select</function>,
      <function>pg_update</function> и <function>pg_delete</function>.
      Вернуть строку с выполненным запросом.
     </simpara>
@@ -788,7 +789,7 @@
    </term>
    <listitem>
     <simpara>
-     Передаётся в <function>pg_insert</function>, <function>pg_select</function>,
+     Передаётся в функцию <function>pg_insert</function>, <function>pg_select</function>,
      <function>pg_update</function> и <function>pg_delete</function>.
      Применить экранирование ко всем параметрам вместо внутреннего вызова <function>pg_convert</function>.
      Эта опция пропускает просмотр метаданных. Запрос может быть таким же быстрым, как и
@@ -870,6 +871,72 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.pgsql-show-context-never">
+   <term>
+    <constant>PGSQL_SHOW_CONTEXT_NEVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Константу указывают при вызове функции <function>pg_set_error_context_visibility</function>,
+     скрывает показ контекста.
+     Доступна с PHP 8.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-show-context-errors">
+   <term>
+    <constant>PGSQL_SHOW_CONTEXT_ERRORS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Константу указывают при вызове функции <function>pg_set_error_context_visibility</function>,
+     поля контекста будут включены только в сообщения об ошибках.
+     Это поведение по умолчанию.
+     Доступна с PHP 8.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-show-context-always">
+   <term>
+    <constant>PGSQL_SHOW_CONTEXT_ALWAYS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Константу указывают при вызове функции <function>pg_set_error_context_visibility</function>,
+     поля контекста будут включены в сообщения об ошибках, уведомления и предупреждения.
+     Доступна с PHP 8.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-trace-suppress-timestamps">
+   <term>
+    <constant>PGSQL_TRACE_SUPPRESS_TIMESTAMPS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Константу указывают при вызове функции <function>pg_trace</function>,
+     метка времени не будет включена в сообщения трассировки.
+     Доступна с PHP 8.3.0.
+    </simpara>
+   </listitem>
+   </varlistentry>
+  <varlistentry xml:id="constant.pgsql-trace-regress-mode">
+   <term>
+    <constant>PGSQL_TRACE_REGRESS_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Константу указывают при вызове функции <function>pg_trace</function>,
+     поля наподобие OIDs будут включены в сообщение трассировки.
+     Доступна с PHP 8.3.0.
+    </simpara>
+   </listitem>
+   </varlistentry>
  </variablelist>
 </appendix>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Запрос на изменение опечаток в названии функции pg_set_error_context_SET_visibility (вместо pg_set_error_context_visibility) в англ. версии отправил. Как и для слов fieds вместо (как я полагаю) fields.