### PR TITLE
Sync EN: ext/pgsql, обновление устаревших требований к версиям PostgreSQL (#5409)

### DIFF
--- a/reference/pgsql/functions/pg-affected-rows.xml
+++ b/reference/pgsql/functions/pg-affected-rows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-affected-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,8 +20,7 @@
    queries.
   </para>
   <para>
-   С версии PostgreSQL 9.0 и новее, сервер возвращает число выбранных рядов для запроса SELECT.
-   Более старые версии возвращают 0 для SELECT.
+   Сервер также возвращает число выбранных рядов для запроса SELECT.
   </para>
   <note>
    <para>

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad618eea48c773ff8768d9d27ea986f81a2a2400 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-client-encoding" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,8 +24,7 @@
   </para>
   <note>
    <para>
-    Для работы функции требуется PostgreSQL версии 7.0
-    или выше. В случае, если libpg скомпилирована без поддержки многобайтовых кодировок,
+    В случае, если libpg скомпилирована без поддержки многобайтовых кодировок,
     <function>pg_client_encoding</function> всегда возвращает <literal>SQL_ASCII</literal>.
     Набор поддерживаемых кодировок зависит от версии сервера БД и описан
     в документации PostgreSQL.

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -21,7 +21,7 @@
   <para>
    <function>pg_lo_create</function> создаёт большой объект
    и возвращает его <varname>OID</varname>. Режимы доступа
-   PostgreSQL <constant>INV_READ</constant> и <constant>INV_WRITE</constant>
+   Константы PostgreSQL <constant>INV_READ</constant> и <constant>INV_WRITE</constant>
    не поддерживаются, объект всегда создаётся с доступом на чтение и запись.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-lo-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,10 +21,8 @@
   <para>
    <function>pg_lo_create</function> создаёт большой объект
    и возвращает его <varname>OID</varname>. Режимы доступа
-   PostgreSQL <constant>INV_READ</constant>, <constant>INV_WRITE</constant>,
-   и <constant>INV_ARCHIVE</constant> не поддерживаются, объект всегда
-   создаётся с доступом на чтение и запись. Режим <constant>INV_ARCHIVE</constant>
-   убран из PostgreSQL версий 6.3 и выше.
+   PostgreSQL <constant>INV_READ</constant> и <constant>INV_WRITE</constant>
+   не поддерживаются, объект всегда создаётся с доступом на чтение и запись.
   </para>
   <para>
    Операции с использованием интерфейса больших объектов
@@ -60,8 +58,7 @@
        Если задан аргумент <parameter>object_id</parameter>, функция
        попытается создать объект с этим идентификатором, в противном
        случае будет использован свободный идентификатор, назначенный
-       сервером. Этот аргумент основан на функционале,
-       впервые реализованном в PostgreSQL 8.1.
+       сервером.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-query-params" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,9 +24,7 @@
   <para>
    <function>pg_query_params</function> подобна функции <function>pg_query</function>,
    но предоставляет дополнительный функционал: параметры запроса можно передавать
-   отдельно от строки запроса. <function>pg_query_params</function> поддерживается
-   на соединениях с серверами PostgreSQL версий 7.4 и выше. Функция не будет работать
-   с серверами ранних версий.
+   отдельно от строки запроса.
   </para>
   <para>
    Если используются параметры <parameter>params</parameter>, они заменяют

--- a/reference/pgsql/functions/pg-result-error-field.xml
+++ b/reference/pgsql/functions/pg-result-error-field.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-result-error-field" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,8 +19,7 @@
   <para>
    <function>pg_result_error_field</function> возвращает одно из полей
    отчёта об ошибках, связанного с экземпляром <parameter>result</parameter>.
-   Функция поддерживается серверами PostgreSQL версий 7.4 и выше. Нужное
-   поле задаётся аргументом <parameter>field_code</parameter>.
+   Нужное поле задаётся аргументом <parameter>field_code</parameter>.
   </para>
   <para>
    Функции <function>pg_query</function> и <function>pg_query_params</function>
@@ -58,10 +57,8 @@
          <constant>PGSQL_DIAG_MESSAGE_DETAIL</constant>,
          <constant>PGSQL_DIAG_MESSAGE_HINT</constant>,
          <constant>PGSQL_DIAG_STATEMENT_POSITION</constant>,
-         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant>
-         (для версий PostgreSQL 8.0 и выше),
-         <constant>PGSQL_DIAG_INTERNAL_QUERY</constant>
-         (для версий PostgreSQL 8.0 и выше),
+         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant>,
+         <constant>PGSQL_DIAG_INTERNAL_QUERY</constant>,
          <constant>PGSQL_DIAG_CONTEXT</constant>,
          <constant>PGSQL_DIAG_SOURCE_FILE</constant>,
          <constant>PGSQL_DIAG_SOURCE_LINE</constant>,

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 58645a79f1993effc0571f7b49acc9aace0e417f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-unescape-bytea" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -26,16 +26,6 @@
     PostgreSQL возвращает значения в восьмеричной системе счисления с префиксом
     '\' (такие как \032). Пользователю необходимо вручную преобразовывать их
     в двоичный формат.
-   </para>
-   <para>
-    Функция поддерживается PostgreSQL версии 7.2 и выше. Для версий
-    7.2.0 и 7.2.1 значения должны быть преобразованы к типу bytea,
-    когда включена мультибайтовая поддержка. Тогда как
-    <literal>INSERT INTO test_table (image)VALUES ('$image_escaped'::bytea);</literal>
-    в PostgreSQL 7.2.2 и выше не требует каких-либо преобразований.
-    Исключение составляет случай, когда клиентская (frontend) кодировка не соответствует
-    серверной (backend). При этом возникает ошибка мультибайтового потока, и пользователь
-    должен привести данные к типу bytea, чтобы её избежать.
    </para>
   </note>
  </refsect1>

--- a/reference/pgsql/functions/pg-version.xml
+++ b/reference/pgsql/functions/pg-version.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-version" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,7 @@
   </methodsynopsis>
   <para>
    <function>pg_version</function> возвращает массив, содержащий версии
-   клиента, протокола клиент-серверного взаимодействия и сервера. Версии
-   протокола и сервера доступны, только если модуль PHP скомпилирован
-   для PostgreSQL версии 7.4 или выше.
+   клиента, протокола клиент-серверного взаимодействия и сервера.
   </para>
   <para>
    Для получения детальной информации о сервере используйте

--- a/reference/pgsql/reference.xml
+++ b/reference/pgsql/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3ba581880a9e5635109c65cef01a7ca192999ad1 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="ref.pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>&Functions; PostgreSQL</title>
@@ -35,8 +35,8 @@
    <note>
     <para>
      В PostgreSQL нет специальных команд для получения информации о схеме БД
-     (к примеру, всех таблиц выбранной базы данных). Но вместо этого в версиях
-     PostgreSQL 7.4 и выше существует стандартная схема, которая называется
+     (к примеру, всех таблиц выбранной базы данных). Но вместо этого
+     существует стандартная схема, которая называется
      <literal>information_schema</literal>. Она содержит системные представления
      (view) со всей необходимой информацией в легкодоступной форме. Для
      дополнительной информации смотрите <link xlink:href="&url.pgsql.manual;">документацию PostgreSQL</link>

--- a/reference/pgsql/setup.xml
+++ b/reference/pgsql/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="pgsql.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -9,9 +9,11 @@
  <section xml:id="pgsql.requirements">
   &reftitle.required;
   <para>
-   Для использования PostgreSQL в PHP, у вас должен
-   быть установлен PostgreSQL версии 6.5 или выше, либо PostgreSQL версии 8.0
-   для использования всех особенностей модуля PostgreSQL. В PostgreSQL есть
+   Для использования поддержки PostgreSQL в PHP необходима библиотека libpq
+   (клиентская библиотека PostgreSQL на языке C).
+   Начиная с PHP 8.0.0 требуется libpq 9.1 или новее.
+   Начиная с PHP 8.4.0 требуется libpq 10.0 или новее.
+   В PostgreSQL есть
    поддержка различных кодировок символов, включая многобайтовую кодировку.
    Последняя версия и полная информация о PostgreSQL доступна на
    <link xlink:href="&url.pgsql;">&url.pgsql;</link> и в


### PR DESCRIPTION
Синхронизация с php/doc-en#5409 : убраны устаревшие упоминания минимальных версий PostgreSQL (7.x/8.x/9.0); в setup.xml требования переписаны в терминах libpq (9.1 с PHP 8.0.0, 10.0 с PHP 8.4.0).

Fixes #1205