### PR TITLE
Fix POST example in HTTP context options

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -225,9 +225,9 @@ $postdata = http_build_query(
 
 $opts = [
     'http' => [
-        'method'        => 'GET',
-        'max_redirects' => '0',
-        'ignore_errors' => '1',
+        'method'  => 'POST',
+        'header'  => 'Content-type: application/x-www-form-urlencoded',
+        'content' => $postdata,
     ]
 ];
 


### PR DESCRIPTION
Fixes #1151 — the first example showed a GET request instead of POST.