### PR TITLE
Update language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1932,19 +1932,21 @@ INI_* даны в разделе «<xref xmlns="http://docbook.org/ns/docbook" l
 <!-- Used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants '
 <simpara xmlns="http://docbook.org/ns/docbook">
- Перечисленные ниже константы определены этим модулем
- и доступны либо в сборках PHP с поддержкой этого модуля,
- либо когда модуль динамически загружен во время исполнения кода.
-</simpara>
-'>
+ Модуль определяет перечисленные ниже константы
+ и открывает к ним доступ только тогда, когда модуль либо собрали в PHP,
+ либо динамически загрузили во время исполнения кода.
+</simpara>'>
 
 <!-- For STANDARD Constants used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">
-Перечисленные ниже константы всегда доступны как часть ядра PHP.
+Перечисленные ниже константы доступны как часть ядра PHP.
 </simpara>'>
 
 <!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook"> Перечисленные ниже классы определяются данным модулем и доступны только тогда, когда PHP был собран с этим модулем, или этот модуль был динамически загружен во время выполнения скрипта.
+<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
+Модуль определяет перечисленные ниже классы
+и открывает к ним доступ только тогда, когда модуль либо собрали в PHP,
+либо динамически загрузили во время исполнения кода.
 </simpara>'>
 
 <!ENTITY note.extension.php5 '<note xmlns="http://docbook.org/ns/docbook"><simpara>


### PR DESCRIPTION
Замена страдательного залога «константы определены модулем» (пассивный залог читать тяжелее) на «модуль определяет константы» (есть действующее лицо и объект, над которым совершается действие)