### PR TITLE
Update EN-Revision hashes after doc-en spelling fixes

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd87866772c31671146ff778140dc0955c55005c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook">
  <title>Функции</title>

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.paamayim-nekudotayim" xmlns="http://docbook.org/ns/docbook">
  <title>Оператор разрешения области действия ::</title>

--- a/reference/com/functions/variant-cmp.xml
+++ b/reference/com/functions/variant-cmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 20216b916ed583938672cd09c2c2f430351430d1 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.variant-cmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/cubrid/cubridmysql/cubrid-fetch-field.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-field.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-fetch-field">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f5e51d56b0a4dd7e70dd47ea7eb3c07fdc207ddd Maintainer: shein Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfromformat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/dio/functions/dio-open.xml
+++ b/reference/dio/functions/dio-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.dio-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/ev/evtimer.xml
+++ b/reference/ev/evtimer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.evtimer" role="class">
  <title>Класс EvTimer</title>

--- a/reference/fann/functions/fann-create-train-from-callback.xml
+++ b/reference/fann/functions/fann-create-train-from-callback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 242efce0dc3aefd028a2956340231d8c62d4e38a Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-create-train-from-callback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/fann/functions/fann-create-train.xml
+++ b/reference/fann/functions/fann-create-train.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 242efce0dc3aefd028a2956340231d8c62d4e38a Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-create-train" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b09581bfdd1fa1c33daa740ad49599cf665cff4 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/gnupg/functions/gnupg-init.xml
+++ b/reference/gnupg/functions/gnupg-init.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a148eb08b658eafa139f8996ad92d860e023da3f Maintainer: bfl Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: bfl Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gnupg-init">
  <refnamediv>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ibm-db2.configuration">
  &reftitle.runtime;

--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 06844e3a94bc257261d350b453750b7ad7f7b27b Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="intl.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/mysqli/mysqli/error-list.xml
+++ b/reference/mysqli/mysqli/error-list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e5d0d1bb69180c9de1992edf9613215c975fa57 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.error-list" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/openssl/functions/openssl-pkcs12-read.xml
+++ b/reference/openssl/functions/openssl-pkcs12-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5bc68add3da3cd18c40f851e944b15095d3a26aa Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-pkcs12-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/outcontrol/examples.xml
+++ b/reference/outcontrol/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e0b70f68d03701ce531be0025af19cdcfe333782 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="outcontrol.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f43157bcb645cbd16083ce6b408649dcafa5a209 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="ref.pdo-sqlsrv">
  <?phpdoc extension-membership="pecl" ?>

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.pg-escape-identifier' xmlns="http://docbook.org/ns/docbook">

--- a/reference/pthreads/threaded/isrunning.xml
+++ b/reference/pthreads/threaded/isrunning.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bf92d8bd839301de7c837d20ab1dac6c14f83bbf Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="thread.isrunning">
  <refnamediv>

--- a/reference/random/random/engine/generate.xml
+++ b/reference/random/random/engine/generate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 43756e54fb34ece9b83559ccdde98864b9c3fb5c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="random-engine.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/snmp/snmp/get.xml
+++ b/reference/snmp/snmp/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.get">
  <refnamediv>

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.getnext">
  <refnamediv>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b0dba86b667cb30b72ef0a8cf42ea26d257ecfe4 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-addrinfo-lookup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/sodium/functions/sodium-crypto-box-publickey-from-secretkey.xml
+++ b/reference/sodium/functions/sodium-crypto-box-publickey-from-secretkey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-box-publickey-from-secretkey">
  <refnamediv>

--- a/reference/swoole/swoole/atomic/construct.xml
+++ b/reference/swoole/swoole/atomic/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="swoole-atomic.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/swoole/swoole/client/connect.xml
+++ b/reference/swoole/swoole/client/connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="swoole-client.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uodbc/functions/odbc-field-num.xml
+++ b/reference/uodbc/functions/odbc-field-num.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.odbc-field-num" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/uodbc/functions/odbc-field-scale.xml
+++ b/reference/uodbc/functions/odbc-field-scale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.odbc-field-scale" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/wincache/functions/wincache-ucache-add.xml
+++ b/reference/wincache/functions/wincache-ucache-add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07e42841b078fc8dfb4a2d053b707b5233c4cfeb Maintainer: evvc Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: evvc Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.wincache-ucache-add" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/wincache/functions/wincache-ucache-set.xml
+++ b/reference/wincache/functions/wincache-ucache-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07e42841b078fc8dfb4a2d053b707b5233c4cfeb Maintainer: evvc Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: evvc Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.wincache-ucache-set" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/yaf/yaf_config_ini/get.xml
+++ b/reference/yaf/yaf_config_ini/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2ba031cea18ed772310819005eeb1557c6a8ec75 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-config-ini.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_loader/registerlocalnamespace.xml
+++ b/reference/yaf/yaf_loader/registerlocalnamespace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7418592d82d6cde8d052effd3607e5761d6c4e67 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-loader.registerlocalnamespace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_loader/registernamespace.xml
+++ b/reference/yaf/yaf_loader/registernamespace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16a1bdfd1c36108534b5af08dc4b751c7ac0fdaf Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="yaf-loader.registernamespace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/yaf/yaf_response_abstract/getbody.xml
+++ b/reference/yaf/yaf_response_abstract/getbody.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6bce1dbf90821e3c720776dd013dc796d14d9781 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-response-abstract.getbody" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_response_abstract/setheader.xml
+++ b/reference/yaf/yaf_response_abstract/setheader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bdcd9cd0940af35cb31799ff2637aaa7c5ffbfdc Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-response-abstract.setheader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b37bddfde36975bf6bf06ce98867e62d489d49c5 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="yaf-route-regex.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/yaf/yaf_view_interface/setscriptpath.xml
+++ b/reference/yaf/yaf_view_interface/setscriptpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: de378121240764d3e88ff734b6eac1b9b2765396 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-view-interface.setscriptpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 167c48c1c76f7f29be2f44fd72ea72a43ae5e1e1 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 32040dd7e5d98c136502134110681f80443dd000 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="zookeeper.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Update EN-Revision hashes for 39 files following the merge of php/doc-en#5362 (spelling & typo fixes).

Only files whose EN-Revision matched the parent commit were updated. 5 files that were already behind were left unchanged.