### PR TITLE
Sync EN: POSIX, записи changelog для изменений PHP 8.5 (#5534)

### DIFF
--- a/reference/posix/functions/posix-fpathconf.xml
+++ b/reference/posix/functions/posix-fpathconf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8d417bd83842efbde90dbb51c31f99f474437ce4 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-fpathconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -55,6 +55,30 @@
    Функция выбрасывает исключение <classname>ValueError</classname>,
    если значение параметра <parameter>resource</parameter> недопустимо.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь устанавливает <varname>last_error</varname> в значение
+       <constant>EBADF</constant> и выдаёт ошибку уровня <constant>E_WARNING</constant>,
+       когда встречает недопустимый файловый дескриптор.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/posix/functions/posix-isatty.xml
+++ b/reference/posix/functions/posix-isatty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 394815225713c1aad0007d80f2c3c3592d085084 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-isatty" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,6 +47,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выдаёт ошибку уровня <constant>E_WARNING</constant>,
+       когда параметр <parameter>file_descriptor</parameter> недопустимый.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-kill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,6 +49,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>process_id</parameter> меньше или больше
+       значения, которое поддерживает платформа (диапазон знакового
+       integer или long).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-setpgid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,6 +49,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>process_id</parameter> или
+       <parameter>process_group_id</parameter> меньше нуля или больше
+       значения, которое поддерживает платформа.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setrlimit.xml
+++ b/reference/posix/functions/posix-setrlimit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-setrlimit" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -62,6 +62,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>hard_limit</parameter> или
+       <parameter>soft_limit</parameter> меньше -1, либо когда
+       <parameter>soft_limit</parameter> больше <parameter>hard_limit</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c166423255b3d5e02f74232f2d05fd3b59d5d62 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-ttyname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -56,6 +56,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь устанавливает <varname>last_error</varname> в значение
+       <constant>EBADF</constant>, когда параметр
+       <parameter>file_descriptor</parameter> недопустимый.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Синхронизация с php/doc-en#5534 : добавлены записи changelog 8.5.0 для posix_fpathconf, posix_isatty, posix_kill, posix_setpgid, posix_setrlimit, posix_ttyname (EBADF/last_error, E_WARNING, ValueError при выходе за диапазон).

Fixes #1310