### PR TITLE
Update language-defs.ent

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -10,7 +10,7 @@
 <!ENTITY InstallAndConfigure "Установка и настройка">
 <!ENTITY Installation      "Установка">
 <!ENTITY LanguageReference "Справочник языка">
-<!ENTITY Features          "Отличительные особенности">
+<!ENTITY Features          "Особенности">
 <!ENTITY Security          "Безопасность">
 <!ENTITY FunctionReference "Справочник функций">
 <!ENTITY VariableandTypeRelatedExtensions         "Модули, относящиеся к переменным и типам">


### PR DESCRIPTION
В слове «особенности» уже зарыт смысл индивидуальности, отличия от всего остального. А сочетание слов «отличительные особенности», выходит, — плеоназм (молодая девушка — например).

Английское feature — многозначительно и в разных контекстах его переводят на русский по-разному.

Возможно, этот ПР не самое лучшее предложение, но оно точно лучше «отличительных особенностей».

Если цель раздела https://www.php.net/manual/ru/features.php рассказать о том, как PHP непохоже или  по-особому работает с разными элементами языка (при сравнении с другими языками), то, наверное, раздел можно так и назать: «Особенности».

Если в этом названии что-то не так — давайте подумаем, как перевести это злосчастное Features, но в любом случае нужно избавится от «отличительных особенностей» ;)