### PR TITLE
Update prev.xml

### DIFF
--- a/reference/array/functions/prev.xml
+++ b/reference/array/functions/prev.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.prev" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>prev</refname>
-  <refpurpose>Передвигает внутренний указатель массива на одну позицию назад</refpurpose>
+  <refpurpose>Сдвигает внутренний указатель массива на одну позицию назад</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -13,12 +13,13 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter role="reference">array</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Передвигает внутренний указатель массива на одну позицию назад.
+   Сдвигает внутренний указатель массива на одну позицию назад.
   </para>
   <para>
-   <function>prev</function> ведёт себя подобно <function>next</function>,
-   за исключением того, что она передвигает внутренний указатель
-   массива на одну позицию назад, а не вперёд.
+   Функция <function>prev</function> ведёт себя так же,
+   как функция <function>next</function>,
+   за исключением того, что она отматывает внутренний указатель
+   массива на одну позицию, а не продвигает его.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -39,8 +40,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Возвращает значение массива, на которое ранее указывал внутренний
-   указатель массива, или &false;, если больше элементов нет.
+   Возвращает значение предыдущего элемента массива,
+   относительно позиции внутреннего указателя,
+   или &false;, если больше нет элементов.
   </para>
   &return.falseproblem;
  </refsect1>
@@ -66,16 +68,18 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования <function>prev</function> и её связанных функций</title>
+    <title>Пример использования функции <function>prev</function> и дружественных функций</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $transport = array('foot', 'bike', 'car', 'plane');
 $mode = current($transport); // $mode = 'foot';
 $mode = next($transport);    // $mode = 'bike';
 $mode = next($transport);    // $mode = 'car';
 $mode = prev($transport);    // $mode = 'bike';
 $mode = end($transport);     // $mode = 'plane';
+
 ?>
 ]]>
     </programlisting>
@@ -86,11 +90,11 @@ $mode = end($transport);     // $mode = 'plane';
   &reftitle.notes;
   <note>
    <simpara>
-    Вы не сможете отличить начало массива от <type>bool</type>
-    элемента &false;. Для корректного обхода массива, который может
-    содержать элементы такие элементы,  проверяйте, что значение, возвращаемое
-    функцией <function>key</function> для элемента <function>prev</function> не
-    равно &null;.
+    Начало массива неотличимо от элемента с логическим (<type>bool</type>)
+    значением &false;. Чтобы отличить,
+    нужно проверить, что возвращаемый функцией <function>key</function> ключ
+    предыдущего элемента, как его определяет функция <function>prev</function>,
+    не равен значению &null;.
    </simpara>
   </note>
  </refsect1>


### PR DESCRIPTION
Из-за описания этой функции и перебрал связанные функции. А то в одном месте функция перемещает указатель, в другом передвигает, в третьем смещает.

Еще удивился, почему слова rewind и advances боятся переводить как отматывает и продвигает. Понятно, что отматывает — значит, назад, продивагет, значит — вперёд, тогда не нужно уточнений (вперёд или назад):

сдигает указатель на одну позицию вперед → продвигает указатель на одну позицию
сдигвает указатель на одну позицию назад → отматывает указатель на одну позицию

В refpurpose оставил уточнения вперёд и назад; в секциях позволил употребление слов «продвигает» и «отматывает»