### PR TITLE
Update curl-getinfo.xml

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_getinfo</refname>
-  <refpurpose>Возвращает информацию об конкретной операции</refpurpose>
+  <refpurpose>Получает информацию о конкретной передаче</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>option</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Возвращает информацию о последней операции.
+   Получает информацию о последней передаче.
   </para>
  </refsect1>
 
@@ -59,7 +59,7 @@
             <constant>CURLINFO_EFFECTIVE_URL</constant>
            </entry>
            <entry valign="top">
-            Последний использованный эффективный URL
+            Последний эффективный URL
            </entry>
           </row>
           <row>
@@ -68,8 +68,8 @@
            </entry>
            <entry valign="top">
             Последний код ответа.
-          Начиная с cURL 7.10.8, это устаревший псевдоним
-          <constant>CURLINFO_RESPONSE_CODE</constant>
+            Начиная с cURL 7.10.8 это устаревший псевдоним
+            опции <constant>CURLINFO_RESPONSE_CODE</constant>
            </entry>
           </row>
           <row>
@@ -77,7 +77,9 @@
             <constant>CURLINFO_FILETIME</constant>
            </entry>
            <entry valign="top">
-            Удалённая (серверная) дата загруженного документа, если включена опция <constant>CURLOPT_FILETIME</constant>; если получено -1, значит это время неизвестно
+            Время получения документа по часам удалённого сервера,
+            если параметр <constant>CURLOPT_FILETIME</constant> включён для дескриптора cURL;
+            если возвращается значение -1, то время получения документа неизвестно
            </entry>
           </row>
           <row>
@@ -85,7 +87,7 @@
             <constant>CURLINFO_TOTAL_TIME</constant>
            </entry>
            <entry valign="top">
-            Общее время выполнения транзакции в секундах последней передачи
+            Общее время транзакции в секундах для последней передачи
            </entry>
           </row>
           <row>
@@ -93,7 +95,7 @@
             <constant>CURLINFO_NAMELOOKUP_TIME</constant>
            </entry>
            <entry valign="top">
-            Время разрешения имени сервера в секундах
+            Время в секундах, затраченное на разрешение имени
            </entry>
           </row>
           <row>
@@ -109,7 +111,7 @@
             <constant>CURLINFO_PRETRANSFER_TIME</constant>
            </entry>
            <entry valign="top">
-            Время в секундах, прошедшее от начала операции до готовности к фактической передаче данных
+            Время в секундах от запуска до момента начала передачи файла
            </entry>
           </row>
           <row>
@@ -117,7 +119,7 @@
             <constant>CURLINFO_STARTTRANSFER_TIME</constant>
            </entry>
            <entry valign="top">
-            Время в секундах до передачи первого байта данных
+            Время в секундах от запуска передачи до получения первого байта
            </entry>
           </row>
           <row>
@@ -125,7 +127,8 @@
             <constant>CURLINFO_REDIRECT_COUNT</constant>
            </entry>
            <entry valign="top">
-            Число перенаправлений с включённой опцией <constant>CURLOPT_FOLLOWLOCATION</constant>
+            Число перенаправлений,
+            если параметр <constant>CURLOPT_FOLLOWLOCATION</constant> включён для дескриптора cURL
            </entry>
           </row>
           <row>
@@ -133,7 +136,11 @@
             <constant>CURLINFO_REDIRECT_TIME</constant>
            </entry>
            <entry valign="top">
-            Общее время в секундах, затраченное на перенаправления до начала последней транзакции с включённой опцией <constant>CURLOPT_FOLLOWLOCATION</constant>
+            Общее время в секундах, которое потребовалось
+            для всех шагов перенаправления
+            до запуска последней транзакции,
+            если параметр <constant>CURLOPT_FOLLOWLOCATION</constant>
+            включён для дескриптора cURL
            </entry>
           </row>
           <row>
@@ -141,7 +148,12 @@
             <constant>CURLINFO_REDIRECT_URL</constant>
            </entry>
            <entry valign="top">
