### PR TITLE
Update ob-list-handlers.xml

### DIFF
--- a/reference/outcontrol/functions/ob-list-handlers.xml
+++ b/reference/outcontrol/functions/ob-list-handlers.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-list-handlers">
  <refnamediv>
   <refname>ob_list_handlers</refname>
-  <refpurpose>Возвращает список заданных обработчиков вывода</refpurpose>
+  <refpurpose>Возвращает список активных обработчиков вывода</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Выводит список заданных обработчиков вывода.
+   Выводит список активных обработчиков вывода.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Функция вернёт массив с заданными обработчиками вывода (если есть).
+   Возвращает массив со списком активных обработчиков вывода, если есть.
   </para>
   <para>
    Возвращает строку <literal>"default output handler"</literal>,


### PR DESCRIPTION
Слово «заданных», вроде бы, корректно, потому что кто-то задаёт (устанавливает) обработчики вывода (например, функция ob_start()). Но слово «активных» всё-таки лучше объясняет, о каких обработчиках идёт речь; ведь после того как их установили (задали), они активируются