### PR TITLE
Update else.xml

### DIFF
--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -5,11 +5,11 @@
  <title>else</title>
  <?phpdoc print-version-for="else"?>
  <para>
-  Часто необходимо выполнить одну инструкцию, если условие
-  верно, и другую — если неверно. Вот, для чего
-  нужна инструкция <literal>else</literal>. Инструкция <literal>else</literal>
-  расширяет инструкцию <literal>if</literal>, чтобы выполнять другую инструкцию
-  тогда, когда выражение внутри <literal>if</literal>
+  Часто необходимо выполнить одно выражение, если условие
+  верно, и другое — если неверно. Вот, для чего
+  нужна конструкция <literal>else</literal>. Конструкция <literal>else</literal>
+  расширяет конструкцию <literal>if</literal>, чтобы выполнять другое выражение
+  тогда, когда условие внутри <literal>if</literal>
   оценивается как &false;. Например, следующий код выведет
   «<computeroutput>a больше b</computeroutput>»,
   если значение переменной <varname>$a</varname> больше, чем
@@ -31,18 +31,18 @@ if ($a > $b) {
    </programlisting>
   </informalexample>
 
-  Инструкция <literal>else</literal> выполняется, только если
-  выражение внутри инструкции <literal>if</literal> вычисляется как
-  &false;, а если были инструкции <literal>elseif</literal>
+  Выражение внутри конструкции <literal>else</literal> выполняется, только если
+  условие внутри конструкции <literal>if</literal> вычисляется как
+  &false;, а если были условия <literal>elseif</literal>
   — то только если они тоже вычисляются как &false;. <link
-  linkend="control-structures.elseif">Об инструкции elseif</link>.
+  linkend="control-structures.elseif">О конструкции elseif</link>.
  </para>
 
  <note>
   <title>Болтающийся else</title>
   <para>
-   В случае вложенных инструкций <literal>if</literal>-<literal>else</literal>,
-   инструкция <literal>else</literal> связывается с близлежащей инструкцией <literal>if</literal>.
+   В случае вложенных конструкций <literal>if</literal>-<literal>else</literal>,
+   конструкция <literal>else</literal> связывается с близлежащей конструкцией <literal>if</literal>.
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -60,8 +60,8 @@ else
 ]]>
     </programlisting>
    </informalexample>
-   Независимо от расстановки отступов, которые ещё и не влияют на PHP-код,
-   инструкция <literal>else</literal> связана с выражением <literal>if ($b)</literal>,
+   Независимо от расстановки отступов, которые не влияют на PHP-код,
+   конструкция <literal>else</literal> связана с выражением <literal>if ($b)</literal>,
    поэтому пример ничего не выведет.
    Код с такой расстановкой отступов будет работать,
    но лучше избегать такого кода и использовать фигурные скобки,

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -31,8 +31,8 @@ if ($a > $b) {
    </programlisting>
   </informalexample>
 
-  Выражение внутри конструкции <literal>else</literal> выполняется, только если
-  условие внутри конструкции <literal>if</literal> вычисляется как
+  Выражение <literal>else</literal> выполняется, только если
+  условие <literal>if</literal> вычисляется как
   &false;, а если были условия <literal>elseif</literal>
   — то только если они тоже вычисляются как &false;. <link
   linkend="control-structures.elseif">О конструкции elseif</link>.


### PR DESCRIPTION
С толку сбил ПР https://github.com/php/doc-ru/pull/799, в котором заявлялось: «Неверный перевод терминологии». И, по сути, было предложено заменить слово «выражение» на «инструкция», а слово «оператор» (if или else) — тоже на «инструкция».

Когда я увидел, что этот ПР был принят, решил, что мейнтейнер согласен с таким положением дел. Хотя внутрений голос говорил: «Что-то здесь не так».

Слово statement по всей доке переведено как «выражение», а тут — вдруг! — «инструкция». Она-то, может быть, и инструкция, то она и выражение, и конструкция, и запись, и заявление, и утверждение… Но исторически это «вырежение».

Предлагаю на этом и остановиться.

Когда я попал на страницу «[Управляющие конструкции](https://www.php.net/manual/ru/language.control-structures.php) (Control Structures)» и окончательно убедился: конструкции if/elseif/else нельзя называть инструкциями. Это —  в рамках гласного или негласного согласия по переводу, — _конструкции_, как и сказано в заголовке раздела «Управляющие конструкции».

Вместе с тем, в англ. доке, которая описывает конструкции if/elseif/else, они всегда называются statement (а не structures, как должно было бы быть, если бы название конструкции if/elseif/else согласовывалось бы с заголовком Control Structures, и не instruction, если бы они были «инструкциями», как было предложено в упомянутом ПР #799). Путаницу вносит ещё и то, что условия (внутри конструкций if/elseif/else) один раз в англ. доке названы condition, а в другой — expression; а последнее тоже переводят как «выражение» (как и слово statement). И выражением же statement называются конструкции if/elseif/else.

Поэтому я написал вот такой псевдокод:

```
if-конструкция (условие|if-условие) {
    выражение|if-выражение;
} elseif-конструкция (условие|elseif-условие) {
    выражение|elseif-выражение;
} else-конструкция {
    выражение|else-выражение;
}
```
Здесь:

- так называемые операторы if/elseif/else всегда называются конструкциями (что согласуется с ру-заголовком «Управляющие конструкции»; а то получается странно, из раздела «Управляющие конструкции» проваливаешься в else, а там else названо инструкцией. Вопрос: «Так это конструкция или инструкция?"»; хотя в англ. доке они и называются выражениями (statement)).
- условия в круглых скобках всегда — условия (хотя в англ. доке они то condition (условия), то expression (выражения))
- выражения (код внутри фигурных скобок) всегда — выражения (ещё одна беда в том, что в англ. доке выражения внутри фигурных скобок тоже названы словом statement, которое для русской доки уже занято инструкциями); я согласен, условия в круглых скобках легально можно назвать выражениями (это ведь выражения!), но в рамках файлов if/elseif/else я бы не стал назвать условия — выражениями, чтобы не вносить путаницу.

Если этих рассуждений и аргументации достаточно, прошу принять ПР, а при очередных попытках «внести ясность в терминологию» — принимать предложения, только если вес аргументов будет выше, чем в текущим ПР (иначе — получим перевод хуже)