### PR TITLE
[RU] Translate ext/uri extension documentation

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -5452,6 +5452,18 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Эта функция была
  <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link> в &false;.
 </para>
 '>
+
+<!ENTITY uri.errors.invalidUriException '
+  <simpara>
+   Если результирующий URI недопустим, выбрасывается исключение <exceptionname>Uri\InvalidUriException</exceptionname>.
+  </simpara>
+'>
+
+<!ENTITY uri.errors.invalidUrlException '
+  <simpara>
+   Если результирующий URL недопустим, выбрасывается исключение <exceptionname>Uri\WhatWg\InvalidUrlException</exceptionname>.
+  </simpara>
+'>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/uri/book.xml
+++ b/reference/uri/book.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4f62b60b56562114d9d816e2e5f13b40a5614c26 Maintainer: lacatoire Status: ready -->
+<book xml:id="book.uri" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
+ <?phpdoc extension-membership="core" ?>
+ <title>URI</title>
+ <titleabbrev>URI</titleabbrev>
+
+ <preface xml:id="intro.uri">
+  &reftitle.intro;
+  <simpara>
+   В этой главе описаны функции для работы с
+   унифицированными идентификаторами ресурсов (URI). URI — это строка символов,
+   которая используется для идентификации ресурса. URI используются в веб-технологиях
+   для идентификации ресурсов в Интернете.
+  </simpara>
+  <simpara>
+   Модуль реализует функциональность, которая следует спецификациям
+   <link xlink:href="&url.url.rfc3986;">RFC 3986,
+   Uniform Resource Identifier (URI): Generic Syntax</link> и
+   <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link>.
+  </simpara>
+ </preface>
+
+ &reference.uri.uri.rfc3986.uri;
+
+ &reference.uri.uri.whatwg.url;
+
+ &reference.uri.uri.uricomparisonmode;
+
+ &reference.uri.uri.uriexception;
+ &reference.uri.uri.urierror;
+ &reference.uri.uri.invaliduriexception;
+ &reference.uri.uri.whatwg.invalidurlexception;
+ &reference.uri.uri.whatwg.urlvalidationerror;
+ &reference.uri.uri.whatwg.urlvalidationerrortype;
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-invaliduriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\InvalidUriException</title>
+ <titleabbrev>Uri\InvalidUriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-invaliduriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Указывает на то, что данный URI недействителен или что операция приведёт к недействительному URI.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-invaliduriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\UriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.rfc3986.uri.xml
+++ b/reference/uri/uri.rfc3986.uri.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-rfc3986-uri" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\Rfc3986\Uri</title>
+ <titleabbrev>Uri\Rfc3986\Uri</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-rfc3986-uri.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-rfc3986-uri.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\Rfc3986</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Uri</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.rfc3986.entities.uri;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>Перечисление Uri\UriComparisonMode</title>
+ <titleabbrev>Uri\UriComparisonMode</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-uricomparisonmode.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-uricomparisonmode.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <enumsynopsis>
+     <enumname>UriComparisonMode</enumname>
+
+     <enumitem>
+      <enumidentifier>IncludeFragment</enumidentifier>
+      <enumitemdescription>Компонент <literal>fragment</literal> включается в сравнение.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>ExcludeFragment</enumidentifier>
+      <enumitemdescription>Компонент <literal>fragment</literal> исключается из сравнения.</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9e2dd56cb1b2fb3e97eed9b16b4b94ac0dbefadc Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
  <title>Перечисление Uri\UriComparisonMode</title>
  <titleabbrev>Uri\UriComparisonMode</titleabbrev>
@@ -8,6 +8,13 @@
   <section xml:id="enum.uri-uricomparisonmode.intro">
    &reftitle.intro;
    <simpara>
+    Указывает, должна ли часть <literal>fragment</literal> учитываться
+    при сравнении URI.
+   </simpara>
+   <simpara>
+    Если часть <literal>fragment</literal> исключена из сравнения, два URI
+    сравниваются так, как если бы ни у одного из них не было части
+    <literal>fragment</literal>.
    </simpara>
   </section>
 

