### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4050,7 +4050,7 @@ local: {
   </para>
   <note>
    <simpara>
-    При вычислении критериев запроса MongoDB сравнивает типы и значения в соответствии с собственными <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">правилами сравнения типов BSON</link>, отличных от правил <link linkend="types.comparisons">сравнения</link> и <link linkend="language.types.type-juggling">приведения типов</link> PHP. Когда указан специальный тип BSON, критерия запроса должна соответствовать <link linkend="book.bson">классу BSON</link> (т.е. использовать <classname>MongoDB\BSON\ObjectId</classname> для выборке по <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
+    При вычислении критериев запроса MongoDB сравнивает типы и значения в соответствии с собственными <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">правилами сравнения типов BSON</link>, отличных от правил <link linkend="types.comparisons">сравнения</link> и <link linkend="language.types.type-juggling">приведения типов</link> PHP. Когда указан специальный тип BSON, критерия запроса должна соответствовать <link linkend="mongodb.bson">классу BSON</link> (т.е. использовать <classname>MongoDB\BSON\ObjectId</classname> для выборке по <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
    </simpara>
   </note>
  </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 22eb2f39973a06dd565e0030f173f8460d2f2811 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Архитектура и внутреннее устройство драйвера</titleabbrev>
  <title>Обзор архитектуры драйвера и её особенностей</title>
 
- <article xml:id="mongodb.overview">
+ <section xml:id="mongodb.overview">
   <titleabbrev>Архитектура</titleabbrev>
   <title>Обзор архитектуры</title>
 
@@ -86,9 +86,9 @@
     </tgroup>
    </table>
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.connection-handling">
+ <section xml:id="mongodb.connection-handling">
   <titleabbrev>Соединения</titleabbrev>
   <title>Обработка и сохранение соединения</title>
 