-            При отключённой опции <constant>CURLOPT_FOLLOWLOCATION</constant>: URL перенаправления, найденный в прошлой итерации, который необходимо запрашивать вручную. Если опция <constant>CURLOPT_FOLLOWLOCATION</constant> включена: пустое значение. URL перенаправления в этом случае доступен в <constant>CURLINFO_EFFECTIVE_URL</constant>
+            Если параметр дескриптора <constant>CURLOPT_FOLLOWLOCATION</constant> отключён:
+            URL-адрес перенаправления, найденный в последней транзакции,
+            который в следующий раз надо запросить вручную.
+            Если параметр <constant>CURLOPT_FOLLOWLOCATION</constant> включён:
+            пустое значение. Тогда URL-адрес перенаправления
+            доступен в опции <constant>CURLINFO_EFFECTIVE_URL</constant>
            </entry>
           </row>
           <row>
@@ -157,7 +169,7 @@
             <constant>CURLINFO_PRIMARY_PORT</constant>
            </entry>
            <entry valign="top">
-            Порт получателя последнего соединения
+            Порт назначения последнего соединения
            </entry>
           </row>
           <row>
@@ -165,7 +177,7 @@
             <constant>CURLINFO_LOCAL_IP</constant>
            </entry>
            <entry valign="top">
-            Локальный (исходящий) IP адрес последнего соединения
+            Локальный (исходящий) IP-адрес последнего соединения
            </entry>
           </row>
           <row>
@@ -181,7 +193,7 @@
             <constant>CURLINFO_SIZE_UPLOAD</constant>
            </entry>
            <entry valign="top">
-            Общее количество байт при закачке
+            Общее количество переданных байтов
            </entry>
           </row>
           <row>
@@ -189,7 +201,7 @@
             <constant>CURLINFO_SIZE_DOWNLOAD</constant>
            </entry>
            <entry valign="top">
-            Общее количество байт при загрузке
+            Общее количество полученных байтов
            </entry>
           </row>
           <row>
@@ -197,7 +209,7 @@
             <constant>CURLINFO_SPEED_DOWNLOAD</constant>
            </entry>
            <entry valign="top">
-            Средняя скорость загрузки
+            Средняя скорость получения данных
            </entry>
           </row>
           <row>
@@ -205,7 +217,7 @@
             <constant>CURLINFO_SPEED_UPLOAD</constant>
            </entry>
            <entry valign="top">
-            Средняя скорость закачки
+            Средняя скорость передачи данных
            </entry>
           </row>
           <row>
@@ -213,7 +225,7 @@
             <constant>CURLINFO_HEADER_SIZE</constant>
            </entry>
            <entry valign="top">
-            Суммарный размер всех полученных заголовков
+            Суммарный размер полученных заголовков
            </entry>
           </row>
           <row>
@@ -221,7 +233,9 @@
             <constant>CURLINFO_HEADER_OUT</constant>
            </entry>
            <entry valign="top">
-            Посылаемая строка запроса. Для работы этого параметра, добавьте опцию <constant>CURLINFO_HEADER_OUT</constant> к дескриптору с помощью вызова <function>curl_setopt</function>
+            Отправленная строка запроса. Чтобы этот параметр работал,
+            нужно добавить опцию <constant>CURLINFO_HEADER_OUT</constant>
+            в дескриптор через вызов функции <function>curl_setopt</function>
            </entry>
           </row>
           <row>
@@ -237,7 +251,8 @@
             <constant>CURLINFO_REQUEST_SIZE</constant>
            </entry>
            <entry valign="top">
-            Суммарный размер всех отправленных запросов, в настоящее время используется только для HTTP-запросов
+            Суммарный размер отправленных запросов,
+            работает пока только для HTTP-запросов
            </entry>
           </row>
           <row>
@@ -245,7 +260,8 @@
             <constant>CURLINFO_RETRY_AFTER</constant>
            </entry>
            <entry valign="top">
-            Информация из заголовка <literal>Retry-After:</literal> или ноль, если корректного заголовка не было.
+            Информация из заголовка <literal>Retry-After:</literal> или ноль,
+            если допустимого заголовка не было
            </entry>
           </row>
           <row>
@@ -253,7 +269,8 @@
             <constant>CURLINFO_SSL_VERIFYRESULT</constant>
            </entry>
            <entry valign="top">
-            Результат проверки SSL-сертификата, запрошенной с помощью установки параметра <constant>CURLOPT_SSL_VERIFYPEER</constant>
+            Результат проверки SSL-сертификации,
+            запрошенный с параметром <constant>CURLOPT_SSL_VERIFYPEER</constant>
            </entry>
           </row>
           <row>
@@ -261,7 +278,8 @@
             <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant>
            </entry>
            <entry valign="top">
