### PR TITLE
readline: remove non-existing formalpara in doc-en

### DIFF
--- a/reference/readline/constants.xml
+++ b/reference/readline/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c4eb41f4747d9f6e8ae17574177d92a2d1d5810 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 51779f7c42f39934403805a42b83cef7126a5fc1 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="readline.constants">
  &reftitle.constants;


### PR DESCRIPTION
While this changelog probably makes sense to have, it first needs to land in doc-en.

Remove to properly sync with doc-en.

This is currently breaking the build after doing bulk XML changes in doc-en and propagating them to all translations.