### PR TITLE
CI: пропускать удалённые файлы в проверке EditorConfig

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -23,4 +23,13 @@ jobs:
         with:
           output: ' '
       - name: Запуск editorconfig-checker
-        run: npx editorconfig-checker ${{ steps.get_file_changes.outputs.files }}
+        run: |
+          files=""
+          for file in ${{ steps.get_file_changes.outputs.files }}; do
+            [ -f "$file" ] && files="$files $file"
+          done
+          if [ -n "$files" ]; then
+            npx editorconfig-checker $files
+          else
+            echo "Нет изменённых файлов для проверки."
+          fi


### PR DESCRIPTION
Сейчас шаг lint передаёт в `editorconfig-checker` все изменённые файлы, включая удалённые. Инструмент завершается с `panic` (`no such file or directory`), из-за чего любой PR, удаляющий файл, валит проверку (например #1332).

Фильтрую список до существующих файлов перед запуском проверки.