### PR TITLE
Sync EN: ImagickDraw::getTextInterlineSpacing (#5480)

### DIFF
--- a/reference/imagick/imagickdraw/gettextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterlinespacing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 13cc59c9fe01418faf015ace0c88ae7b52f9d0a1 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="imagickdraw.gettextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Синхронизация с php/doc-en#5480 (исправление interword -> interline в EN). Перевод уже корректен (межстрочный интервал), обновлён только EN-Revision.

Fixes #1241