-            Размер скачанных данных, прочитанный из заголовка <literal>Content-Length:</literal>
+            Размер полученных данных,
+            прочитанный из заголовка <literal>Content-Length:</literal>
            </entry>
           </row>
           <row>
@@ -269,7 +287,7 @@
             <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant>
            </entry>
            <entry valign="top">
-            Размер закачиваемых данных
+            Размер переданных данных
            </entry>
           </row>
           <row>
@@ -277,7 +295,9 @@
             <constant>CURLINFO_CONTENT_TYPE</constant>
            </entry>
            <entry valign="top">
-            Содержимое полученного заголовка <literal>Content-Type:</literal>. Если NULL, то сервер не послал правильный заголовок <literal>Content-Type:</literal>
+            Значение заголовка <literal>Content-Type:</literal> запрошенного документа.
+            Значение NULL указывает, что сервер не отправил
+            допустимый заголовок <literal>Content-Type:</literal>
            </entry>
           </row>
           <row>
@@ -285,7 +305,10 @@
             <constant>CURLINFO_PRIVATE</constant>
            </entry>
            <entry valign="top">
-            Внутренние данные, связанные с данным cURL-обработчиком, ранее установленные с помощью опции <constant>CURLOPT_PRIVATE</constant> в функции <function>curl_setopt</function>
+            Закрытые данные, связанные с текущим дескриптором cURL,
+            которые до этого были установлены
+            функцией <function>curl_setopt</function>
+            с параметром <constant>CURLOPT_PRIVATE</constant>
            </entry>
           </row>
           <row>
@@ -293,10 +316,12 @@
             <constant>CURLINFO_PROXY_ERROR</constant>
            </entry>
            <entry valign="top">
-            Подробный (SOCKS) код ошибки прокси, когда последняя
-          передача вернула ошибку <constant>CURLE_PROXY</constant>.
-          Возвращаемое значение будет ровно одним из значений <constant>CURLPX_<replaceable>*</replaceable></constant>.
-          Код ошибки будет <constant>CURLPX_OK</constant>, если код ответа не был доступен.
+            Подробный код ошибки прокси-сервера (SOCKS),
+            когда последняя передача вернула ошибку <constant>CURLE_PROXY</constant>.
+            Возвращаемое значение будет равно значению константы
+            из семейства <constant>CURLPX_<replaceable>*</replaceable></constant>.
+            Код ошибки будет равен значению константы <constant>CURLPX_OK</constant>,
+            если код ответа не был доступен
            </entry>
           </row>
           <row>
@@ -304,7 +329,7 @@
             <constant>CURLINFO_RESPONSE_CODE</constant>
            </entry>
            <entry valign="top">
-            Последний код возврата
+            Последний код ответа
            </entry>
           </row>
           <row>
@@ -312,7 +337,7 @@
             <constant>CURLINFO_HTTP_CONNECTCODE</constant>
            </entry>
            <entry valign="top">
-            Код ответа операции CONNECT
+            Код ответа на запрос CONNECT
            </entry>
           </row>
           <row>
@@ -320,7 +345,8 @@
             <constant>CURLINFO_HTTPAUTH_AVAIL</constant>
            </entry>
            <entry valign="top">
-            Битовая маска, показывающая возможные методы аутентификации, доступные при предыдущем ответе
+            Битовая маска доступного метода или методов
+            аутентификации на основе данных предыдущего ответа
            </entry>
           </row>
           <row>
@@ -328,7 +354,8 @@
             <constant>CURLINFO_PROXYAUTH_AVAIL</constant>
            </entry>
            <entry valign="top">
-            Битовая маска, показывающая возможные методы аутентификации на прокси, доступные при предыдущем ответе
+            Битовая маска доступного метода или методов
+            аутентификации прокси-сервера на основе данных предыдущего ответа
            </entry>
           </row>
           <row>
@@ -336,7 +363,8 @@
             <constant>CURLINFO_OS_ERRNO</constant>
            </entry>
            <entry valign="top">
-            Номер ошибки при попытке соединения. Код может различаться в зависимости от системы и ОС
+            Значение переменной Errno в случае сбоя соединения.
+            Номер ошибки зависит от ОС и особенностей системы
            </entry>
           </row>
           <row>
@@ -344,7 +372,8 @@
             <constant>CURLINFO_NUM_CONNECTS</constant>
            </entry>
            <entry valign="top">
