### PR TITLE
Create mongodb/driver/monitoring

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
-<phpdoc:classref xml:id="class.mongodb-driver-monitoring-logsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref
+    xml:id="class.mongodb-driver-monitoring-logsubscriber"
+    xmlns:phpdoc="http://php.net/ns/phpdoc"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+>
 
  <title>Интерфейс MongoDB\Driver\Monitoring\LogSubscriber</title>
  <titleabbrev>MongoDB\Driver\Monitoring\LogSubscriber</titleabbrev>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
+<!-- Reviewed: no -->
+<phpdoc:classref xml:id="class.mongodb-driver-monitoring-logsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Интерфейс MongoDB\Driver\Monitoring\LogSubscriber</title>
+ <titleabbrev>MongoDB\Driver\Monitoring\LogSubscriber</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\Driver\Monitoring\LogSubscriber intro -->
+  <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
+   &reftitle.intro;
+   <para>
+    Классам, которые реализуют этот интерфейс, разрешено регистрироваться в качестве подписчиков
+    и получать сообщения журнала от драйвера. Это похоже на ведение журнала отладки
+    на основе потоков (т. е. директива <link linkend="ini.mongodb.debug">mongodb.debug</link>),
+    за исключением того, что сообщения журнала уровня трассировки не принимаются.
+   </para>
+   <para>
+    Как и в случае с потоковым журналированием, глобально зарегистрировать логгер
+    можно только методом <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
+    Драйвер не может различать сообщения журнала для отдельных объектов
+    <classname>MongoDB\Driver\Manager</classname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-driver-monitoring-logsubscriber.synopsis">
+   &reftitle.interfacesynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\Driver\Monitoring\LogSubscriber</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\Driver\Monitoring\LogSubscriber</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\Driver\Monitoring\Subscriber</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-error">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-critical">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-warning">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-message">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</varname>
+     <initializer>3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-info">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-logsubscriber.constants.level-debug">MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</varname>
+     <initializer>5</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-logsubscriber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ MongoDB\BSON\Binary constants -->
+  <section xml:id="mongodb-driver-monitoring-logsubscriber.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-error">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
+     <listitem>
+      <para>
+       Уровень журнала ошибок. Состояние ошибки, о котором драйвер не в состоянии сообщить
+       через свой API. Это самый серьёзный уровень журнала в драйвере.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-critical">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
+     <listitem>
+      <para>
+       Критический уровень журнала. Состояние ошибки с несколько меньшей серьёзностью.
+       Эта константа существует для согласованности с модулем libmongoc;,
+       однако, драйвер вряд ли будет использовать его на практике.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-warning">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
+     <listitem>
+      <para>
+       Уровень журнала предупреждений. Указывает на ситуацию, при которой есть риск
+       нежелательного поведения приложения.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-message">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
+     <listitem>
+      <para>
+       Уровень журнала сообщений или уведомлений. Указывает на необычное,
+       но не проблематичное событие.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-info">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
+     <listitem>
+      <para>
+       Информационный уровень журнала. Информация высокого уровня о нормальном поведении драйвера.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-debug">
+     <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
+     <listitem>
+      <para>
+       Уровень журнала отладки. Подробная информация, полезная при отладке приложения.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+ </partintro>
+
+   &reference.mongodb.mongodb.driver.monitoring.entities.logsubscriber;
+
+</phpdoc:classref>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
-<!-- Reviewed: no -->
+<!-- $Revision$ -->
 
-<phpdoc:classref
-    xml:id="class.mongodb-driver-monitoring-logsubscriber"
-    xmlns:phpdoc="http://php.net/ns/phpdoc"
-    xmlns="http://docbook.org/ns/docbook"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xi="http://www.w3.org/2001/XInclude"
->
+<phpdoc:classref xml:id="class.mongodb-driver-monitoring-logsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>Интерфейс MongoDB\Driver\Monitoring\LogSubscriber</title>
+ <title>The MongoDB\Driver\Monitoring\LogSubscriber interface</title>
  <titleabbrev>MongoDB\Driver\Monitoring\LogSubscriber</titleabbrev>
 
  <partintro>
@@ -19,16 +12,16 @@
   <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
    &reftitle.intro;
    <para>
-    Классам, которые реализуют этот интерфейс, разрешено регистрироваться в качестве подписчиков
-    и получать сообщения журнала от драйвера. Это похоже на ведение журнала отладки
-    на основе потоков (т. е. директива <link linkend="ini.mongodb.debug">mongodb.debug</link>),
-    за исключением того, что сообщения журнала уровня трассировки не принимаются.
+    Classes implementing this interface may be registered as a subscriber and
+    receive log messages from the driver. This is similar to stream-based debug
+    logging (i.e. <link linkend="ini.mongodb.debug">mongodb.debug</link>) except
+    that trace-level log messages are <emphasis>not</emphasis> received.
    </para>
    <para>
