### PR TITLE
Update inotify-rm-watch.xml

### DIFF
--- a/reference/inotify/functions/inotify-rm-watch.xml
+++ b/reference/inotify/functions/inotify-rm-watch.xml
@@ -37,7 +37,7 @@
      <term><parameter>watch_descriptor</parameter></term>
      <listitem>
       <para>
-       Наблюдение для удаления из дескриптора наблюдения.
+       Дескриптор наблюдения для удаления из дескриптора файла.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Таки ф-ция `inotify_rm_watch()` удаляет `wd` (watch descriptor, или элемент списка наблюдения) из `fd` (file descriptor, он же экземпляр inotify), была ошибка, исправляюсь ;-)