### PR TITLE
Sync EN: Uri fixes (#5467)

### DIFF
--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: malferov Status: ready -->
 <refentry xml:id="uri-rfc3986-uri.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\Rfc3986\Uri::getUsername</refname>


### PR DESCRIPTION
Синхронизация с php/doc-en#5467 (перемещение файлов uri): обновление EN-Revision последнего несинхронизированного файла rfc3986 getUsername (изменений содержимого нет, только перемещение).

Fixes #1239