### PR TITLE
Update implode.xml

### DIFF
--- a/reference/strings/functions/implode.xml
+++ b/reference/strings/functions/implode.xml
@@ -77,14 +77,14 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Функция больше не поддерживает передачу разделителя (<parameter>separator</parameter>)
-       после массива (<parameter>array</parameter>).
+       Функция больше не поддерживает передачу разделителя <parameter>separator</parameter>
+       после массива <parameter>array</parameter>.
       </entry>
      </row>
      <row>
       <entry>7.4.0</entry>
       <entry>
-       Передача разделителя (<parameter>separator</parameter>) после массива (<parameter>array</parameter>),
+       Передача разделителя <parameter>separator</parameter> после массива <parameter>array</parameter>,
        т. е. сигнатура, которая досталась в наследство, устарела.
       </entry>
      </row>


### PR DESCRIPTION
Всё не мог понять, почему в одном случае хочется послат поставить скобки, а в другом нет. Сообразил: если указан тип, скобки просятся, если название параметра — нет.

Скобки — зло, из-за них спотыкаешься при чтении. Имена параметров без них прочитываются легко. А вот для указания типов скобки более или менее уместны.

Хоть добавляй правила по аргументамии параметрам и наличию или отсутствию скобок для типов и названий параметров ))