### PR TITLE
Sync EN: Yar_Concurrent_Client::call (#5492)

### DIFF
--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c50df321d2cccb1044219a98d4c5c7677d4b29cf Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -62,18 +62,18 @@
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Callback-функция, которую модуль Yar вызовет, если возникнет ошибка.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Массив опций.
       См. <link linkend="yar.constants">список констант</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Синхронизация с php/doc-en#5492 : описания error_callback и options приведены к simpara (текст уже был переведён).

Fixes #1275