### PR TITLE
Sync EN: SplFileInfo::getFilename, вывод примера (#5250)

### DIFF
--- a/reference/spl/splfileinfo/getfilename.xml
+++ b/reference/spl/splfileinfo/getfilename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: northcat Status: ready -->
+<!-- EN-Revision: 4532dcab5cc997cc75983d403c6be1ee6142b63c Maintainer: northcat Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileinfo.getfilename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,7 +57,7 @@ var_dump($info->getFilename());
 <![CDATA[
 string(7) "foo.txt"
 string(7) "foo.txt"
-string(0) ""
+string(11) "www.php.net"
 string(7) "svn.php"
 ]]>
     </screen>


### PR DESCRIPTION
Синхронизация с php/doc-en#5250 : обновлён вывод примера (getFilename для http://www.php.net/ теперь возвращает www.php.net).

Fixes #1213