-    Как и в случае с потоковым журналированием, глобально зарегистрировать логгер
-    можно только методом <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
-    Драйвер не может различать сообщения журнала для отдельных объектов
-    <classname>MongoDB\Driver\Manager</classname>.
+    As with stream-based logging, it is only possible to register a logger
+    globally using <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
+    The driver is not able to distinguish log messages for individual
+    <classname>MongoDB\Driver\Manager</classname> objects.
    </para>
   </section>
 <!-- }}} -->
@@ -105,8 +98,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
      <listitem>
       <para>
-       Уровень журнала ошибок. Состояние ошибки, о котором драйвер не в состоянии сообщить
-       через свой API. Это самый серьёзный уровень журнала в драйвере.
+       Error log level. An error condition that the driver is unable to report
+       through its API. This is the most severe log level in the driver.
       </para>
      </listitem>
     </varlistentry>
@@ -115,9 +108,9 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
      <listitem>
       <para>
-       Критический уровень журнала. Состояние ошибки с несколько меньшей серьёзностью.
-       Эта константа существует для согласованности с модулем libmongoc;,
-       однако, драйвер вряд ли будет использовать его на практике.
+       Critical log level. An error condition with slightly less severity. This
+       constant exists for consistency with libmongoc; however, the driver is
+       unlikely to use it in practice.
       </para>
      </listitem>
     </varlistentry>
@@ -126,8 +119,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
      <listitem>
       <para>
-       Уровень журнала предупреждений. Указывает на ситуацию, при которой есть риск
-       нежелательного поведения приложения.
+       Warning log level. Indicates a situation where undesirable application
+       behavior may occur.
       </para>
      </listitem>
     </varlistentry>
@@ -136,8 +129,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
      <listitem>
       <para>
-       Уровень журнала сообщений или уведомлений. Указывает на необычное,
-       но не проблематичное событие.
+       Message or notice log level. Indicates an event that is unusual but not
+       problematic.
       </para>
      </listitem>
     </varlistentry>
@@ -146,7 +139,7 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
      <listitem>
       <para>
-       Информационный уровень журнала. Информация высокого уровня о нормальном поведении драйвера.
+       Info log level. High-level information about normal driver behavior.
       </para>
      </listitem>
     </varlistentry>
@@ -155,7 +148,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
      <listitem>
       <para>
-       Уровень журнала отладки. Подробная информация, полезная при отладке приложения.
+       Debug log level. Detailed information that may be helpful when debugging
+       an application.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
-
 <phpdoc:classref xml:id="class.mongodb-driver-monitoring-logsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Интерфейс MongoDB\Driver\Monitoring\LogSubscriber</title>
@@ -110,7 +109,7 @@
      <listitem>
       <para>
        Критический уровень журнала. Состояние ошибки с несколько меньшей серьёзностью.
-       Эта константа существует для согласованности с модулем libmongoc;,
+       Эта константа существует для согласованности с модулем libmongoc;
        однако, драйвер вряд ли будет использовать его на практике.
       </para>
      </listitem>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
+
 <phpdoc:classref
     xml:id="class.mongodb-driver-monitoring-logsubscriber"
     xmlns:phpdoc="http://php.net/ns/phpdoc"

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
+<!-- Reviewed: no -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-monitoring-logsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The MongoDB\Driver\Monitoring\LogSubscriber interface</title>
+ <title>Интерфейс MongoDB\Driver\Monitoring\LogSubscriber</title>
  <titleabbrev>MongoDB\Driver\Monitoring\LogSubscriber</titleabbrev>
 
  <partintro>
@@ -12,16 +13,16 @@
   <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
    &reftitle.intro;
    <para>
-    Classes implementing this interface may be registered as a subscriber and
-    receive log messages from the driver. This is similar to stream-based debug
-    logging (i.e. <link linkend="ini.mongodb.debug">mongodb.debug</link>) except
-    that trace-level log messages are <emphasis>not</emphasis> received.
+    Классам, которые реализуют этот интерфейс, разрешено регистрироваться в качестве подписчиков
+    и получать сообщения журнала от драйвера. Это похоже на ведение журнала отладки
+    на основе потоков (т. е. директива <link linkend="ini.mongodb.debug">mongodb.debug</link>),
+    за исключением того, что сообщения журнала уровня трассировки не принимаются.
    </para>
    <para>
