### PR TITLE
Sync EN: записи changelog об устаревании в PHP 8.5.0 (#5369)

### DIFF
--- a/reference/fileinfo/functions/finfo-buffer.xml
+++ b/reference/fileinfo/functions/finfo-buffer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82ddd2ec8ad195035dcb57dd8f97d27b83ddc126 Maintainer: mch Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-buffer">
  <refnamediv>
@@ -84,6 +84,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Параметр <parameter>context</parameter> объявлен устаревшим,
+       поскольку игнорируется.
+      </entry>
+     </row>
      &fileinfo.changelog.finfo-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -56,7 +56,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       Вызов <methodname>ReflectionClass::getConstant</methodname> для
+       Вызов метода <methodname>ReflectionClass::getConstant</methodname> для
        несуществующих констант объявлен устаревшим.
       </entry>
      </row>

--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: mch Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.getconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -40,6 +40,29 @@
    Значение константы с именем <parameter>name</parameter>.
    Возвращает &false; если константа отсутствует в классе.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Вызов <methodname>ReflectionClass::getConstant</methodname> для
+       несуществующих констант объявлен устаревшим.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,6 +50,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Метод объявлен устаревшим, поскольку больше ни на что не влияет.
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Вызов этого метода ни на что не влияет; все методы по умолчанию
+       доступны для вызова.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -49,7 +49,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       Вызов <methodname>ReflectionProperty::getDefaultValue</methodname>
+       Вызов метода <methodname>ReflectionProperty::getDefaultValue</methodname>
        для свойств без значений по умолчанию объявлен устаревшим.
       </entry>
      </row>

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f89eee340331eb13a38a95ea64f47dfe866d46e Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,6 +33,29 @@
    Метод <methodname>ReflectionProperty::hasDefaultValue</methodname>
    умеет определять разницу.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Вызов <methodname>ReflectionProperty::getDefaultValue</methodname>
+       для свойств без значений по умолчанию объявлен устаревшим.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,6 +51,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Метод объявлен устаревшим, поскольку больше ни на что не влияет.
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Вызов этого метода ни на что не влияет; все свойства по умолчанию
+       доступны.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -64,7 +64,7 @@
       <entry>8.5.0</entry>
       <entry>
        Передача функции <function>spl_autoload_call</function> в качестве
-       аргумента-обратного вызова для отмены регистрации всех автозагрузчиков
+       аргумента callback-функции для отмены регистрации всех автозагрузчиков
        объявлена устаревшей. Вместо этого следует пройти по значениям, которые
        возвращает <function>spl_autoload_functions</function>, и вызвать
        <function>spl_autoload_unregister</function> для каждого значения.

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: tmn Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.spl-autoload-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,6 +47,32 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Передача функции <function>spl_autoload_call</function> в качестве
+       аргумента-обратного вызова для отмены регистрации всех автозагрузчиков
+       объявлена устаревшей. Вместо этого следует пройти по значениям, которые
+       возвращает <function>spl_autoload_functions</function>, и вызвать
+       <function>spl_autoload_unregister</function> для каждого значения.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -66,8 +66,8 @@
        Передача функции <function>spl_autoload_call</function> в качестве
        аргумента callback-функции для отмены регистрации всех автозагрузчиков
        объявлена устаревшей. Вместо этого следует пройти по значениям, которые
-       возвращает <function>spl_autoload_functions</function>, и вызвать
-       <function>spl_autoload_unregister</function> для каждого значения.
+       возвращает функция <function>spl_autoload_functions</function>, и вызвать
+       функцию <function>spl_autoload_unregister</function> для каждого значения.
       </entry>
      </row>
     </tbody>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a0d62151102e4bf83e2bb4068782757d20ba086d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -59,6 +59,29 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Метод объявлен устаревшим в пользу
+       <methodname>SplObjectStorage::offsetSet</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,6 +47,29 @@
    Метод возвращает значение &true;, если объект в аргументе <type>object</type> содержится в хранилище,
    иначе возвращает значение &false;.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Метод объявлен устаревшим в пользу
+       <methodname>SplObjectStorage::offsetExists</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Синхронизация с php/doc-en#5369 : добавлены записи changelog 8.5.0 об устаревании для finfo_buffer (context), ReflectionClass::getConstant, ReflectionMethod::setAccessible, ReflectionProperty::getDefaultValue, ReflectionProperty::setAccessible, spl_autoload_unregister, SplObjectStorage::attach и SplObjectStorage::contains.

Fixes #1323