-            Количество соединений, совершенных curl для обеспечения предыдущей передачи
+            Количество соединений, которые curl пришлось создать,
+            что успешно выполнить предыдущую передачу
            </entry>
           </row>
           <row>
@@ -352,7 +381,7 @@
             <constant>CURLINFO_SSL_ENGINES</constant>
            </entry>
            <entry valign="top">
-            Поддержка OpenSSL
+            Список поддерживаемых криптодвижков библиотеки OpenSSL
            </entry>
           </row>
           <row>
@@ -360,7 +389,7 @@
             <constant>CURLINFO_COOKIELIST</constant>
            </entry>
            <entry valign="top">
-            Все известные куки
+            Известные куки
            </entry>
           </row>
           <row>
@@ -376,7 +405,8 @@
             <constant>CURLINFO_APPCONNECT_TIME</constant>
            </entry>
            <entry valign="top">
-            Время в секундах от начала и до установления SSL/SSH connect/handshake с удалённым хостом
+            Время в секундах от запуска до установления SSL- или SSH-
+            подключения или рукопожатия с удалённым хостом
            </entry>
           </row>
           <row>
@@ -384,7 +414,7 @@
             <constant>CURLINFO_CERTINFO</constant>
            </entry>
            <entry valign="top">
-            Связка ключей TLS
+            Цепочка сертификатов TLS
            </entry>
           </row>
           <row>
@@ -392,7 +422,7 @@
             <constant>CURLINFO_CONDITION_UNMET</constant>
            </entry>
            <entry valign="top">
-            Информация о неудовлетворённых временных условиях
+            Информация о невыполненных за отведённое время условиях
            </entry>
           </row>
           <row>
@@ -400,7 +430,7 @@
             <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant>
            </entry>
            <entry valign="top">
-            Следующий RTSP клиентского CSeq
+            Следующий CSeq-заголовок RTSP-клиента
            </entry>
           </row>
           <row>
@@ -408,7 +438,7 @@
             <constant>CURLINFO_RTSP_CSEQ_RECV</constant>
            </entry>
            <entry valign="top">
-            Недавно полученный CSeq
+            Последний полученный заголовок CSeq
            </entry>
           </row>
           <row>
@@ -416,7 +446,7 @@
             <constant>CURLINFO_RTSP_SERVER_CSEQ</constant>
            </entry>
            <entry valign="top">
-            Следующий RTSP серверного CSeq
+            Следующий CSeq-заголовок RTSP-сервера
            </entry>
           </row>
           <row>
@@ -424,7 +454,7 @@
             <constant>CURLINFO_RTSP_SESSION_ID</constant>
            </entry>
            <entry valign="top">
-            ID сессии RTSP
+            Идентификатор RTSP-сессии
            </entry>
           </row>
           <row>
@@ -432,7 +462,9 @@
             <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Заголовок Content-length загрузки. Это значение считывается из поля <literal>Content-Length:</literal>. -1 если размер не известен
+            Размер полученных данных. Это значение
+            считывается из поля <literal>Content-Length:</literal>.
+            Значение будет равно -1, если размер неизвестен
            </entry>
           </row>
           <row>
@@ -440,7 +472,8 @@
             <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Указанный размер загрузки. Значение -1, если размер неизвестен
+            Размер отправленных данных. Значение будет равно -1,
+            если размер неизвестен
            </entry>
           </row>
           <row>
@@ -448,7 +481,10 @@
             <constant>CURLINFO_HTTP_VERSION</constant>
            </entry>
            <entry valign="top">
-            Версия, использованная в последнем HTTP-соединении. Возвращаемое значение будет одной из определённых констант <constant>CURL_HTTP_VERSION_*</constant> или 0, если версия не может быть определена
+            Версия HTTP-протокола последнего соединении.
+            Возвращаемое значение будет равно значению константы
+            из семейства <constant>CURL_HTTP_VERSION_*</constant>
+            или 0, если версию невозможно определить
            </entry>
           </row>
           <row>
@@ -456,7 +492,9 @@
             <constant>CURLINFO_PROTOCOL</constant>
            </entry>
            <entry valign="top">
-            Протокол, использованный в последнем HTTP-соединении. Возвращаемое значение будет точно одним из значений <constant>CURLPROTO_*</constant>
+            Протокол последнего HTTP-соединения.
+            Возвращаемое значение будет равно значению константы
+            из семейства <constant>CURLPROTO_*</constant>
            </entry>
           </row>
           <row>
