### PR TITLE
Update to English reference/com/constants.xml

### DIFF
--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 44becea8d20298029753f96ce944bae9ca74a723 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="com.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -23,9 +23,9 @@
      </entry>
      <entry>1</entry>
      <entry>
-      Код, создающий и управляющий объектами этого класса
-      является DLL запущенным в том же процессе, который
-      вызывает функцию указанную в контексте класса.
+      Код, который создаёт и управляет объектами этого класса, —
+      это DLL-библиотека, запущенная в том же процессе, который
+      вызывает функцию, указанную в контексте класса.
      </entry>
      <entry></entry>
     </row>
@@ -36,10 +36,10 @@
      </entry>
      <entry>2</entry>
      <entry>
-      Код, создающий и управляющий объектами этого класса
-      является обработчиком внутри процесса. Это DLL , запускаемый
-      в процессе клиента и реализующий структуру этого класса на
-      стороне клиента, когда экземпляр класса используется удалённо.
+      Код, который создаёт и управляет объектами этого класса, —
+      это обработчик внутри процесса. Это DLL-библиотека, запускаемая
+      в процессе клиента и реализующая структуру этого класса на
+      стороне клиента, когда экземпляр класса используют удалённо.
      </entry>
      <entry></entry>
     </row>
@@ -62,7 +62,7 @@
      </entry>
      <entry>16</entry>
      <entry>
-      Внешний контекст. Код, создающий и управляющий объектами этого класса
+      Внешний контекст. Код, создающий и управляющий объектами этого класса,
       работает на другом компьютере.
      </entry>
      <entry></entry>
@@ -74,11 +74,11 @@
      </entry>
      <entry>21</entry>
      <entry>
-      Означает серверный код, локальный, удалённый или же внутри процесса.
+      Указывает код сервера, внутрипроцессный, локальный или удалённый.
       Задаётся побитовым ИЛИ констант
       <constant>CLSCTX_INPROC_SERVER</constant>,
-      <constant>CLSCTX_LOCAL_SERVER</constant> и
-      <constant>CLSCTX_REMOTE_SERVER</constant>.
+      <constant>CLSCTX_LOCAL_SERVER</constant>
+      и <constant>CLSCTX_REMOTE_SERVER</constant>.
      </entry>
      <entry></entry>
     </row>
@@ -90,8 +90,8 @@
      <entry>23</entry>
      <entry>
       Обозначает весь контекст класса. Задаётся побитовым ИЛИ констант
-      <constant>CLSCTX_INPROC_HANDLER</constant> и
-      <constant>CLSCTX_SERVER</constant>.
+      <constant>CLSCTX_INPROC_HANDLER</constant>
+      и <constant>CLSCTX_SERVER</constant>.
      </entry>
      <entry></entry>
     </row>
@@ -113,8 +113,8 @@
      </entry>
      <entry>0</entry>
      <entry>
-      Свойство с индикатором типа из <constant>VT_EMPTY</constant> не
-      имеющий данных ассоциированных с ним. Размер этого значения равен нулю.
+      Свойство с индикатором типа из <constant>VT_EMPTY</constant>
+      без ассоциированных с ним данных. Размер этого значения равен нулю.
      </entry>
      <entry></entry>
     </row>
@@ -125,7 +125,7 @@
      </entry>
      <entry>22</entry>
      <entry>
