### PR TITLE
Sync EN: stream_select, уточнение поведения timeout при microseconds 0 или null (#5428)

### DIFF
--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a123b24db5b3e42841179fea13cd508418fc45c7 Maintainer: mch Status: ready -->
+<!-- EN-Revision: a758e79c3bf173203550cb78ef07509cf859b212 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -81,9 +81,9 @@
        в течение которого функция <function>stream_select</function> будет ждать,
        прежде чем вернёт результат.
        Функция <function>stream_select</function> не будет ждать данные,
-       если обоим параметрам — <parameter>seconds</parameter>
-       и <parameter>microseconds</parameter> —
-       установлено значение <literal>0</literal>, вместо этого функция вернёт
+       если параметру <parameter>seconds</parameter> установлено значение
+       <literal>0</literal>, а параметр <parameter>microseconds</parameter>
+       равен <literal>0</literal> или &null;, вместо этого функция вернёт
        результат немедленно, указывая текущий статус потоков.
       </para>
       <para>


### PR DESCRIPTION
Синхронизация с php/doc-en#5428 : функция возвращается немедленно, когда <parameter>seconds</parameter> равно 0, а <parameter>microseconds</parameter> равно 0 или &null; (а не когда оба равны 0).

Fixes #1210