@@ -207,9 +207,9 @@ foreach ($managers as $manager) {
     API-интерфейс потоков PHP.
    </para>
   </section>
- </article>
+ </section>
 
- <article xml:id="mongodb.persistence">
+ <section xml:id="mongodb.persistence">
   <titleabbrev>Сохранение данных</titleabbrev>
   <title>Сериализация и десериализация PHP-переменных в модуле MongoDB</title>
 
@@ -960,8 +960,8 @@ function bsonUnserialize(array $map)
    </section>
   </section>
 
- </article>
-</book>
+ </section>
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<set xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Модуль MongoDB</title>
  <titleabbrev>MongoDB</titleabbrev>
 
@@ -16,7 +17,7 @@
     <link linkend="class.mongodb-driver-query">запросы</link>,
     <link linkend="class.mongodb-driver-bulkwrite">записи</link>,
     <link linkend="class.mongodb-driver-manager">управление соединением</link>
-    и <link linkend="book.bson">сериализация BSON</link>.
+    и <link linkend="mongodb.bson">сериализация BSON</link>.
    </simpara>
    <simpara>
     Самодельные библиотеки PHP, требующие этот модуль, могут предоставлять
@@ -32,6 +33,7 @@
  </info>
 
  &reference.mongodb.setup;
+ &reference.mongodb.constants;
  &reference.mongodb.tutorial;
  &reference.mongodb.architecture;
  &reference.mongodb.security;
@@ -40,7 +42,7 @@
  &reference.mongodb.bson;
  &reference.mongodb.monitoring;
  &reference.mongodb.exceptions;
-</set>
+</book>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/bson.xml
+++ b/reference/mongodb/bson.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="book.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>Классы и функции модуля MongoDB для работы с форматом BSON</title>
  <titleabbrev>MongoDB\BSON</titleabbrev>
@@ -44,4 +44,4 @@
  &reference.mongodb.bson.int64;
  &reference.mongodb.bson.symbol;
  &reference.mongodb.bson.undefined;
-</book>
+</part>

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 8c84a7f1fd238b71d31f315cc52b8b7771401fdd Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<article xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <section xml:id="mongodb.installation.pecl">
@@ -267,7 +267,7 @@ extension=mongodb.so
   </para>
  </section>
 
-</article>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 4083e8f9523a60390960c52a7ab810dc7b096d40 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>MongoDB\Driver\Exception</titleabbrev>
  <title>Классы исключений</title>
 
@@ -83,4 +83,4 @@
    </listitem>
   </itemizedlist>
  </article>
-</book>
+</part>

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<article xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
  <para>
@@ -72,7 +72,7 @@
 
   </variablelist>
  </para>
-</article>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>Классы модуля MongoDB</title>
  <titleabbrev>MongoDB\Driver</titleabbrev>
@@ -29,4 +29,4 @@
  &reference.mongodb.mongodb.driver.writeconcernerror;
  &reference.mongodb.mongodb.driver.writeerror;
  &reference.mongodb.mongodb.driver.writeresult;
-</book>
+</part>

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Классы мониторинга и функции подписчика</title>
  <titleabbrev>MongoDB\Driver\Monitoring</titleabbrev>
 
@@ -28,4 +28,4 @@
  &reference.mongodb.mongodb.driver.monitoring.logsubscriber;
  &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
  &reference.mongodb.mongodb.driver.monitoring.subscriber;
-</book>
+</part>

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -2,10 +2,10 @@
 <!-- EN-Revision: 4e0bf229045ff87d5f84469280bf0a6b195bfb8b Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
-<book xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Безопасность</title>
 
- <article xml:id="mongodb.security.request_injection">
+ <section xml:id="mongodb.security.request_injection">
   <title>Атака с помощью инъекций в запросе</title>
   <para>
    Если вы передаёте параметры <literal>$_GET</literal> (или <literal>$_POST</literal>)
@@ -44,9 +44,9 @@
    Смотрите <link xlink:href="&url.mongodb.dochub.security;">основную документацию</link>
    для получения дополнительной информации о проблемах SQL инъекций в MongoDB.
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.security.script_injection">
+ <section xml:id="mongodb.security.script_injection">
   <title>Атака с помощью инъекций в скриптах</title>
   <para>
    Если вы используете JavaScript, убедитесь, что все переменные, которые пересекают границу
@@ -157,8 +157,8 @@ $r = $m->executeCommand( 'dramio', $cmd );
    xlink:href="&url.mongodb.docs;reference/command/eval/">eval</link>
    устарела с MongoDB 3.0, и её также следует избегать.
   </para>
- </article>
-</book>
+ </section>
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <article xml:id="mongodb.requirements">
+ <section xml:id="mongodb.requirements">
   &reftitle.required;
   <para>
    Начиная с версии 1.16.0 для работы модуля требуется PHP 7.2 или выше.
@@ -38,21 +38,20 @@
    типа PHP.
    </simpara>
   </note>
- </article>
+ </section>
 
  &reference.mongodb.configure;
  &reference.mongodb.ini;
  <!--
- <article xml:id="mongodb.resources">
+ <section xml:id="mongodb.resources">
   &reftitle.resources;
   <para>
 
   </para>
- </article>
+ </section>
 -->
- &reference.mongodb.constants;
 
-</book>
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 680b85d4cc40065d48ae1f918e7579d8eb244f85 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<book xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Обучающие материалы</title>
  <titleabbrev>Обучающие материалы</titleabbrev>
 
@@ -15,7 +15,7 @@
  </info>
  &reference.mongodb.tutorial.library;
  &reference.mongodb.tutorial.apm;
-</book>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: af0472588c9f07f2f20533d80dc8b17018b224dd Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Мониторинг производительности приложения (Application Performance Monitoring, или APM)</title>
 
  <para>
@@ -173,7 +173,7 @@ $cursor = $m->executeQuery('dramio.whisky', $query);
   </programlisting>
  </section>
 
-</chapter>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Работа библиотеки PHP с драйвером MongoDB (PHPLIB)</title>
 
  <para>
@@ -155,7 +155,7 @@ foreach ($result as $entry) {
     <xref linkend="mongodb.persistence"/>.
    </para>
  </section>
-</chapter><!-- Keep this comment at the end of the file
+</section><!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
 sgml-omittag:t


### PR DESCRIPTION
This PR converts `doc-ru`'s MongoDB chapter from a `<set>` to a `<book>` as is done in https://github.com/php/doc-en/pull/3627. This needs the `doc-en` PR and https://github.com/php/doc-base/pull/138 both to work properly.

Also, the revision hash probably needs updating once the `doc-en` changes are merged.