@@ -464,7 +502,9 @@
             <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>
            </entry>
            <entry valign="top">
-            Результат проверки сертификата, который был запрошен (с использованием параметра <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Используется только для HTTPS-прокси
+            Результат запрошенной проверки сертификата
+            (с параметром <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>).
+            Работает только для серверов HTTPS-прокси
            </entry>
           </row>
           <row>
@@ -472,7 +512,7 @@
             <constant>CURLINFO_SCHEME</constant>
            </entry>
            <entry valign="top">
-            Схема URL, используемая для самого последнего соединения
+            Схема URL последнего соединения
            </entry>
           </row>
           <row>
@@ -480,7 +520,9 @@
             <constant>CURLINFO_SIZE_DOWNLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Общее количество скачанных байтов. Номер предназначен только для последней передачи и будет сбрасываться для каждой новой передачи.
+            Общее количество байтов, которые были получены.
+            Число будет указано только для последней передачи
+            и будет сбрасываться при каждой новой передаче
            </entry>
           </row>
           <row>
@@ -488,7 +530,7 @@
             <constant>CURLINFO_SIZE_UPLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Общее количество загруженных байтов
+            Общее количество байтов, которые были переданы
            </entry>
           </row>
           <row>
@@ -496,7 +538,8 @@
             <constant>CURLINFO_SPEED_DOWNLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Средняя скорость скачивания в байтах/секунду, измеренная для полного скачивания
+            Средняя скорость получения данных в байтах в секунду,
+            которую curl измерил в конце передачи
            </entry>
           </row>
           <row>
@@ -504,7 +547,8 @@
             <constant>CURLINFO_SPEED_UPLOAD_T</constant>
            </entry>
            <entry valign="top">
-            Средняя скорость загрузки в байтах/секунду, измеренная для полной загрузки
+            Средняя скорость передачи данных в байтах в секунду,
+            которую curl измерил в конце передачи
            </entry>
           </row>
           <row>
@@ -512,7 +556,9 @@
             <constant>CURLINFO_APPCONNECT_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Время в микросекундах, которое прошло с самого начала до тех пор, пока соединение/рукопожатие SSL/SSH не было завершено
+            Время в микросекундах, прошедшее от запуска
+            до завершения SSL- или SSH- подключения или рукопожатия
+            с удалённым хостом
            </entry>
           </row>
           <row>
@@ -520,7 +566,8 @@
             <constant>CURLINFO_CONNECT_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Общее время, затрачиваемое в микросекундах с начала до момента подключения к удалённому хосту (или прокси-серверу)
+            Общее время в микросекундах, прошедшее от запуска
+            до завершения подключения к удалённому хосту или прокси-серверу
            </entry>
           </row>
           <row>
@@ -528,12 +575,19 @@
             <constant>CURLINFO_FILETIME_T</constant>
            </entry>
            <entry valign="top">
-            Удалённое время извлечённого документа (как метка времени Unix), альтернатива <constant>CURLINFO_FILETIME</constant>, чтобы разрешить системам с 32-битными long-переменными извлекать даты вне диапазона 32-битных временных меток
+            Время получения документа в виде метки времени Unix
+            по часам удалённого сервера,
+            альтернатива опции <constant>CURLINFO_FILETIME</constant>,
+            чтобы разрешить системам с 32-битными long-переменными
+            извлекать даты за пределами диапазона 32-битных меток времени
            </entry>
           </row>
           <row>
            <entry valign="top">
-            <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> -в Время в микросекундах от начала до разрешения имени
+            <constant>CURLINFO_NAMELOOKUP_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Время в микросекундах от запуска до разрешения имени
            </entry>
           </row>
           <row>
@@ -541,7 +595,7 @@
             <constant>CURLINFO_PRETRANSFER_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Время в микросекундах, затраченное с самого начала до начала передачи файла
+            Время в микросекундах от запуска до момента начала передачи файла
            </entry>
           </row>
           <row>
@@ -549,7 +603,10 @@
             <constant>CURLINFO_REDIRECT_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Общее время в микросекундах, которое потребовалось для всех шагов перенаправления, включая поиск имени, подключение, предварительный перенос и передачу до запуска окончательной транзакции
+            Общее время в микросекундах, которое потребовалось
+            для всех шагов перенаправления, включая поиск имени,
+            подключение, предварительную о основную передачу
+            до запуска окончательной транзакции
            </entry>
           </row>
           <row>
@@ -557,7 +614,7 @@
             <constant>CURLINFO_STARTTRANSFER_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Время в микросекундах, которое прошло с начала до получения первого байта
+            Время в микросекундах от запуска передачи до получения первого байта
            </entry>
           </row>
           <row>
@@ -565,7 +622,8 @@
             <constant>CURLINFO_TOTAL_TIME_T</constant>
            </entry>
            <entry valign="top">
-            Общее время в микросекундах для предыдущей передачи, включая разрешение имён, TCP-соединение и т. д.
+            Общее время предыдущей передачи в микросекундах,
+            включая разрешение имени, TCP-соединение и т. д.
            </entry>
           </row>
          </tbody>
@@ -581,150 +639,152 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Если параметр <parameter>option</parameter> указан, то возвращается его
-   значение. Иначе возвращается ассоциативный массив со
-   следующими элементами (которые соответствуют значениям аргумента
-   <parameter>option</parameter>) или &false; в случае возникновения ошибки:
+   Если параметр <parameter>option</parameter> задан, возвращается
+   его значение. В остальных случаях возвращается ассоциативный массив
+   со следующими элементами (которые соответствуют значениям параметра
+   <parameter>option</parameter>) или &false; в случае ошибки:
    <itemizedlist>
     <listitem>
      <simpara>
-      "url"
+      «url»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "content_type"
+      «content_type»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "http_code"
+      «http_code»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "header_size"
+      «header_size»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "request_size"
+      «request_size»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "filetime"
+      «filetime»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "ssl_verify_result"
+      «ssl_verify_result»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "redirect_count"
+      «redirect_count»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "total_time"
+      «total_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "namelookup_time"
+      «namelookup_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "connect_time"
+      «connect_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "pretransfer_time"
+      «pretransfer_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "size_upload"
+      «size_upload»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "size_download"
+      «size_download»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "speed_download"
+      «speed_download»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "speed_upload"
+      «speed_upload»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "download_content_length"
+      «download_content_length»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "upload_content_length"
+      «upload_content_length»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "starttransfer_time"
+      «starttransfer_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "redirect_time"
+      «redirect_time»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "certinfo"
+      «certinfo»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "primary_ip"
+      «primary_ip»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "primary_port"
+      «primary_port»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "local_ip"
+      «local_ip»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "local_port"
+      «local_port»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "redirect_url"
+      «redirect_url»
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "request_header" (возвращается только при установленной
-      опции <constant>CURLINFO_HEADER_OUT</constant>
-      с помощью вызова <function>curl_setopt</function> до выполнения запроса)
+      «request_header» (Значение будет заполнено,
+      только если функцией <function>curl_setopt</function>
+      для дескриптора включён параметр
+      <constant>CURLINFO_HEADER_OUT</constant>.)
      </simpara>
     </listitem>
    </itemizedlist>
-   Учтите, что внутренние данные не добавляются в ассоциативный массив и должны получаться отдельно с помощью опции <constant>CURLINFO_PRIVATE</constant>.
+   Учтите, что закрытые данные не добавляются в ассоциативный массив
+   и извлекаются отдельно через опцию <constant>CURLINFO_PRIVATE</constant>.
   </para>
  </refsect1>
 
@@ -743,14 +803,14 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        Добавлены константы <constant>CURLINFO_CAINFO</constant>
+        Добавлены опции <constant>CURLINFO_CAINFO</constant>
         и <constant>CURLINFO_CAPATH</constant>.
        </entry>
       </row>
       <row>
        <entry>8.2.0</entry>
        <entry>
-        Добавлены константы <constant>CURLINFO_PROXY_ERROR</constant>,
+        Добавлены опции <constant>CURLINFO_PROXY_ERROR</constant>,
         <constant>CURLINFO_REFERER</constant>,
         <constant>CURLINFO_RETRY_AFTER</constant>.
        </entry>
@@ -759,14 +819,14 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Теперь параметр <parameter>option</parameter> может принимать значение &null;.
+        Теперь параметр <parameter>option</parameter> принимает значение &null;.
         ранее значением по умолчанию был <literal>0</literal>.
        </entry>
       </row>
       <row>
        <entry>7.3.0</entry>
        <entry>
-        Добавлены <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
+        Добавлены опции <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
         <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>,
         <constant>CURLINFO_HTTP_VERSION</constant>,
         <constant>CURLINFO_PROTOCOL</constant>,
@@ -796,10 +856,11 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>curl_getinfo</function></title>
+    <title>Пример использования функции <function>curl_getinfo</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Создаём дескриптор cURL
 $ch = curl_init('http://www.example.com/');
 
@@ -814,6 +875,7 @@ if (!curl_errno($ch)) {
 
 // Закрываем дескриптор
 curl_close($ch);
+
 ?>
 ]]>
     </programlisting>
