### PR TITLE
Update language-defs.ent

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -43,7 +43,7 @@
 <!ENTITY SearchEngineExtensions                   "Модули для работы с поисковыми системами">
 <!ENTITY MiscExtensions                           "Различные модули">
 <!ENTITY UIExtensions                             "Модули для работы с GUI">
-<!ENTITY Appendixes        "Приложения">
+<!ENTITY Appendices        "Приложения">
 <!ENTITY PEAR              "PEAR: Репозиторий модулей и приложений PHP">
 <!ENTITY FAQ               "ЧАВО: ЧАсто задаваемые Вопросы и Ответы на них">
 <!ENTITY FAQabbrev         "ЧАВО">


### PR DESCRIPTION
Я так понимаю, раньше в англ. доке [употребляли](http://doc.php.net/tutorial/style.php) слово appendixes, но позже от него отказались в пользу appendiсes. А в рус. файле [language-defs.ent](https://github.com/php/doc-ru/blob/master/language-defs.ent) остался старый термин, из-за него на всех страницах ру-мануала слово appendices теперь [без перевода](https://www.google.com/search?q=site%3Aphp.net%2Fmanual%2Fru+%22Appendi%D1%81es%22&newwindow=1&sca_esv=600269070&sxsrf=ACQVn09yen3CGaHoTClMxvRqgyPBbHvPdQ%3A1705869031190&ei=536tZbehC9eTseMPm86k0AU&udm=&ved=0ahUKEwj3sIytqe-DAxXXSWwGHRsnCVoQ4dUDCBA&uact=5&oq=site%3Aphp.net%2Fmanual%2Fru+%22Appendi%D1%81es%22&gs_lp=Egxnd3Mtd2l6LXNlcnAiJHNpdGU6cGhwLm5ldC9tYW51YWwvcnUgIkFwcGVuZGnRgWVzIkitClCRBlirBnABeACQAQCYAQCgAQCqAQC4AQPIAQD4AQHiAwQYASBBiAYB&sclient=gws-wiz-serp), при этом слово appendixes в рус. доке не встречается [ни разу](https://www.google.com/search?q=site%3Aphp.net%2Fmanual%2Fru+%22Appendixes%22&newwindow=1&sca_esv=600269070&sxsrf=ACQVn0-gv4mjTbVsVv3JZu4bLtL5FZWRcA%3A1705868862500&ei=Pn6tZduMHvLbwPAP9eO12As&udm=&ved=0ahUKEwjbo9TcqO-DAxXyLRAIHfVxDbsQ4dUDCBA&uact=5&oq=site%3Aphp.net%2Fmanual%2Fru+%22Appendixes%22&gs_lp=Egxnd3Mtd2l6LXNlcnAiI3NpdGU6cGhwLm5ldC9tYW51YWwvcnUgIkFwcGVuZGl4ZXMiSJkbUJcJWI0YcAZ4AJABAJgB1QigAY8NqgEHNS0xLjAuMbgBA8gBAPgBAeIDBBgAIEGIBgE&sclient=gws-wiz-serp).

Если так, этот ПР исправит ситуацию ;-)