-      Знаковое целое размером в 4 байт. (аналогично
+      Знаковое целое число размером 4 байта. (аналогично
       <constant>VT_I4</constant>).
      </entry>
      <entry></entry>
@@ -137,7 +137,7 @@
      </entry>
      <entry>16</entry>
      <entry>
-      Знаковое целое размером в 1 байт.
+      Знаковое целое число размером 1 байт.
      </entry>
      <entry></entry>
     </row>
@@ -148,7 +148,7 @@
      </entry>
      <entry>2</entry>
      <entry>
-      Знаковое целое размером в 2 байта.
+      Знаковое целое число размером 2 байта.
      </entry>
      <entry></entry>
     </row>
@@ -159,7 +159,7 @@
      </entry>
      <entry>3</entry>
      <entry>
-      Знаковое целое размером в 4 байта.
+      Знаковое целое число размером 4 байта.
      </entry>
      <entry></entry>
     </row>
@@ -170,7 +170,7 @@
      </entry>
      <entry>3</entry>
      <entry>
-      8-байтовое целочисленное значение со знаком.
+      Знаковое целое число размером 8 байтов.
      </entry>
      <entry>Доступно с PHP 7.0.0 (только для x64).</entry>
     </row>
@@ -181,7 +181,7 @@
      </entry>
      <entry>23</entry>
      <entry>
-      4-byte unsigned integer (equivalent to
+      Беззнаковое целое число размером 4 байта (эквивалент константы
       <constant>VT_UI4</constant>).
      </entry>
      <entry></entry>
@@ -193,7 +193,7 @@
      </entry>
      <entry>17</entry>
      <entry>
-      Беззнаковое целое размером в 1 байт.
+      Беззнаковое целое число размером 1 байт.
      </entry>
      <entry></entry>
     </row>
@@ -204,7 +204,7 @@
      </entry>
      <entry>18</entry>
      <entry>
-      Беззнаковое целое размером в 2 байта.
+      Беззнаковое целое число размером 2 байта.
      </entry>
      <entry></entry>
     </row>
@@ -215,7 +215,7 @@
      </entry>
      <entry>19</entry>
      <entry>
-      Беззнаковое целое размером в 4 байта.
+      Беззнаковое целое число размером 4 байта.
      </entry>
      <entry></entry>
     </row>
@@ -226,7 +226,7 @@
      </entry>
      <entry>19</entry>
      <entry>
-      8-байтовое целочисленное значение со знаком.
+      Знаковое целое число размером 8 байтов.
      </entry>
      <entry>Доступно с PHP 7.0.0 (только для x64).</entry>
     </row>
@@ -270,7 +270,7 @@
      </entry>
      <entry>10</entry>
      <entry>
-      Код ошибки; содержит код статуса ассоциированный с ошибкой.
+      Код ошибки; содержит код статуса, ассоциированный с ошибкой.
      </entry>
      <entry></entry>
     </row>
@@ -281,7 +281,7 @@
      </entry>
      <entry>6</entry>
      <entry>
-      Дополненное целое размером 8 байт (масштабируется к 10,000).
+      Дополненное до двух целое число размером 8 байтов (масштабируется к 10 000).
      </entry>
      <entry></entry>
     </row>
@@ -292,10 +292,10 @@
      </entry>
      <entry>7</entry>
      <entry>
-      Значение с плавающей точкой размером 64 бита представляющее
-      количество дней (не секунд) с 31 Декабря 1899 года. К примеру,
-      <literal>1 Января 1900</literal> равно 2.0, <literal>2 Января 1900</literal> равно
-      3.0, и т.д. Хранится таким же образом, что и
+      Значение с плавающей точкой размером 64 бита, представляющее
+      количество дней (не секунд) с 31 декабря 1899 года. К примеру,
+      <literal>1 января 1900</literal> равно 2.0, <literal>2 января 1900</literal> равно
+      3.0, и т. д. Хранится таким же образом, что и
       <constant>VT_R8</constant>.
      </entry>
      <entry></entry>
@@ -307,7 +307,7 @@
      </entry>
      <entry>8</entry>
      <entry>
-      Указатель на строку Unicode заканчивающуюся null-байтом.
+      Указатель на строку Unicode, заканчивающуюся null-байтом.
      </entry>
      <entry></entry>
     </row>
@@ -329,7 +329,7 @@
      </entry>
      <entry>13</entry>
      <entry>
-      Указатель на объект реализующий интерфейс IUnknown.
+      Указатель на объект, реализующий интерфейс IUnknown.
      </entry>
      <entry></entry>
     </row>
@@ -352,8 +352,8 @@
      <entry>12</entry>
      <entry>
       Индикатор типа с последующим, соответствующим, значением.
-      <constant>VT_VARIANT</constant> можно использовать только с
-      <constant>VT_BYREF</constant>.
+      Константу <constant>VT_VARIANT</constant> можно указывать только
+      вместе с константой <constant>VT_BYREF</constant>.
      </entry>
      <entry></entry>
     </row>
@@ -364,9 +364,10 @@
      </entry>
      <entry>8192</entry>
      <entry>
-      Если индикатор типа комбинирован с
-      <constant>VT_ARRAY</constant> с помощью побитового ИЛИ, то значение является
-      указателем на <literal>SAFEARRAY</literal>. <constant>VT_ARRAY</constant>
+      Если индикатор типа комбинирован
+      с константой <constant>VT_ARRAY</constant> через побитовое ИЛИ, то значение —
+      указатель на константу <literal>SAFEARRAY</literal>.
+      Константу <constant>VT_ARRAY</constant>
       можно комбинировать побитовым ИЛИ со следующими типами:
       <constant>VT_I1</constant>, <constant>VT_UI1</constant>,
       <constant>VT_I2</constant>, <constant>VT_UI2</constant>,
@@ -376,8 +377,8 @@
       <constant>VT_BOOL</constant>, <constant>VT_DECIMAL</constant>,
       <constant>VT_ERROR</constant>, <constant>VT_CY</constant>,
       <constant>VT_DATE</constant>, <constant>VT_BSTR</constant>,
-      <constant>VT_DISPATCH</constant>, <constant>VT_UNKNOWN</constant> и
-      <constant>VT_VARIANT</constant>.
+      <constant>VT_DISPATCH</constant>, <constant>VT_UNKNOWN</constant>
+      и <constant>VT_VARIANT</constant>.
      </entry>
      <entry></entry>
     </row>
@@ -386,10 +387,10 @@
       <constant>VT_BYREF</constant>
       (<type>int</type>)
      </entry>
-     <entry>16384</entry>
+     <entry>16 384</entry>
      <entry>
-      Если индикатор типа комбинирован с <constant>VT_BYREF</constant>
-      с помощью побитового ИЛИ, значит значение является ссылкой. Тип "ссылка"
+      Если индикатор типа комбинирован с константой <constant>VT_BYREF</constant>
+      через побитовое ИЛИ, значит, значение — ссылка. Тип «ссылка»
       интерпретируется как ссылка на данные, аналогично ссылкам C++.
      </entry>
      <entry></entry>
@@ -432,7 +433,7 @@
       <constant>CP_UTF7</constant>
       (<type>int</type>)
      </entry>
-     <entry>65000</entry>
+     <entry>65 000</entry>
      <entry>
       Unicode (UTF-7).
      </entry>
@@ -443,7 +444,7 @@
       <constant>CP_UTF8</constant>
       (<type>int</type>)
      </entry>
-     <entry>65001</entry>
+     <entry>65 001</entry>
      <entry>
       Unicode (UTF-8).
      </entry>
@@ -467,7 +468,7 @@
      </entry>
      <entry>3</entry>
      <entry>
-      Кодировка ANSI текущего потока исполнения
+      Кодировка ANSI текущего потока исполнения.
      </entry>
      <entry></entry>
     </row>
@@ -553,7 +554,7 @@
       <constant>NORM_IGNOREWIDTH</constant>
       (<type>int</type>)
      </entry>
-     <entry>131072</entry>
+     <entry>131 072</entry>
      <entry>
       Игнорировать длину строки.
      </entry>
@@ -564,7 +565,7 @@
       <constant>NORM_IGNOREKANATYPE</constant>
       (<type>int</type>)
      </entry>
-     <entry>65536</entry>
+     <entry>65 536</entry>
      <entry>
       Игнорировать тип Kana.
      </entry>
@@ -575,7 +576,7 @@
       <constant>NORM_IGNOREKASHIDA</constant>
       (<type>int</type>)
      </entry>
-     <entry>262144</entry>
+     <entry>262 144</entry>
      <entry>
       Игнорировать символы Arabic kashida.
      </entry>
@@ -588,46 +589,81 @@
       <constant>DISP_E_DIVBYZERO</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352558</entry>
+     <entry>-2 147 352 558</entry>
      <entry>
       Ответ означающий попытку деления на ноль.
      </entry>
-     <entry>Начиная с PHP 7.0.0, значение равно <literal>2147614738</literal> в x64.</entry>
+     <entry>Начиная с PHP 7.0.0 значение равно <literal>2147614738</literal> в x64.</entry>
     </row>
     <row xml:id="constant.disp-e-overflow">
      <entry>
       <constant>DISP_E_OVERFLOW</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352566</entry>
+     <entry>-2 147 352 566</entry>
      <entry>
       Ошибка означающая, что значение не может быть
       приведено к ожидаемому типу.
      </entry>
-     <entry>Начиная с PHP 7.0.0, значение равно <literal>2147614730</literal> в x64.</entry>
+     <entry>Начиная с PHP 7.0.0 значение равно <literal>2147614730</literal> в x64.</entry>
     </row>
     <row xml:id="constant.disp-e-badindex">
      <entry>
       <constant>DISP_E_BADINDEX</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352565</entry>
+     <entry>-2 147 352 565</entry>
      <entry>
       Ошибка, означающая, что индекс массива не существует.
      </entry>
-     <entry>Начиная с PHP 7.0.0, значение равно <literal>2147614731</literal> в x64.</entry>
+     <entry>Начиная с PHP 7.0.0 значение равно <literal>2 147 614 731</literal> в x64.</entry>
+    </row>
+    <row xml:id="constant.disp-e-paramnotfound">
+     <entry>
+      <constant>DISP_E_PARAMNOTFOUND</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>-2 147 352 572</entry>
+     <entry>
+      Возвращаемое значение, которое указывает, что один из идентификаторов параметра
+      не соответствует параметру не соответствует параметру метода.
+     </entry>
+     <entry>Начиная с PHP 7.0.0 значение равно <literal>2 147 614 724</literal> в x64.</entry>
     </row>
     <row xml:id="constant.mk-e-unavailable">
      <entry>
       <constant>MK_E_UNAVAILABLE</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147221021</entry>
+     <entry>-2 147 221 021</entry>
      <entry>
       Код статуса iMoniker COM, возвращается в случае возникновения ошибки когда
       функция не может быть вызвана, поскольку недоступна.
      </entry>
-     <entry>Начиная с PHP 7.0.0, значение равно <literal>2147746275</literal> в x64.</entry>
+     <entry>Начиная с PHP 7.0.0 значение равно <literal>2 147 746 275</literal> в x64.</entry>
+    </row>
+    <row xml:id="constant.locale-neutral">
+     <entry>
+      <constant>LOCALE_NEUTRAL</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>0</entry>
+     <entry>
+      Нейтральный регион. Эту константу обычно не указывают при вызове функций API поддержки национальных языков (NLS).
+      Вместо нее указывают константу LOCALE_SYSTEM_DEFAULT.
+     </entry>
+     <entry></entry>
+    </row>
+    <row xml:id="constant.locale-system-default">
+     <entry>
+      <constant>LOCALE_SYSTEM_DEFAULT</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>2048</entry>
+     <entry>
+      Языковой стандарт операционной системы по умолчанию.
+     </entry>
+     <entry></entry>
     </row>
    </tbody>
   </tgroup>


### PR DESCRIPTION
Обновлено до англ. версии, исправлены ошибки пунктуации, допереведено оставленное без перевода (в старых коммитах, видимо, пропущено).

Касательно чисел. Полагаю, будет правильным отбивать в длинных числах разряды по три (для чисел от 5 знаков включительно; 4 знака оставлять без изменений, то есть 12345 превращать в 12 345, а 1234 оставлять как есть), если значение — не вывод, который надо передать точно. То есть, если число указано «для человека», почему бы не превратить:

-2147352572

в:

-2 147 352 572

Ведь так проще же воспринимать!