### PR TITLE
Update intl/dateformatter

### DIFF
--- a/reference/intl/dateformatter/create.xml
+++ b/reference/intl/dateformatter/create.xml
@@ -59,8 +59,8 @@
      <term><parameter>locale</parameter></term>
      <listitem>
       <para>
-       Языковой стандарт форматирования или синтаксического анализа
-       или &null; для выбора значения, указанного в ini-настройке
+       Языковой стандарт, который будет использован для форматирования или синтаксического анализа,
+       или &null; для выбора значения, заданного в ini-настройке
        <link linkend="ini.intl.default-locale">intl.default_locale</link>.
       </para>
      </listitem>

--- a/reference/intl/dateformatter/create.xml
+++ b/reference/intl/dateformatter/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: b2332afcd09ceceed83d1e82ad94d7734012bd6f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intldateformatter.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -59,8 +59,8 @@
      <term><parameter>locale</parameter></term>
      <listitem>
       <para>
-       Языковой стандарт, используемый при форматировании или синтаксическом анализе
-       или &null; для использования значения, указанного в ini-настройке
+       Языковой стандарт форматирования или синтаксического анализа
+       или &null; для выбора значения, указанного в ini-настройке
        <link linkend="ini.intl.default-locale">intl.default_locale</link>.
       </para>
      </listitem>
@@ -69,10 +69,10 @@
      <term><parameter>dateType</parameter></term>
      <listitem>
       <para>
-       Тип даты (<constant>none</constant>, <constant>short</constant>,
-       <constant>medium</constant>, <constant>long</constant>,
-       <constant>full</constant>).
-       Одна из <link linkend="intl.intldateformatter-constants">констант IntlDateFormatter</link>.
+       Формат даты, который был определён одной
+       <link linkend="intl.intldateformatter-constants">из констант IntlDateFormatter</link>.
+       Значение по умолчанию
+       <constant>IntlDateFormatter::FULL</constant>.
       </para>
      </listitem>
     </varlistentry>
@@ -80,10 +80,10 @@
      <term><parameter>timeType</parameter></term>
      <listitem>
       <para>
-       Тип времени (<constant>none</constant>, <constant>short</constant>,
-       <constant>medium</constant>, <constant>long</constant>,
-       <constant>full</constant>).
-       Одна из <link linkend="intl.intldateformatter-constants">констант IntlDateFormatter</link>.
+       Формат времени, который был определён одной
+       <link linkend="intl.intldateformatter-constants">из констант IntlDateFormatter</link>.
+       Значение по умолчанию
+       <constant>IntlDateFormatter::FULL</constant>.
       </para>
      </listitem>
     </varlistentry>
@@ -91,7 +91,7 @@
      <term><parameter>timezone</parameter></term>
      <listitem>
       <para>
-       Идентификатор часового пояса. По умолчанию (и тот, который используется, если указан &null;) - это тот,
+       Идентификатор часового пояса. По умолчанию (и тот, который используется, если указан &null;) — это тот,
        который возвращается <function>date_default_timezone_get</function> или, если применимо,
        объект <classname>IntlCalendar</classname>, указанный в параметре <parameter>calendar</parameter>.
        Этот идентификатор должен быть корректным идентификатором в базе данных ICU или идентификатором,
@@ -106,7 +106,7 @@
      <term><parameter>calendar</parameter></term>
      <listitem>
       <para>
-       Календарь для форматирования или анализа. Значение по умолчанию - &null;,
+       Календарь для форматирования или анализа. Значение по умолчанию — &null;,
        что соответствует <constant>IntlDateFormatter::GREGORIAN</constant>.
        Может быть одна из <link linkend="intl.intldateformatter-constants.calendartypes">констант IntlDateFormatter</link>
        или объект <classname>IntlCalendar</classname>.
@@ -151,25 +151,11 @@
      </thead>
      <tbody>
       <row>
-       <entry>5.5.0/PECL 3.0.0</entry>
+       <entry>8.1.0</entry>
        <entry>
         <para>
-         Объект <classname>IntlCalendar</classname> допускается в параметре
-         <parameter>calendar</parameter>.
-        </para>
-        <para>
-         Объекты <classname>IntlTimeZone</classname> и
-         <classname>DateTimeZone</classname> допускаются в параметре
-         <parameter>timezone</parameter>.
-        </para>
-        <para>
-         Недопустимые идентификаторы часового пояса (включая пустые строки)
-         больше не допускаются в параметре <parameter>timezone</parameter>.
-        </para>
-        <para>
-         Если в параметре <parameter>timezone</parameter> указано значение &null;,
-         идентификатор часового пояса, заданный <function>date_default_timezone_get</function>,
-         будет использоваться вместо значения ICU по умолчанию.
+         Теперь параметры <parameter>dateType</parameter>
+         и <parameter>timeType</parameter> необязательны.
         </para>
        </entry>
       </row>
@@ -225,6 +211,26 @@ echo "Второй форматированный вывод с шаблоном
 ]]>
    </programlisting>
   </example>
+  <example>
+    <title>Пример обработки неверного значения языкового стандарта</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+try {
+    $fmt = new IntlDateFormatter(
+        'invalid_locale',
+        IntlDateFormatter::FULL,
+        IntlDateFormatter::FULL,
+        'dunno',
+        IntlDateFormatter::GREGORIAN,
+    );
+} catch (\Error $e) {
+    // ...
+}
+?>
+]]>
+    </programlisting>
+   </example>
   &example.outputs;
   <screen>
 <![CDATA[

--- a/reference/intl/dateformatter/get-calendar.xml
+++ b/reference/intl/dateformatter/get-calendar.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>IntlDateFormatter::getCalendar</refname>
   <refname>datefmt_get_calendar</refname>
-  <refpurpose>Получает тип календаря, используемый IntlDateFormatter</refpurpose>
+  <refpurpose>Получает тип календаря для объекта IntlDateFormatter</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -47,8 +47,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <link linkend="intl.intldateformatter-constants.calendartypes">Тип календаря</link>,
-   используемый сервисом форматирования. Либо
+   Возвращает <link linkend="intl.intldateformatter-constants.calendartypes">тип календаря</link>
+   для сервиса форматирования. Либо
    <constant>IntlDateFormatter::TRADITIONAL</constant>, либо
    <constant>IntlDateFormatter::GREGORIAN</constant>.
    Возвращает &false; в случае возникновения ошибки.
@@ -58,7 +58,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
    <example>
-    <title>Пример использования <function>datefmt_get_calendar</function></title>
+    <title>Пример использования функции <function>datefmt_get_calendar</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -92,6 +92,27 @@ echo 'Тип календаря средства форматирования : 
 $fmt->setCalendar(IntlDateFormatter::TRADITIONAL);
 echo 'Теперь тип календаря средства форматирования : ' . $fmt->getCalendar();
 
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>Пример обработки неверного значения языкового стандарта</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+try {
+    $fmt = new IntlDateFormatter(
+        'invalid_locale',
+        IntlDateFormatter::FULL,
+        IntlDateFormatter::FULL,
+        'dunno',
+        IntlDateFormatter::GREGORIAN,
+    );
+    $cal = $fmt->getCalendar();
+} catch (\Error $e) {
+    // ...
+}
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Идущие подряд «или» в прежней формулировке сбивали с толку. В текущей формулировке, вроде бы, стало понятнее, что при определении локали либо будет выбрано переданное в метод значение, либо будет взято значение из файла php.ini