@@ -821,10 +883,14 @@ curl_close($ch);
   </para>
   <para>
    <example>
-    <title>Пример использования <function>curl_getinfo</function> с параметром <parameter>option</parameter></title>
+    <title>
+     Пример использования функции <function>curl_getinfo</function>
+     с параметром <parameter>option</parameter>
+    </title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Создаём дескриптор cURL
 $ch = curl_init('http://www.example.com/');
 
@@ -843,6 +909,7 @@ if (!curl_errno($ch)) {
 
 // Закрываем дескриптор
 curl_close($ch);
+
 ?>
 ]]>
     </programlisting>
@@ -854,10 +921,11 @@ curl_close($ch);
   &reftitle.notes;
   <note>
    <para>
-    Информация, собранная этой функцией, будет сохранена при дальнейшем
-    использовании дескриптора. Это означает, что если статистика не
-    будет перезаписана самой функцией, будет возвращаться информация
-    по предыдущему запросу.
+    Информация, которую собирает эта функция,
+    хранится в дескрипторе
+    и доступна для запуска повторной передачи.
+    То есть, пока статистика не переопределена внутренне,
+    эта функция возвращает предыдущую информацию.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
Табличка в одном месте поехала, хотел пару тегов изменить. Не вышло пару, перебрал весь файл :)

