### PR TITLE
Fix wrong varname for SoapFault::$lang property

### DIFF
--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5e36b489fc67bd0b5c424c7d1cd131c2e982bc5c Maintainer: mch Status: ready -->
+<!-- EN-Revision: cdb9b8afa58e676e9c7844a892aa6eca152f916d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.soapfault" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -154,7 +154,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="soapfault.props.lang">
-     <term><varname>headerfault</varname></term>
+     <term><varname>lang</varname></term>
      <listitem>
       <simpara>
        Soap 1.2 Атрибут xml:lang Reason Text.


### PR DESCRIPTION
Fixes #1170