### PR TITLE
Sync EN: LiteSpeed SAPI в документации Apache-функций и миграции 7.4 (#4922)

### DIFF
--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 90242f8793566eb87ee35a989912310a7c7c132b Maintainer: lex Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Другие изменения</title>
@@ -191,7 +191,7 @@
    </listitem>
 
    <listitem>
-    <simpara>Litespeed:</simpara>
+    <simpara>LiteSpeed:</simpara>
     <itemizedlist>
      <listitem>
       <simpara>

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 
 <book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -9,9 +9,11 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.apache">
   &reftitle.intro;
-  <para>
-   Доступ к этим функциям открывается, только если PHP работает как модуль веб-сервера Apache.
-  </para>
+  <simpara>
+   Эти функции доступны, когда PHP работает как модуль веб-сервера Apache.
+   Некоторые функции могут быть доступны при работе под другими API
+   веб-серверов. Подробности смотрите в документации каждой функции.
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.apache-request-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <type>array</type><methodname>apache_request_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция получает список HTTP-заголовков текущего запроса.
-   Функция работает на веб-серверах Apache, FastCGI, CLI и FPM.
-  </para>
+   Функция работает на веб-серверах Apache, LiteSpeed, FastCGI, CLI и FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает ассоциативный массив с HTTP-заголовками текущего запроса.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -91,14 +91,14 @@ Connection: Keep-Alive
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Пользователям также доступны значения общих
     <acronym>CGI</acronym>-переменных, которые считывают из окружения сервера;
     это работает независимо от того, установили ли PHP как модуль
     веб-сервера <productname>Apache</productname> или нет. Список доступных
     <link linkend="language.variables.predefined">переменных окружения</link>
     получают функцией <function>phpinfo</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.apache-response-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция получает список HTTP-заголовков ответа.
-   Функция работает на веб-серверах Apache, FastCGI, CLI и FPM.
-  </para>
+   Функция работает на веб-серверах Apache, LiteSpeed, FastCGI, CLI и FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    В случае успешного выполнения функция возвращает массив с HTTP-заголовками ответа веб-сервера Apache.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Синхронизация с php/doc-en#4922 (часть, портируемая на RU) : apache_request_headers/apache_response_headers теперь упоминают LiteSpeed, обновлено описание в book.xml, исправлено написание LiteSpeed в migration74, para -> simpara. Новые файлы расширения litespeed (book/функции/setup) и appendices/extensions.xml не входят в эту синхронизацию.

Fixes #1328