### PR TITLE
Update callable.xml

### DIFF
--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -5,7 +5,7 @@
  <title>Callable и callback-функции</title>
 
  <para>
-  Callback-функции, или функции обратного вызова, разрешено
+  Callback-функции разрешено
   обозначать объявлением типа <type>callable</type>.
  </para>
 

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -2,25 +2,26 @@
 <!-- EN-Revision: c897161ca5a62a887295c695adc161b8fde5d772 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.callable">
- <title>Функции обратного вызова (callback-функции)</title>
+ <title>Callable и callback-функции</title>
 
  <para>
-  Callback-функции могут быть обозначены объявлением типа <type>callable</type>.
+  Callback-функции, или функции обратного вызова, разрешено
+  обозначать объявлением типа <type>callable</type>.
  </para>
 
  <para>
-  Некоторые функции, такие как <function>call_user_func</function> или
-  <function>usort</function>, принимают определённые пользователем
-  callback-функции в качестве параметра. Callback-функции могут быть как простыми
-  функциями, так и методами объектов, включая статические методы классов.
+  Функции вроде <function>call_user_func</function> или
+  <function>usort</function> принимают определённые пользователем
+  callback-функции в качестве параметра. Callback-функциями бывают как простые
+  функции, так и методы объектов, включая статические методы классов.
  </para>
 
  <sect2 xml:id="language.types.callable.passing">
   <title>Передача</title>
 
   <para>
-   В PHP функции передаются по имени в виде строки. Можно использовать любые встроенные,
-   либо созданные пользователем функции, за исключением конструкций языка, таких как:
+   PHP-функция передаётся по имени в виде строки. Разрешено передавать
+   любую встроенную или пользовательскую функцию, исключая языковые конструкции:
    <function>array</function>, <function>echo</function>,
    <function>empty</function>, <function>eval</function>,
    <function>exit</function>, <function>isset</function>,
@@ -29,32 +30,33 @@
   </para>
 
   <para>
-   Метод созданного объекта (<type>object</type>) передаётся как массив, содержащий
-   объект по индексу 0 и имя метода по индексу 1. Доступ к закрытым и защищённым
-   методам разрешён изнутри класса.
+   Метод созданного объекта (<type>object</type>) передаётся как массив, который
+   в индексе 0 содержит — объект, а в индексе 1 — название метода.
+   Изнутри класса разрешён доступ к закрытым и защищённым методам.
   </para>
 
   <para>
-   Статические методы класса также могут быть вызваны без создания экземпляра
-   объекта класса путём передачи имени класса вместо объекта в элементе массива с
-   индексом 0 или выполнения <literal>'ClassName::methodName'</literal>.
+   Статические методы класса также допустимо передавать без создания экземпляра
+   объекта класса, или передавая массив, в индексе 0 которого вместо объекта будет название класса,
+   или передавая строку вида <literal>'ClassName::methodName'</literal>.
   </para>
 
   <para>
-   Помимо обычных пользовательских функций, в качестве callback-функции можно передавать
-   <link linkend="functions.anonymous">анонимные функции</link> и
-   <link linkend="functions.arrow">стрелочные функции</link>.
+   Кроме пользовательских функций, в callback-параметр разрешено передавать
+   <link linkend="functions.anonymous">анонимные</link>
+   и <link linkend="functions.arrow">стрелочные функции</link>.
   </para>
 
   <note>
    <para>
-    Начиная с PHP 8.1.0, у <link linkend="functions.first_class_callable_syntax">Callback-функций как объектов первого класса</link> та же семантика, что и у этого метода.
+    Начиная с PHP 8.1.0 анонимные функции разрешено создавать
+    <link linkend="functions.first_class_callable_syntax">синтаксисом callable-объектов первого класса</link>.
    </para>
   </note>
 
   <para>
-   Как правило, любой объект, реализующий <link linkend="object.invoke">__invoke()</link>, также
-   может быть передан в параметр callback.
+   Объекты, которые реализуют магический метод <link linkend="object.invoke">__invoke()</link>,
+   разрешно передавать в callback-параметр.
   </para>
 
   <para>
@@ -106,7 +108,7 @@ class B extends A {
 
 call_user_func(array('B', 'parent::who')); // A, устарело, начиная с PHP 8.2.0
 
-// Тип 6: Объекты, реализующие __invoke, могут быть использованы как callback
+// Тип 6: Объекты, которые реализуют магический метод __invoke, разрешено использовать как callable-объекты
 class C {
     public function __invoke($name) {
         echo 'Привет ', $name, "\n";
@@ -115,6 +117,7 @@ class C {
 
 $c = new C();
 call_user_func($c, 'PHP!');
+
 ?>
 ]]>
     </programlisting>
@@ -123,12 +126,13 @@ call_user_func($c, 'PHP!');
   <para>
    <example>
     <title>
-     Пример callback-функции с использованием замыкания
+     Пример передачи замыкания в callback-параметр
     </title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// Наше замыкание
+
+// Замыкание
 $double = function($a) {
     return $a * 2;
 };
@@ -136,11 +140,12 @@ $double = function($a) {
 // Диапазон чисел
 $numbers = range(1, 5);
 
-// Использование замыкания в качестве callback-функции
-// для удвоения каждого элемента в нашем диапазоне
+// Передаём в параметр замыкание в качестве callback-функции
+// для удвоения каждого элемента в созданном выше диапазоне
 $new_numbers = array_map($double, $numbers);
 
 print implode(' ', $new_numbers);
+
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Нахожу странным, что в списке _типов_ указаны типы и псевдотипы, но для callable почему-то сделано исключение, и вместо типа указаны передаваемые как параметры функции. Ведь тип callable может быть не только у callback-функций. Проще говоря, кто в списке типов главный: callback-функции или callable-объекты?

И вообще…

```
<?php

function foo(): callable
{
	return 'bar';
}

function bar() {}

var_dump(
	is_callable('foo'),
	is_callable(foo()),
);
```

И функция foo(), и возвращаемое функцией значение принадлежат псевдотипу callable, но никто из них не представляет собой callback-функцию (хотя и мог бы). Но в списке типов у нас главные — callback-функции.

Переводить тип callable в заголовке и (или) в меню я бы не стал, по аналогии с Void, Mixed и другими, которые можно было бы перевести, но получилось бы так себе :) Предложенный вариант, по кр. мере, больше отвечает требованию — назвать тип (а то получается, что в PHP появляется тип callback-функция).

Конечно, можно обсудить «за» и «против», возможно, я чего-то не замечаю