### PR TITLE
Sync EN: proc_close, changelog 8.3.0 (#5483)

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 350d95443aeb0ea8751d71f262aac56d3ad48f83 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,6 +50,30 @@
    Функция возвращает <literal>-1</literal>, если возникла ошибка.
   </para>
   &note.sigchild;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Функция <function>proc_close</function> теперь возвращает правильный код завершения,
+       даже если сначала вызвали функцию <function>proc_get_status</function>.
+       Раньше в этом случае возвращалось значение <literal>-1</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Синхронизация с php/doc-en#5483 : добавлена запись changelog 8.3.0 (proc_close возвращает правильный код завершения даже после вызова proc_get_status).

Fixes #1306