### PR TITLE
Sync EN: opcache.jit_hot_loop (#4685)

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8ea24dc32374bf4f6b04005e317101e4c65a0214 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: f2cdcd5af4558c22db95463b6ccdd25e4cea3cf5 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
@@ -309,9 +309,9 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></entry>
-      <entry>64</entry>
+      <entry>61</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Опция доступна с PHP 8.0.0</entry>
+      <entry>Опция доступна с PHP 8.0.0. До PHP 8.5.0 значение по умолчанию было 64</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></entry>
@@ -1328,6 +1328,11 @@ function getA() { return A; }
      например <literal>-1</literal> или <literal>256</literal>, будет использоваться значение по умолчанию.
      Значение <literal>0</literal> отключит трассировку и компиляцию циклов JIT-компилятором.
     </simpara>
+    <note>
+     <simpara>
+      Рекомендуется задавать этому параметру простое число, чтобы оно не было кратно числу итераций цикла.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-hot-func">


### PR DESCRIPTION
Синхронизация с php/doc-en#4685 : значение по умолчанию изменено на 61 (до PHP 8.5.0 было 64), добавлена рекомендация задавать простое число.

Fixes #1314