### PR TITLE
Sync EN: синхронизация сигнатур intl со стабами, часть 10 (#5415)

### DIFF
--- a/reference/intl/intltimezone/createenumeration.xml
+++ b/reference/intl/intltimezone/createenumeration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: lex Status: ready -->
+<!-- EN-Revision: f7f861700c504afc40c14603d0fa0b36629a87ff Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intltimezone.createenumeration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
   <para>&style.oop; (метод):</para>
   <methodsynopsis role="IntlTimeZone">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>IntlTimeZone::createEnumeration</methodname>
-   <methodparam choice="opt"><type class="union"><type>IntlTimeZone</type><type>string</type><type>int</type><type>float</type><type>null</type></type><parameter>countryOrRawOffset</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>int</type><type>null</type></type><parameter>countryOrRawOffset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>intltz_create_enumeration</methodname>
-   <methodparam choice="opt"><type class="union"><type>IntlTimeZone</type><type>string</type><type>int</type><type>float</type><type>null</type></type><parameter>countryOrRawOffset</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>int</type><type>null</type></type><parameter>countryOrRawOffset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/intl/resourcebundle/get.xml
+++ b/reference/intl/resourcebundle/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b35a2269ff83dde1436a407952b08f78dbe39ead Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: f7f861700c504afc40c14603d0fa0b36629a87ff Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="resourcebundle.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,7 +14,7 @@
    &style.oop;
   </para>
   <methodsynopsis role="ResourceBundle">
-   <modifier>public</modifier> <type>mixed</type><methodname>ResourceBundle::get</methodname>
+   <modifier>public</modifier> <type class="union"><type>ResourceBundle</type><type>array</type><type>string</type><type>int</type><type>null</type></type><methodname>ResourceBundle::get</methodname>
    <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>fallback</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
@@ -22,7 +22,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>mixed</type><methodname>resourcebundle_get</methodname>
+   <type class="union"><type>ResourceBundle</type><type>array</type><type>string</type><type>int</type><type>null</type></type><methodname>resourcebundle_get</methodname>
    <methodparam><type>ResourceBundle</type><parameter>bundle</parameter></methodparam>
    <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>fallback</parameter><initializer>&true;</initializer></methodparam>

--- a/reference/intl/transliterator/geterrorcode.xml
+++ b/reference/intl/transliterator/geterrorcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: f7f861700c504afc40c14603d0fa0b36629a87ff Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="transliterator.geterrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,12 +12,12 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="Transliterator">
-   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>Transliterator::getErrorCode</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>Transliterator::getErrorCode</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
-   <type class="union"><type>int</type><type>false</type></type><methodname>transliterator_get_error_code</methodname>
+   <type>int</type><methodname>transliterator_get_error_code</methodname>
    <methodparam><type>Transliterator</type><parameter>transliterator</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/intl/transliterator/geterrormessage.xml
+++ b/reference/intl/transliterator/geterrormessage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: f7f861700c504afc40c14603d0fa0b36629a87ff Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="transliterator.geterrormessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,12 +12,12 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="Transliterator">
-   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Transliterator::getErrorMessage</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>Transliterator::getErrorMessage</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
-   <type class="union"><type>string</type><type>false</type></type><methodname>transliterator_get_error_message</methodname>
+   <type>string</type><methodname>transliterator_get_error_message</methodname>
    <methodparam><type>Transliterator</type><parameter>transliterator</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Синхронизация с php/doc-en#5415 : типы сигнатур intl (IntlTimeZone::createEnumeration, ResourceBundle::get, Transliterator::getErrorCode/getErrorMessage) приведены к стабам php-src.

Fixes #1211