### PR TITLE
Обновление списка переводчиков

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -10,52 +10,7 @@
   <authorgroup xml:id="translators">
    <author>
     <personname>
-     <firstname>Алексей</firstname><surname>Шеин</surname> <!-- shein -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Андрей</firstname><surname>Безруков</surname> <!-- aur -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Максим</firstname><surname>Чабан</surname> <!-- mch -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Александр</firstname><surname>Москалёв</surname> <!-- irker -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Борис</firstname><surname>Клименко</surname> <!-- das -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Дмитрий</firstname><surname>Винярчук</surname> <!-- tmn -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Борис</firstname><surname>Флейтлих</surname> <!-- bfl -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Алексей</firstname><surname>Егоров</surname> <!-- countzero -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Юрий</firstname><surname>Бабиков</surname> <!-- alien -->
-    </personname>
-   </author>
-   <author>
-    <personname>
-     <firstname>Михаил</firstname><surname>Баранов</surname> <!-- northcat -->
+     <firstname>Алексей</firstname><surname>Пыльцын</surname> <!-- lex -->
     </personname>
    </author>
    <author>
@@ -65,12 +20,12 @@
    </author>
    <author>
     <personname>
-     <firstname>Алексей</firstname><surname>Пыльцын</surname> <!-- lex -->
+     <firstname>Евгений</firstname><surname>Четвериков</surname> <!-- evvc -->
     </personname>
    </author>
    <author>
     <personname>
-     <firstname>Сергей</firstname><surname>Пантелеев</surname> <!-- sergey -->
+     <firstname>Михаил</firstname><surname>Алфёров</surname> <!-- malferov -->
     </personname>
    </author>
    <author>
@@ -80,20 +35,113 @@
    </author>
    <author>
     <personname>
-     <firstname>Евгений</firstname><surname>Четвериков</surname> <!-- 	evvc -->
+     <firstname>Сергей</firstname><surname>Пантелеев</surname> <!-- sergey -->
     </personname>
    </author>
-
-   <!-- This is not too nice, but works -->
-   <othercredit>
-    <personname>
-     <othername>
-     <link linkend="other.translators">&AndSeveralOthers;</link>
-     </othername>
-    </personname>
-   </othercredit>
-
   </authorgroup>
+
+ <authorgroup xml:id="translators.old">
+  <author>
+   <personname>
+    <firstname>Александр</firstname><surname>Москалёв</surname> <!-- irker -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Александр</firstname><surname>Войцеховский</surname> <!-- young -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Алексей</firstname><surname>Асемов</surname> <!-- alexws -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Алексей</firstname><surname>Егоров</surname> <!-- countzero -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Алексей</firstname><surname>Шеин</surname> <!-- shein -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Андрей</firstname><surname>Безруков</surname> <!-- aur -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Андрей</firstname><surname>Деменев</surname> <!-- blindman -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Антон</firstname><surname>Довгаль</surname> <!-- tony2001 -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Борис</firstname><surname>Безруков</surname> <!-- lovchy -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Борис</firstname><surname>Клименко</surname> <!-- das -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Борис</firstname><surname>Флейтлих</surname> <!-- bfl -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Даниил</firstname><surname>Реужков</surname> <!-- dre -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Дмитрий</firstname><surname>Винярчук</surname> <!-- tmn -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Евгений</firstname><surname>Сюзев</surname> <!-- seprize -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Иван</firstname><surname>Коваленко</surname> <!-- tronic -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Казбек</firstname><surname>Джигкаев</surname> <!-- kai -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Кирилл</firstname><surname>Барашкин</surname> <!-- notarius -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Максим</firstname><surname>Чабан</surname> <!-- mch -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Михаил</firstname><surname>Баранов</surname> <!-- northcat -->
+   </personname>
+  </author>
+  <author>
+   <personname>
+    <firstname>Юрий</firstname><surname>Бабиков</surname> <!-- alien -->
+   </personname>
+  </author>
+ </authorgroup>
 
   <copyright>
    <year>1997-<?dbtimestamp format="Y"?></year>

--- a/preface.xml
+++ b/preface.xml
@@ -38,51 +38,7 @@
    история языка, обращаются к разделу «<link linkend="history">История PHP</link>».
   </para>
 
-<!--
-ВАЖНО!!!
-Этот  файл — исключение. Он всегда будет помечен как файл с ошибками в переводе. Исправлять его не нужно.
--->
-
   &contributors;
-  <section xml:id="other.translators">
-   <title>Другие переводчики</title>
-   <para>
-    Наиболее активные переводчики, присылавшие патчи:
-    Spbima, Тигрович, Иван Ремень, Serg, Wolg,
-    Degit, Nooneon, StelZek, Grul, Alexandr Fedotov, Marina Lagun,
-    Mike, HaJIuBauKa, Sunny, dba, Александр Тушин.
-   </para>
-   <para>
-    Мы публикуем имена самых активных на текущий момент переводчиков документации,
-    но ещё много участников помогают улучшать справочные материалы. И каждый их перевод, поправка или совет —
-    ценен и важен.
-   </para>
-   <para>
-    Переводчики, которые раньше участвовали в переводе руководства на русский язык
-    (в алфавитном порядке):
-    Alexander Voytsekhovskyy, <!-- young -->
-    Alexey Asemov,           <!-- alexws -->
-    Andrey Demenev,          <!-- blindman -->
-    Antony Dovgal,           <!-- tony2001 -->
-    Boris Bezrukov,          <!-- lovchy -->
-    Daniil Reuzhkov,         <!-- dre -->
-    Evgeniy Syuzev,          <!-- seprize -->
-    Irina Goble,             <!-- irinagoble -->
-    Ivan Kovalenko,          <!-- tronic -->
-    Jigkayev Kazbek,         <!-- kai -->
-    Kirill Barashkin,        <!-- notarius -->
-    Olishuk Andrey,          <!-- biznw -->
-    Veniamin Zolotukhin.     <!-- venya -->
-   </para>
-   <para>
-    А также неизвестные переводчики со следующими никами:
-    freespace,
-    santiago,
-    shafff,
-    sveta.
-   </para>
-
-  </section>
  </preface>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/translation.xml
+++ b/translation.xml
@@ -29,6 +29,7 @@
   <person name="Sergey Panteleev" email="sergey@php.net" nick="sergey" vcs="yes"/>
   <person name="Sergey Zorin" email="zors1@php.net" nick="zors1" vcs="yes"/>
   <person name="Evgeniy Chetverikov" email="evvc@php.net" nick="evvc" vcs="yes"/>
+  <person name="Mikhail Alferov" email="malferov@gmail.com" nick="malferov" vcs="no"/>
  </translators>
 
  <work-in-progress>


### PR DESCRIPTION
- `bookinfo.xml` – добавил 2 раздела: актуальные переводчики (которые за последние годы вносили вклад) и те, кто помогал ранее.

- `preface.xml` – по аналогии с другими языками, старых переводчиков перенёс из него в `bookinfo.xml`.

- `translation.xml` – @mmalferov добавил тебя в список, так как у тебя уже есть и доступ к `doc-ru` и перевод под твоим авторством. Когда будет одобрена почта, обновим тут данные.

---

Предложение по обновлению этих файлов:

- В актуальных предлагаю держать, кто за последние 5 лет вносил вклад, далее – просто в `translators.old` переносим.
- Имена указываем на русском языке, в алфавитном порядке.
- Файл `translation.xml`: если у человека есть хоть 1 файл в столбцах [`Files maintained`](http://doc.php.net/revcheck.php?p=translators&lang=ru), то он присутствует в списке, если файлов больше нет – можно убирать.