### PR TITLE
Sync EN: hash/hash_hmac/hash_hmac_file, changelog упоминает E_WARNING, секция ошибок для hash() (#5271)

### DIFF
--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.hash-hmac-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -99,7 +99,8 @@
        <entry>
         Функция теперь выбрасывает исключение <classname>ValueError</classname>,
         если алгоритм <parameter>algo</parameter> неизвестен или не криптографическая хеш-функция;
-        раньше вместо этого возвращалось значение &false;.
+        раньше вместо этого возвращалось значение &false;
+        и выдавалось сообщение об ошибке уровня <constant>E_WARNING</constant>.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.hash-hmac" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -98,7 +98,8 @@
        <entry>
         Функция теперь выбрасывает ошибку <classname>ValueError</classname>,
         если в параметр <parameter>algo</parameter> передали название неизвестной или некриптографической хеш-функции;
-        раньше вместо этого возвращалось значение &false;.
+        раньше вместо этого возвращалось значение &false;
+        и выдавалось сообщение об ошибке уровня <constant>E_WARNING</constant>.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.hash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -71,6 +71,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Функция выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+   если алгоритм <parameter>algo</parameter> неизвестен.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -92,8 +100,9 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Функция <function>hash</function> теперь выбрасывает исключение <classname>ValueError</classname>,
-        если алгоритм <parameter>algo</parameter> неизвестен; раньше вместо этого возвращалось значение &false;.
+        Функция теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+        если алгоритм <parameter>algo</parameter> неизвестен; раньше вместо этого возвращалось значение &false;
+        и выдавалось сообщение об ошибке уровня <constant>E_WARNING</constant>.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Синхронизация с php/doc-en#5271 : в записи changelog 8.0.0 уточнено, что ранее наряду с возвратом &false; выдавалось сообщение уровня <constant>E_WARNING</constant>; для <function>hash</function> добавлена секция errors.

Fixes #1311