-    As with stream-based logging, it is only possible to register a logger
-    globally using <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
-    The driver is not able to distinguish log messages for individual
-    <classname>MongoDB\Driver\Manager</classname> objects.
+    Как и в случае с потоковым журналированием, глобально зарегистрировать логгер
+    можно только методом <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
+    Драйвер не может различать сообщения журнала для отдельных объектов
+    <classname>MongoDB\Driver\Manager</classname>.
    </para>
   </section>
 <!-- }}} -->
@@ -98,8 +99,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
      <listitem>
       <para>
-       Error log level. An error condition that the driver is unable to report
-       through its API. This is the most severe log level in the driver.
+       Уровень журнала ошибок. Состояние ошибки, о котором драйвер не в состоянии сообщить
+       через свой API. Это самый серьёзный уровень журнала в драйвере.
       </para>
      </listitem>
     </varlistentry>
@@ -108,9 +109,9 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
      <listitem>
       <para>
-       Critical log level. An error condition with slightly less severity. This
-       constant exists for consistency with libmongoc; however, the driver is
-       unlikely to use it in practice.
+       Критический уровень журнала. Состояние ошибки с несколько меньшей серьёзностью.
+       Эта константа существует для согласованности с модулем libmongoc;,
+       однако, драйвер вряд ли будет использовать его на практике.
       </para>
      </listitem>
     </varlistentry>
@@ -119,8 +120,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
      <listitem>
       <para>
-       Warning log level. Indicates a situation where undesirable application
-       behavior may occur.
+       Уровень журнала предупреждений. Указывает на ситуацию, при которой есть риск
+       нежелательного поведения приложения.
       </para>
      </listitem>
     </varlistentry>
@@ -129,8 +130,8 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
      <listitem>
       <para>
-       Message or notice log level. Indicates an event that is unusual but not
-       problematic.
+       Уровень журнала сообщений или уведомлений. Указывает на необычное,
+       но не проблематичное событие.
       </para>
      </listitem>
     </varlistentry>
@@ -139,7 +140,7 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
      <listitem>
       <para>
-       Info log level. High-level information about normal driver behavior.
+       Информационный уровень журнала. Информация высокого уровня о нормальном поведении драйвера.
       </para>
      </listitem>
     </varlistentry>
@@ -148,8 +149,7 @@
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
      <listitem>
       <para>
-       Debug log level. Detailed information that may be helpful when debugging
-       an application.
+       Уровень журнала отладки. Подробная информация, полезная при отладке приложения.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
@@ -28,7 +28,7 @@
     <term><parameter>level</parameter></term>
     <listitem>
      <para>
-      Уровень серьезности. Это будет одна из
+      Уровень серьезности. Одна из
       <link linkend="mongodb-driver-monitoring-logsubscriber.constants">констант интерфейса</link>.
      </para>
     </listitem>
@@ -95,4 +95,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-Footer

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: sergey Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="mongodb-driver-monitoring-logsubscriber.log" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Monitoring\LogSubscriber::log</refname>
+  <refpurpose>Метод уведомления для сообщения журнала</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\LogSubscriber::log</methodname>
+   <methodparam><type>int</type><parameter>level</parameter></methodparam>
+   <methodparam><type>string</type><parameter>domain</parameter></methodparam>
+   <methodparam><type>string</type><parameter>message</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Если подписчик зарегистрирован, драйвер будет вызывать этот метод
+   для каждого зарегистрированного сообщения.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>level</parameter></term>
+    <listitem>
+     <para>
+      Уровень серьезности. Это будет одна из
+      <link linkend="mongodb-driver-monitoring-logsubscriber.constants">констант интерфейса</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>domain</parameter></term>
+    <listitem>
+     <para>
+      Название компонента драйвера, который вывел сообщение журнала.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <para>
+      Сообщение журнала.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Monitoring\addSubscriber</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->
+Footer


### PR DESCRIPTION
Не пойму, что не так с этим файлом. Чекер ругается и это странно: ведь файл скопирован из англ. доки:

https://github.com/php/doc-en/edit/master/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml

P. S. Да, я сохранил локально переведенный текст, а в файл просто скопировал содержимое англ. файла. Сохранил. Снова та же ошибка:

ERROR (file:////home/runner/work/doc-ru/doc-ru/ru/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml:163:4)
</phpdoc:classref>
----^
 Element classref content does not follow the DTD, expecting (((title |
 titleabbrev | subtitle)* , info?) , partintro? , refentry*), got (title
 titleabbrev partintro refentry CDATA)

Возвращаю перевод и надеюсь, что ваших знаний хватит для исправления ситуации ;)