### PR TITLE
Sync EN: settype, ValueError при недопустимом типе с PHP 8.0 (#5382)

### DIFF
--- a/reference/var/functions/settype.xml
+++ b/reference/var/functions/settype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8d49e302b4 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8d49e302b484f0e5c237dd16ca1afef3b7515f46 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.settype" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/var/functions/settype.xml
+++ b/reference/var/functions/settype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8d49e302b4 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.settype" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -85,6 +85,41 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Начиная с PHP 8.0.0 выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+   если значение параметра <parameter>type</parameter> не является допустимым типом.
+   До PHP 8.0.0 выдавалась ошибка уровня <constant>E_WARNING</constant>
+   и возвращалось значение &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Теперь выбрасывает исключение <exceptionname>ValueError</exceptionname>,
+       когда в параметр <parameter>type</parameter> передан недопустимый тип.
+       Раньше выдавалась ошибка уровня <constant>E_WARNING</constant>
+       и функция возвращала &false;.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Синхронизация с php/doc-en#5382 : добавлены секции errors и changelog: с PHP 8.0.0 <function>settype</function> выбрасывает <exceptionname>ValueError</exceptionname> при недопустимом типе (раньше E_WARNING и возврат &false;).

Fixes #1175