--- a/reference/uri/uri.urierror.xml
+++ b/reference/uri/uri.urierror.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-urierror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\UriError</title>
+ <titleabbrev>Uri\UriError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-urierror.intro">
+   &reftitle.intro;
+   <simpara>
+    Базовый класс для ошибок (<type>Error</type>), возникающих при обработке URI.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-urierror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriError</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Error</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uriexception.xml
+++ b/reference/uri/uri.uriexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-uriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\UriException</title>
+ <titleabbrev>Uri\UriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-uriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Базовый класс для исключений (<type>Exception</type>), возникающих при обработке URI.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-uriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-invalidurlexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\WhatWg\InvalidUrlException</title>
+ <titleabbrev>Uri\WhatWg\InvalidUrlException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-invalidurlexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Указывает на то, что данный URL недействителен или что операция приведёт
+    к недействительному URL в соответствии со стандартом
+    <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link>.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUrlException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\InvalidUriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>readonly</modifier>
+      <type>array</type>
+      <varname linkend="uri-whatwg-invalidurlexception.props.errors">errors</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-invalidurlexception.props.errors">
+     <term><varname>errors</varname></term>
+     <listitem>
+      <simpara>
+       Массив (&array;) объектов <classname>Uri\WhatWg\UrlValidationError</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.invalidurlexception;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.url.xml
+++ b/reference/uri/uri.whatwg.url.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-url" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\WhatWg\Url</title>
+ <titleabbrev>Uri\WhatWg\Url</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-url.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-url.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Url</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.url;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b6e9565ba267f4c9a463104ffb0ea45e1a6753b0 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-urlvalidationerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Uri\WhatWg\UrlValidationError</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-urlvalidationerror.intro">
+   &reftitle.intro;
+   <simpara>
+    Предоставляет подробную информацию об ошибках, обнаруженных при разборе URL с помощью
+    <classname>Uri\WhatWg\Url</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>UrlValidationError</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>string</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.context">context</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>Uri\WhatWg\UrlValidationErrorType</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.type">type</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>bool</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.failure">failure</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.context">
+     <term><varname>context</varname></term>
+     <listitem>
+      <simpara>
+       Входной URL в точке, где была обнаружена ошибка.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.type">
+     <term><varname>type</varname></term>
+     <listitem>
+      <simpara>
+       Тип ошибки.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.failure">
+     <term><varname>failure</varname></term>
+     <listitem>
+      <simpara>
+       Если &true;, ошибка привела к отклонению URL как недействительного. Если &false;,
+       ошибка является мягкой ошибкой, которая была автоматически исправлена при разборе.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.urlvalidationerror;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>Перечисление Uri\WhatWg\UrlValidationErrorType</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <enumsynopsis>
+     <enumname>UrlValidationErrorType</enumname>
+
+     <enumitem>
+      <enumidentifier>DomainToAscii</enumidentifier>
+      <enumitemdescription>Ошибка при преобразовании доменного имени в строку ASCII.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainToUnicode</enumidentifier>
+      <enumitemdescription>Ошибка при преобразовании доменного имени в строку Unicode.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainInvalidCodePoint</enumidentifier>
+      <enumitemdescription>Хост входных данных содержит запрещённую кодовую точку домена.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostInvalidCodePoint</enumidentifier>
+      <enumitemdescription>Непрозрачный хост (в URL, который не является специальным) содержит запрещённую кодовую точку хоста.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4EmptyPart</enumidentifier>
+      <enumitemdescription>IPv4-адрес заканчивается символом <literal>U+002E</literal> (<literal>.</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4TooManyParts</enumidentifier>
+      <enumitemdescription>IPv4-адрес не состоит ровно из 4 частей.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonNumericPart</enumidentifier>
+      <enumitemdescription>Часть IPv4-адреса не является числовой.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonDecimalPart</enumidentifier>
+      <enumitemdescription>IPv4-адрес содержит числа, выраженные шестнадцатеричными или восьмеричными цифрами.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4OutOfRangePart</enumidentifier>
+      <enumitemdescription>Часть IPv4-адреса превышает <literal>255</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6Unclosed</enumidentifier>
+      <enumitemdescription>В IPv6-адресе отсутствует закрывающий символ <literal>U+005D</literal> (<literal>]</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCompression</enumidentifier>
+      <enumitemdescription>IPv6-адрес начинается с неправильного сжатия.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooManyPieces</enumidentifier>
+      <enumitemdescription>IPv6-адрес содержит более 8 частей.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6MultipleCompression</enumidentifier>
+      <enumitemdescription>IPv6-адрес сжат в более чем одном месте.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>
+       IPv6-адрес содержит кодовую точку, которая не является ни шестнадцатеричной цифрой ASCII,
+       ни символом <literal>U+003A</literal> (<literal>:</literal>). Или адрес неожиданно заканчивается.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooFewPieces</enumidentifier>
+      <enumitemdescription>Несжатый IPv6-адрес содержит менее 8 частей.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooManyPieces</enumidentifier>
+      <enumitemdescription>IPv6-адрес с синтаксисом IPv4-адреса: IPv6-адрес содержит более 6 частей.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>IPv6-адрес с синтаксисом IPv4-адреса.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6OutOfRangePart</enumidentifier>
+      <enumitemdescription>IPv6-адрес с синтаксисом IPv4-адреса: часть IPv4-адреса превышает <literal>255</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooFewParts</enumidentifier>
+      <enumitemdescription>IPv6-адрес с синтаксисом IPv4-адреса: IPv4-адрес содержит слишком мало частей.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidUrlUnit</enumidentifier>
+      <enumitemdescription>Обнаружена кодовая точка, которая не является единицей URL.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>SpecialSchemeMissingFollowingSolidus</enumidentifier>
+      <enumitemdescription>За схемой входных данных не следует <literal>//</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>MissingSchemeNonRelativeUrl</enumidentifier>
+      <enumitemdescription>
+       Во входных данных отсутствует схема, поскольку они не начинаются с буквы ASCII, и либо базовый URL не был предоставлен,
+       либо базовый URL не может использоваться в качестве базового, поскольку имеет непрозрачный путь.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidReverseSoldius</enumidentifier>
+      <enumitemdescription>URL имеет специальную схему и использует <literal>U+005C</literal> (<literal>\</literal>)
+       вместо <literal>U+002F</literal> (<literal>/</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidCredentials</enumidentifier>
+      <enumitemdescription>Входные данные содержат учётные данные.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostMissing</enumidentifier>
+      <enumitemdescription>Входные данные имеют специальную схему, но не содержат хоста.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortOutOfRange</enumidentifier>
+      <enumitemdescription>Порт входных данных слишком велик.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortInvalid</enumidentifier>
+      <enumitemdescription>Порт входных данных недействителен.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetter</enumidentifier>
+      <enumitemdescription>
+       Входные данные являются строкой относительного URL, которая начинается с буквы диска Windows,
+       а схема базового URL — <literal>file</literal>.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetterHost</enumidentifier>
+      <enumitemdescription>Хост URL с протоколом <literal>file:</literal> является буквой диска Windows.</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
-<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
+<!-- EN-Revision: 8352249a84d0b91b38c741ff1c256061127dbfbb Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
  <title>Перечисление Uri\WhatWg\UrlValidationErrorType</title>
  <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
 
@@ -8,6 +8,8 @@
   <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
    &reftitle.intro;
    <simpara>
+    Возможные ошибки валидации, определённые в
+    <link xlink:href="&url.url.whatwg-url;">стандарте URL WHATWG</link>.
    </simpara>
   </section>
 

--- a/reference/uri/uri/rfc3986/uri/construct.xml
+++ b/reference/uri/uri/rfc3986/uri/construct.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__construct</refname>
+  <refpurpose>Создаёт объект Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <methodname>Uri\Rfc3986\Uri::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Создаёт объект <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI для разбора.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Когда передаётся строка (&string;), параметр <parameter>uri</parameter> применяется
+      к <parameter>baseUrl</parameter>, если <parameter>uri</parameter> является относительной ссылкой.
+      Если передаётся &null; или <parameter>uri</parameter> не является относительной ссылкой,
+      то <parameter>baseUrl</parameter> не оказывает никакого эффекта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/debuginfo.xml
+++ b/reference/uri/uri/rfc3986/uri/debuginfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__debugInfo</refname>
+  <refpurpose>Получает отладочную информацию</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Возвращает внутреннее состояние URI.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает внутреннее состояние URI в виде массива (&array;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/equals.xml
+++ b/reference/uri/uri/rfc3986/uri/equals.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::equals</refname>
+  <refpurpose>Сравнивает два URI</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\Rfc3986\Uri::equals</methodname>
+   <methodparam><type>Uri\Rfc3986\Uri</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Проверяет, эквивалентны ли два URI.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI для сравнения с текущим URI.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      Определяет, учитывается ли компонент фрагмента при сравнении
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>) или нет
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>). По умолчанию фрагмент исключается.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает &true;, если два URI эквивалентны, или &false; в противном случае.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.equals.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::equals</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri1 = new \Uri\Rfc3986\Uri("https://example.com");
+$uri2 = new \Uri\Rfc3986\Uri("HTTPS://example.com");
+
+var_dump($uri1->equals($uri2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getFragment</refname>
+  <refpurpose>Получает нормализованный компонент фрагмента</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент фрагмента.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент фрагмента в виде строки (&string;), если компонент фрагмента существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getFragment</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/gethost.xml
+++ b/reference/uri/uri/rfc3986/uri/gethost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getHost</refname>
+  <refpurpose>Получает нормализованный компонент хоста</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент хоста.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент хоста в виде строки (&string;), если компонент хоста существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.gethost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getpassword.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPassword</refname>
+  <refpurpose>Получает нормализованный пароль</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованную часть пароля (текст после первого символа <literal>:</literal>)
+   из компонента userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный пароль в виде строки (&string;), если компонент userinfo содержит символ <literal>:</literal>.
+   Возвращает пустую строку, если компонент userinfo не содержит символ <literal>:</literal>.
+   Возвращает &null;, если компонент userinfo не существует.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpassword.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPassword</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPath</refname>
+  <refpurpose>Получает нормализованный компонент пути</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент пути.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент пути в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPath</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getport.xml
+++ b/reference/uri/uri/rfc3986/uri/getport.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPort</refname>
+  <refpurpose>Получает нормализованный компонент порта</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент порта.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент порта в виде целого числа (&integer;), если компонент порта существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getport.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPort</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:443");
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getQuery</refname>
+  <refpurpose>Получает нормализованный компонент запроса</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент запроса.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент запроса в виде строки (&string;), если компонент запроса существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getQuery</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawFragment</refname>
+  <refpurpose>Получает необработанный (raw) компонент фрагмента</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент фрагмента.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент фрагмента в виде строки (&string;), если компонент фрагмента существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getRawFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawhost.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawhost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawHost</refname>
+  <refpurpose>Получает необработанный (raw) компонент хоста</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент хоста.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент хоста в виде строки (&string;), если компонент хоста существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawhost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpassword.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPassword</refname>
+  <refpurpose>Получает необработанный (raw) пароль</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанную (ненормализованную) часть пароля (текст после первого символа <literal>:</literal>)
+   из компонента userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный (ненормализованный) пароль в виде строки (&string;), если компонент userinfo содержит символ <literal>:</literal>.
+   Возвращает пустую строку, если компонент userinfo не содержит символ <literal>:</literal>.
+   Возвращает &null;, если компонент userinfo не существует.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpassword.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPath</refname>
+  <refpurpose>Получает необработанный (raw) компонент пути</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getRawPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент пути.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент пути в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawPath</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getRawPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawQuery</refname>
+  <refpurpose>Получает необработанный (raw) компонент запроса</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент запроса.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент запроса в виде строки (&string;), если компонент запроса существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getRawQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawScheme</refname>
+  <refpurpose>Получает необработанный (raw) компонент схемы</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент схемы.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент схемы в виде строки (&string;), если компонент схемы существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUserInfo</refname>
+  <refpurpose>Получает необработанный (raw) компонент информации о пользователе</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанный (ненормализованный) компонент информации о пользователе.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанный компонент информации о пользователе в виде строки (&string;), если компонент информации о пользователе существует, в противном случае возвращается &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawusername.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUsername</refname>
+  <refpurpose>Получает необработанное (raw) имя пользователя</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает необработанную (ненормализованную) часть имени пользователя (текст перед первым символом <literal>:</literal>)
+   из компонента информации о пользователе.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает необработанное (ненормализованное) имя пользователя в виде строки (&string;), если компонент информации о пользователе существует, в противном случае возвращается &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawusername.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getScheme</refname>
+  <refpurpose>Получает нормализованный компонент схемы</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент схемы.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент схемы в виде строки (&string;), если компонент схемы существует, в противном случае возвращается &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getScheme</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getuserinfo.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUserInfo</refname>
+  <refpurpose>Получает нормализованный компонент информации о пользователе</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованный компонент информации о пользователе.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованный компонент информации о пользователе в виде строки (&string;), если компонент информации о пользователе существует, в противном случае возвращается &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUsername</refname>
+  <refpurpose>Получает нормализованное имя пользователя</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает нормализованную часть имени пользователя (текст перед первым символом <literal>:</literal>)
+   из компонента информации о пользователе.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает нормализованное имя пользователя в виде строки (&string;), если компонент информации о пользователе существует, в противном случае возвращается &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getusername.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getUsername</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::parse</refname>
+  <refpurpose>Разбирает URI</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Разбирает URI.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI для разбора.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Когда передаётся строка (&string;), параметр <parameter>uri</parameter> применяется к
+      <parameter>baseUrl</parameter>, если <parameter>uri</parameter> является относительной ссылкой.
+      Если передаётся &null; или <parameter>uri</parameter> не является относительной ссылкой,
+      <parameter>baseUrl</parameter> не оказывает никакого эффекта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает экземпляр <classname>Uri\Rfc3986\Uri</classname> в случае успеха или &null; в случае неудачи.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.parse.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::parse</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = \Uri\Rfc3986\Uri::parse("https://example.com");
+
+if ($uri !== null) {
+    echo "Valid URI: " . $uri->toString();
+} else {
+    echo "Invalid URI"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URI: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -60,9 +60,9 @@
 $uri = \Uri\Rfc3986\Uri::parse("https://example.com");
 
 if ($uri !== null) {
-    echo "Valid URI: " . $uri->toString();
+    echo "Допустимый URI: " . $uri->toString();
 } else {
-    echo "Invalid URI"
+    echo "Недопустимый URI"
 }
 ?>
 ]]>
@@ -70,7 +70,7 @@ if ($uri !== null) {
    &example.outputs;
    <screen>
 <![CDATA[
-Valid URI: https://example.com
+Допустимый URI: https://example.com
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/resolve.xml
+++ b/reference/uri/uri/rfc3986/uri/resolve.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::resolve</refname>
+  <refpurpose>Разрешает URI с текущим объектом в качестве базового URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Разрешает URI, который может быть относительной ссылкой, с текущим объектом в качестве базового URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI для применения к текущему объекту.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Новый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.resolve.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::resolve</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->resolve("/foo");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/serialize.xml
+++ b/reference/uri/uri/rfc3986/uri/serialize.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__serialize</refname>
+  <refpurpose>Сериализует объект Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Сериализует объект <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сериализованный URI в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/torawstring.xml
+++ b/reference/uri/uri/rfc3986/uri/torawstring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.torawstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toRawString</refname>
+  <refpurpose>Формирует необработанный (raw) URI в виде строки</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toRawString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Формирует необработанный (ненормализованный) URI в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сформированный необработанный (ненормализованный) URI в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.torawstring.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::toRawString</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/tostring.xml
+++ b/reference/uri/uri/rfc3986/uri/tostring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toString</refname>
+  <refpurpose>Формирует нормализованный URI в виде строки</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Формирует нормализованный URI в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сформированный нормализованный URI в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.tostring.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::toString</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/unserialize.xml
+++ b/reference/uri/uri/rfc3986/uri/unserialize.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__unserialize</refname>
+  <refpurpose>Десериализует параметр data в объект Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\Rfc3986\Uri::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Десериализует параметр data в объект <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      Сериализованные данные в виде массива (<type>array</type>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Если метод <methodname>__unserialize</methodname> вызывается для уже существующего URI, выбрасывается исключение <exceptionname>Error</exceptionname>.
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/withfragment.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withFragment</refname>
+  <refpurpose>Изменяет компонент фрагмента</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент фрагмента.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент фрагмента.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withFragment</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+$uri = new \Uri\Rfc3986\Uri("https://example.com/#foo");
+$uri = $uri->withFragment("bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withhost.xml
+++ b/reference/uri/uri/rfc3986/uri/withhost.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withHost</refname>
+  <refpurpose>Изменяет компонент хоста</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент хоста.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент хоста.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withhost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withHost("example.net");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withpath.xml
+++ b/reference/uri/uri/rfc3986/uri/withpath.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPath</refname>
+  <refpurpose>Изменяет компонент пути</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент пути.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент пути.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withPath</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+$uri = $uri->withPath("/baz");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withport.xml
+++ b/reference/uri/uri/rfc3986/uri/withport.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPort</refname>
+  <refpurpose>Изменяет компонент порта</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент порта.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент порта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withport.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withPort</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:8080");
+$uri = $uri->withPort(443);
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withquery.xml
+++ b/reference/uri/uri/rfc3986/uri/withquery.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withQuery</refname>
+  <refpurpose>Изменяет компонент запроса</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент запроса.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент запроса.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withQuery</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+$uri = $uri->withQuery("foo=baz");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/withscheme.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withScheme</refname>
+  <refpurpose>Изменяет компонент схемы</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withScheme</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент схемы.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент схемы.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withScheme</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withScheme("http");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/withuserinfo.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withUserInfo</refname>
+  <refpurpose>Изменяет компонент информации о пользователе</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>userinfo</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URI и изменяет его компонент информации о пользователе.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>userinfo</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент информации о пользователе.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+$uri = $uri->withUserInfo("userinfo");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+userinfo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/invalidurlexception/construct.xml
+++ b/reference/uri/uri/whatwg/invalidurlexception/construct.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-invalidurlexception.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\InvalidUrlException::__construct</refname>
+  <refpurpose>Создаёт объект InvalidUrlException</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\InvalidUrlException">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\InvalidUrlException::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>message</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>errors</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>code</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Throwable</type><type>null</type></type><parameter>previous</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Создаёт объект <classname>Uri\WhatWg\InvalidUrlException</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <simpara>
+      Сообщение исключения.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      Массив (&array;) объектов <classname>Uri\WhatWg\UrlValidationError</classname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>code</parameter></term>
+    <listitem>
+     <simpara>
+      Код исключения.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>previous</parameter></term>
+    <listitem>
+     <simpara>
+      Предыдущее исключение, используемое для цепочки исключений.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/construct.xml
+++ b/reference/uri/uri/whatwg/url/construct.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__construct</refname>
+  <refpurpose>Создаёт объект Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\Url::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Создаёт объект <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Допустимая строка URL для разбора (например, <literal>/foo</literal> или (например, <literal>https://example.com/foo</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Когда передана строка (&string;), параметр <parameter>uri</parameter> применяется к
+      <parameter>baseUrl</parameter>, если <parameter>uri</parameter> является относительной строкой URL.
+      Если передано значение &null; или <parameter>uri</parameter> не является относительной строкой URL, то
+      <parameter>baseUrl</parameter> не оказывает никакого эффекта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      Массив (&array;) для передачи списка экземпляров <classname>Uri\WhatWg\UrlValidationError</classname>
+      по ссылке для предоставления расширенной информации об ошибках, возникших при разборе.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/debuginfo.xml
+++ b/reference/uri/uri/whatwg/url/debuginfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__debugInfo</refname>
+  <refpurpose>Возвращает внутреннее состояние URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Возвращает внутреннее состояние URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает внутреннее состояние URL в виде массива (&array;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/equals.xml
+++ b/reference/uri/uri/whatwg/url/equals.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::equals</refname>
+  <refpurpose>Проверяет эквивалентность двух URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\WhatWg\Url::equals</methodname>
+   <methodparam><type>Uri\WhatWg\Url</type><parameter>url</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Проверяет эквивалентность двух URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>url</parameter></term>
+    <listitem>
+     <simpara>
+      URL для сравнения с текущим URL.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      Определяет, учитывается ли компонент фрагмента при сравнении
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>) или нет
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>). По умолчанию фрагмент исключается.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает &true;, если два URL эквивалентны, или &false; в противном случае.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.equals.example.basic">
+   <title><methodname>Uri\WhatWg\Url::equals</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url1 = new \Uri\WhatWg\Url("https://example.com");
+$url2 = new \Uri\WhatWg\Url("HTTPS://example.com");
+
+var_dump($url1->equals($url2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getasciihost.xml
+++ b/reference/uri/uri/whatwg/url/getasciihost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getasciihost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getAsciiHost</refname>
+  <refpurpose>Получает компонент хоста в виде ASCII-строки (&string;)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getAsciiHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент хоста в виде строки (&string;), используя транскрипцию punycode вместо символов Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент хоста в виде ASCII-строки (&string;), если компонент хоста существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getasciihost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getAsciiHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getfragment.xml
+++ b/reference/uri/uri/whatwg/url/getfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getFragment</refname>
+  <refpurpose>Получает компонент фрагмента</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент фрагмента.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент фрагмента в виде строки (&string;), если компонент фрагмента существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getfragment.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getFragment</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com#foo");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpassword.xml
+++ b/reference/uri/uri/whatwg/url/getpassword.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPassword</refname>
+  <refpurpose>Получает компонент пароля</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент пароля.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент пароля в виде строки (&string;), если компонент пароля существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpassword.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPassword</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpath.xml
+++ b/reference/uri/uri/whatwg/url/getpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPath</refname>
+  <refpurpose>Получает компонент пути</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент пути.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент пути в виде строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpath.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPath</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a00f03a6131b0b74c851b06879c528fc9537da8c Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPort</refname>
+  <refpurpose>Получает компонент порта</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент порта.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент порта в виде целого числа (&integer;), если компонент порта существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getport.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPort</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getQuery</refname>
+  <refpurpose>Получает компонент запроса</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент запроса.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент запроса в виде строки (&string;), если компонент запроса существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getquery.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getQuery</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo/bar");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getscheme.xml
+++ b/reference/uri/uri/whatwg/url/getscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getScheme</refname>
+  <refpurpose>Получает компонент схемы</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент схемы.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент схемы в виде строки (&string;), если компонент схемы существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getscheme.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getScheme</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getunicodehost.xml
+++ b/reference/uri/uri/whatwg/url/getunicodehost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getunicodehost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUnicodeHost</refname>
+  <refpurpose>Получает компонент хоста в виде Unicode-строки (&string;)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент хоста в виде строки (&string;), которая может содержать символы Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент хоста в виде Unicode-строки (&string;), если компонент хоста существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getunicodehost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getUnicodeHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getusername.xml
+++ b/reference/uri/uri/whatwg/url/getusername.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUsername</refname>
+  <refpurpose>Получает компонент имени пользователя</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Получает компонент имени пользователя.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает компонент имени пользователя в виде строки (&string;), если компонент имени пользователя существует, в противном случае возвращает &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getusername.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getUsername</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://username:password@example.com");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+username
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::parse</refname>
+  <refpurpose>Разбирает URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\WhatWg\Url::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">errors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Разбирает URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Допустимая строка URL для разбора (например, <literal>/foo</literal> или (например, <literal>https://example.com/foo</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Когда передана строка (&string;), параметр <parameter>uri</parameter> применяется к
+      <parameter>baseUrl</parameter>, если <parameter>uri</parameter> является относительной строкой URL.
+      Если передано значение &null; или <parameter>uri</parameter> не является относительной строкой URL, то
+      <parameter>baseUrl</parameter> не оказывает никакого эффекта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      Массив (&array;) для передачи списка экземпляров <classname>Uri\WhatWg\UrlValidationError</classname>
+      по ссылке для предоставления расширенной информации об ошибках, возникших при разборе.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает экземпляр <classname>Uri\WhatWg\Url</classname> в случае успешного выполнения или &null; в случае неудачи.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.parse.example.basic">
+   <title><methodname>Uri\WhatWg\Url::parse</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = \Uri\WhatWg\Url::parse("https://example.com");
+
+if ($url !== null) {
+    echo "Valid URL: " . $url->toAsciiString();
+} else {
+    echo "Invalid URL"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URL: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -70,9 +70,9 @@
 $url = \Uri\WhatWg\Url::parse("https://example.com");
 
 if ($url !== null) {
-    echo "Valid URL: " . $url->toAsciiString();
+    echo "Допустимый URL: " . $url->toAsciiString();
 } else {
-    echo "Invalid URL"
+    echo "Недопустимый URL"
 }
 ?>
 ]]>
@@ -80,7 +80,7 @@ if ($url !== null) {
    &example.outputs;
    <screen>
 <![CDATA[
-Valid URL: https://example.com
+Допустимый URL: https://example.com
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/resolve.xml
+++ b/reference/uri/uri/whatwg/url/resolve.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::resolve</refname>
+  <refpurpose>Разрешает URL относительно текущего объекта как базового URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Разрешает допустимую строку URL, которая потенциально может быть строкой относительного URL, используя текущий объект как базовый URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Допустимая строка URL (например, <literal>/foo</literal> или <literal>https://example.com/foo</literal>), которая применяется
+      к текущему объекту.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      Массив (&array;) для передачи по ссылке списка экземпляров <classname>Uri\WhatWg\UrlValidationError</classname>,
+      предоставляющих расширенную информацию о мягких ошибках, возникших при разрешении ссылки.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Новый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.resolve.example.basic">
+   <title><methodname>Uri\WhatWg\Url::resolve</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->resolve("/foo");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/serialize.xml
+++ b/reference/uri/uri/whatwg/url/serialize.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__serialize</refname>
+  <refpurpose>Сериализует объект Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Сериализует объект <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сериализованный URL в виде массива (&array;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/toasciistring.xml
+++ b/reference/uri/uri/whatwg/url/toasciistring.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.toasciistring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toAsciiString</refname>
+  <refpurpose>Формирует URL в виде ASCII-строки (&string;)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toAsciiString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Формирует URL в виде ASCII-строки (&string;), используя транскрипцию punycode вместо символов Unicode в
+   компоненте хоста.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сформированный URL в виде ASCII-строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.toasciistring.example.basic">
+   <title><methodname>Uri\WhatWg\Url::toAsciiString</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/tounicodestring.xml
+++ b/reference/uri/uri/whatwg/url/tounicodestring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.tounicodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toUnicodeString</refname>
+  <refpurpose>Формирует URL в виде Unicode-строки (&string;)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toUnicodeString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Формирует URL в виде строки (&string;), в которой компонент хоста может содержать символы Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает сформированный URL в виде Unicode-строки (&string;).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.tounicodestring.example.basic">
+   <title><methodname>Uri\WhatWg\Url::toUnicodeString</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toUnicodeString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/unserialize.xml
+++ b/reference/uri/uri/whatwg/url/unserialize.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__unserialize</refname>
+  <refpurpose>Десериализует параметр data в объект Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\WhatWg\Url::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Десериализует параметр data в объект <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      Сериализованные данные в виде массива (<type>array</type>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Если метод <methodname>__unserialize</methodname> вызывается для уже существующего URL, выбрасывается исключение <exceptionname>Error</exceptionname>.
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withfragment.xml
+++ b/reference/uri/uri/whatwg/url/withfragment.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withFragment</refname>
+  <refpurpose>Изменяет компонент фрагмента</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент фрагмента.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент фрагмента.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withfragment.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withFragment</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/#foo");
+$url = $url->withFragment("bar");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withhost.xml
+++ b/reference/uri/uri/whatwg/url/withhost.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withHost</refname>
+  <refpurpose>Изменяет компонент хоста</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент хоста.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент хоста.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withhost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withHost</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withHost("example.net");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpassword.xml
+++ b/reference/uri/uri/whatwg/url/withpassword.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPassword</refname>
+  <refpurpose>Изменяет компонент пароля</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPassword</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент пароля.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент пароля.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpassword.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPassword</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withPassword("pass");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+pass
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpath.xml
+++ b/reference/uri/uri/whatwg/url/withpath.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPath</refname>
+  <refpurpose>Изменяет компонент пути</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент пути.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент пути.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpath.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPath</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+$url = $url->withPath("/baz");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPort</refname>
+  <refpurpose>Изменяет компонент порта</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент порта.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент порта.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withport.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPort</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+$url = $url->withPort(443);
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withquery.xml
+++ b/reference/uri/uri/whatwg/url/withquery.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withQuery</refname>
+  <refpurpose>Изменяет компонент запроса</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент запроса.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент запроса.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withquery.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withQuery</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo=bar");
+$url = $url->withQuery("foo=baz");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withscheme.xml
+++ b/reference/uri/uri/whatwg/url/withscheme.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withScheme</refname>
+  <refpurpose>Изменяет компонент схемы</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withScheme</methodname>
+   <methodparam><type>string</type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент схемы.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент схемы.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withscheme.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withScheme</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withScheme("http");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withusername.xml
+++ b/reference/uri/uri/whatwg/url/withusername.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withUsername</refname>
+  <refpurpose>Изменяет компонент имени пользователя</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withUsername</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>username</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Создаёт новый URL и изменяет его компонент имени пользователя.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>username</parameter></term>
+    <listitem>
+     <simpara>
+      Новый компонент имени пользователя.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Изменённый экземпляр <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withusername.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withUsername</methodname> простой пример</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withUsername("usr");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+usr
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translate the ext/uri extension documentation to Russian.

This adds translations for:
- `Uri\Rfc3986\Uri` class and all its methods
- `Uri\WhatWg\Url` class and all its methods
- `Uri\UriComparisonMode` enum
- Exception/Error classes (`UriException`, `UriError`, `InvalidUriException`, `InvalidUrlException`)
- `Uri\WhatWg\UrlValidationError` and `UrlValidationErrorType`
- URI-related entity snippets in `language-snippets.ent`