### PR TITLE
Sync EN: Sockets, записи changelog PHP 8.5 и константа AF_PACKET (#5535)

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 42402941bba0208a919e03e1320ca4732330eafa Maintainer: countzero Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: countzero Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -46,7 +46,23 @@
    </term>
    <listitem>
     <simpara>
+     Семейство адресов сокета для интерфейса <literal>divert(4)</literal> FreeBSD,
+     используется для приёма пакетов, перенаправленных межсетевым экраном.
      Константа доступна с PHP 8.3.0 (только в ОС FreeBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Семейство адресов сокета для низкоуровневых пакетных сокетов,
+     используется для отправки и приёма необработанных пакетов на уровне
+     драйвера устройства (уровень 2 модели OSI).
+     Константа доступна с PHP 8.5.0 (только в ОС Linux).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lex Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-addrinfo-lookup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -75,6 +75,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>TypeError</exceptionname>,
+       если какое-либо значение массива <parameter>hints</parameter> нельзя
+       привести к int, и может выбросить исключение
+       <exceptionname>ValueError</exceptionname>, если какое-либо из этих
+       значений переполняется.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -80,7 +80,7 @@
       <entry>
        Теперь выбрасывает исключение <exceptionname>TypeError</exceptionname>,
        если какое-либо значение массива <parameter>hints</parameter> нельзя
-       привести к int, и может выбросить исключение
+       привести к целому числу, и может выбросить исключение
        <exceptionname>ValueError</exceptionname>, если какое-либо из этих
        значений переполняется.
       </entry>

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 35883800e764cccacf5772330bc007b6b08ffc6e Maintainer: countzero Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: countzero Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-bind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -88,6 +88,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>port</parameter> меньше 0 или больше 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: countzero Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: countzero Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -74,6 +74,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>port</parameter> меньше 0 или больше 65535.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a871ef72edf436c59422dedd538594db2541d5f1 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -226,6 +226,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь поддерживает создание сокетов семейства <constant>AF_PACKET</constant>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-getsockname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -91,6 +91,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Теперь получает индекс интерфейса и его строковое представление
+        при использовании на сокете семейства <constant>AF_PACKET</constant>.
+       </entry>
+      </row>
       &sockets.changelog.socket-param;
      </tbody>
     </tgroup>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: countzero Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: countzero Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-sendto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -137,6 +137,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда параметр <parameter>port</parameter> меньше 0 или больше 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 93105c67e470df72333493cc2e534635dd16422d Maintainer: countzero Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: countzero Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.socket-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -89,6 +89,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Теперь выбрасывает исключение, когда используется
+        <constant>MCAST_LEAVE_GROUP</constant> или
+        <constant>MCAST_LEAVE_SOURCE_GROUP</constant>, а значение не является
+        допустимым объектом или массивом, и выбрасывает исключение
+        <exceptionname>ValueError</exceptionname>, когда параметр многоадресной
+        рассылки используется на сокете, который не относится к семейству
+        <constant>AF_INET</constant> или <constant>AF_INET6</constant>.
+       </entry>
+      </row>
       &sockets.changelog.socket-param;
      </tbody>
     </tgroup>


### PR DESCRIPTION
Синхронизация с php/doc-en#5535 : добавлена константа <constant>AF_PACKET</constant> и описание <constant>AF_DIVERT</constant>; записи changelog 8.5.0 для socket_addrinfo_lookup, socket_bind, socket_create, socket_create_listen, socket_getsockname, socket_sendto, socket_set_option.

Fixes #1307