В англ. версии — много неточностей:

- завели кучу T-опций CURLINFO_*_T (которые новые, с PHP 7.3.0) и даже не заикнулись, что с ними функция `curl_getinfo()` возвращает int'ы, в отличие от их старых аналогов, которые, оказывается, возвращают float'ы.

 - о том, что константы, для которых выпустиил T-версии, устарели в разных версиях curl (например, https://curl.se/libcurl/c/CURLINFO_CONTENT_LENGTH_DOWNLOAD.html и все остальные с Т-дублями) в разных версиях curl, тоже ни слова.

- Information gathered by this function is kept if the handle is re-used. This means that unless a statistic is overridden internally by this function, the previous info is returned — формулировка невыносимо некорректная.

> Information gathered by this function is kept if the handle is re-used.

_Информация, собранная этой функцией, сохраняется, если дескриптор используется повторно._

Как будто информация сохраняется _благодаря_ переиспользованию дескриптора. Но речь, вероятно, о том, что настроенный cURL-дескриптор (кстати, почему в ру-доке именно про cURL — везде дескриптор, а не обработчик, handler ведь, непонятно) можно переиспользовать. Не надо каждый раз насыщать его параметрами. Можно один раз настроить и, скажем, менять только URL запроса. Дескриптор и соединение держит открытым.

> This means that unless a statistic is overridden internally by this function, the previous info is returned.

_Это означает, что, если эта функция не переопределяет статистику внутри, возвращается предыдущая информация._

или

_Это означает, что если статистика не переопределена внутренне этой функцией, возвращается предыдущая информация._

Что?! Функция `curl_getinfo()` умеет переопределять сведения, которые хранятся в cURL-дескрипторе? Ерунда же. Очевидно, речь о том, что до тех пор пока сведения в дескрипторе не изменятся «внутренне», функция `curl_getinfo()` будет возвращать одну и ту же информацию.

То есть англ. вординг мог бы быть хотя бы:

Information gathered by this function is kept in handle and may re-used. This means that unless a statistic is overridden within handler the previous info is returned by this function.

Я не силён в этих with, in, within, inside, internally настолько, чтобы создавать PR для англ. доки. Но, если есть люди, которые могут проверить мои догадки о _не_правильности формулировки описанного [абзаца в англ. доке](https://www.php.net/manual/en/function.curl-getinfo.php#refsect1-function.curl-getinfo-notes), было бы здорово.