### PR TITLE
Sync EN: grapheme_strlen возвращает null при ошибке кодирования (#5568)

### DIFF
--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b548fc8e5592b577d29aabf9cf2e79d5385ae549 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: e7d502fecc2e84d4c57e6451b16f68bec1295ba8 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.grapheme-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Функция возвращает количество графемных кластеров в строке, если выполнилась успешно,&return.falseforfailure;.
-  </para>
+  <simpara>
+   Функция возвращает количество графемных кластеров в строке, если выполнилась успешно, &null; или &false; в случае возникновения ошибки.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Синхронизация с php/doc-en#5568 : возвращаемое значение grapheme_strlen теперь документирует &null; или &false; при ошибке (para → simpara).

Fixes #1327