### PR TITLE
Sync EN: ob_get_clean (исправление опечатки) (#5449)

### DIFF
--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86b976d5afaf037868174fe5c242e886eb69baa4 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5778b68049cc01810523b09b028398c70115cd56 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">
  <refnamediv>


### PR DESCRIPTION
Синхронизация с php/doc-en#5449 (it's -> its в EN). Перевод уже корректен, обновлён только EN-Revision.

Fixes #1221