### PR TITLE
Исправление названия примеров в магических методах

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -121,7 +121,7 @@
    выполнения других операций повторной инициализации.
   </para>
   <example>
-   <title>Сериализация и десериализация</title>
+   <title>Использование __sleep() и __wakeup()</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -121,7 +121,7 @@
    выполнения других операций повторной инициализации.
   </para>
   <example>
-   <title>Использование __sleep() и __wakeup()</title>
+   <title>Использование <link linkend="object.sleep">__sleep()</link> и <link linkend="object.wakeup">__wakeup()</link></title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -383,7 +383,7 @@ bool(true)
    </screen>
   </example>
   <example>
-   <title>Пример использования <link linkend="object.invoke">__invoke()</link></title>
+   <title>Использование <link linkend="object.invoke">__invoke()</link></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -121,7 +121,7 @@
    выполнения других операций повторной инициализации.
   </para>
   <example>
-   <title>Использование <link linkend="object.sleep">__sleep()</link> и <link linkend="object.wakeup">__wakeup()</link></title>
+   <title>Засыпание и пробуждение</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
В первом примере заголовок отличается от содержания примера.

Использовал перевод похожий на французский "Utilisation de sleep() et wakeup()".