### PR TITLE
Sync EN: preg_replace, удаление описания модификатора e (#5430)

### DIFF
--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 79c53e3fa2afc0f09373b17c23896465d8d41d0a Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.preg-replace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -101,16 +101,6 @@
        Решение состоит в том, чтобы использовать конструкцию <literal>${1}1</literal>,
        которая создаёт изолированную обратную ссылку <literal>$1</literal>,
        а число <literal>1</literal> оставляет литералом.
-      </para>
-      <para>
-       Если в шаблоне указали устаревший модификатор <literal>e</literal>,
-       функция заэкранирует в строках, которыми замещаются обратные ссылки,
-       отдельные символы: <literal>'</literal>, <literal>"</literal>, <literal>\</literal> и NULL.
-       Это сделали, чтобы гарантировать отсутствие синтаксических ошибок
-       при записи обратных ссылок в одинарных или двойных кавычках:
-       <literal>'strlen(\'$1\')+strlen("$2")'</literal>.
-       Знание <link linkend="language.types.string">синтаксиса записи строк</link>
-       в PHP помогает понять, как интерпретатор будет видеть строку.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Синхронизация с php/doc-en#5430 : удалён абзац про устаревший модификатор e (экранирование в строках замены), как в EN.

Fixes #1214