### PR TITLE
Document underflow limitation in Randomizer::getFloat()

### DIFF
--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 423a1da63f8265c57827234807709232afd274ec Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="random-randomizer.getfloat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -344,6 +344,15 @@ printf(
     чтобы получить нужные поведенческие свойства.
    </para>
   </note>
+  <caution>
+   <para>
+    Потеря значимости (underflow) намеренно не обрабатывается в алгоритме γ-секции.
+    Это может привести к возврату некорректных значений для интервалов с
+    границами в субнормальном диапазоне чисел с плавающей точкой, то есть
+    для границ с абсолютным значением меньше приблизительно
+    <literal>2<superscript>-1020</superscript></literal> (около <literal>8.9e-308</literal>).
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Fixes #1178