### PR TITLE
Sync EN: изменения CLI SAPI в PHP 8.5 (#5077)

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Работа с PHP из командной строки</title>
@@ -366,7 +366,6 @@ Usage: php [options] [-f] <file> [--] [args...]
   -s               Output HTML syntax highlighted source.
   -v               Version number
   -w               Output source with stripped comments and whitespace.
-  -z <file>        Load Zend extension <file>.
 
   args...          Arguments passed to script. Use -- args when first argument
                    starts with - or script is read from stdin
@@ -839,26 +838,14 @@ Zend Engine v2.3.0, Copyright (c) 1998-2009 Zend Technologies
        </entry>
       </row>
       <row>
-       <entry>-z</entry>
-       <entry>--zend-extension</entry>
-       <entry>
-        <para>
-         Загружает модуль Zend. PHP попытается загрузить модуль из текущего пути библиотеки
-         по умолчанию в системе, который в Linux-системах обычно указывают
-         в файле <filename>/etc/ld.so.conf</filename>, если передали только название файла.
-         Передача файла с абсолютным путём не будет использовать
-         системный путь поиска библиотеки. Относительное имя файла, которое содержит
-         директорию, заставит PHP загрузить модуль относительно
-         текущей директории.
-        </para>
-       </entry>
-      </row>
-      <row>
        <entry></entry>
        <entry>--ini</entry>
        <entry>
         <para>
          Показывает имена файлов конфигурации и просканированные каталоги.
+         Дополнительно можно передать <literal>--ini=diff</literal>, чтобы
+         показать различия между загруженными файлами конфигурации
+         и конфигурацией по умолчанию.
          <example>
           <title>Пример <literal>--ini</literal></title>
           <programlisting role="shell">
@@ -871,6 +858,11 @@ Additional .ini files parsed:      (none)
 ]]>
           </programlisting>
          </example>
+         <note>
+          <simpara>
+           Опция <literal>--ini=diff</literal> недоступна до PHP 8.5.0.
+          </simpara>
+         </note>
         </para>
        </entry>
       </row>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a331ac8a86bb5929b79be9a369fac1e3af516241 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-get-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,11 +14,11 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Устанавливает заголовок процесса, видимое утилитами <command>top</command> и
    <command>ps</command>. Эта функция доступна только в режиме
    <link linkend="features.commandline">CLI</link>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Новое имя.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,26 +38,47 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-
-  <para>
+  <simpara>
    Если команда не поддерживается вашей операционной системой, то будет
    вызвана ошибка уровня <constant>E_WARNING</constant>.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>cli_set_process_title</function> теперь выдаёт ошибку уровня
+       <constant>E_WARNING</constant> при установке слишком длинного заголовка
+       процесса; раньше заголовок усекался.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Пример использования <function>cli_set_process_title</function></title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "Мой потрясающий PHP-скрипт";
@@ -72,18 +93,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -65,7 +65,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       <function>cli_set_process_title</function> теперь выдаёт ошибку уровня
+       Функция <function>cli_set_process_title</function> теперь выдаёт ошибку уровня
        <constant>E_WARNING</constant> при установке слишком длинного заголовка
        процесса; раньше заголовок усекался.
       </entry>


### PR DESCRIPTION
Синхронизация с php/doc-en#5077 : убрана опция -z/--zend-extension, добавлено описание --ini=diff (с PHP 8.5.0), запись changelog 8.5.0 для cli_set_process_title (E_WARNING при слишком длинном заголовке), para -> simpara.

Fixes #1324