### PR TITLE
Sync EN: stream_filter_append/prepend, имена параметров filter_name и mode (#5356)

### DIFF
--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: mch Status: ready -->
+<!-- EN-Revision: a684294e0b7ce0c18e2212b002b442b6ceba321d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-filter-append" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -11,12 +11,12 @@
   <methodsynopsis>
    <type>resource</type><methodname>stream_filter_append</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filtername</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>read_write</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filter_name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Функция добавляет фильтр <parameter>filtername</parameter> в список фильтров,
+   Функция добавляет фильтр <parameter>filter_name</parameter> в список фильтров,
    прикреплённых к потоку <parameter>stream</parameter>.
   </para>
  </refsect1>
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>filtername</parameter></term>
+     <term><parameter>filter_name</parameter></term>
      <listitem>
       <para>
        Название фильтра.
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>read_write</parameter></term>
+     <term><parameter>mode</parameter></term>
      <listitem>
       <para>
        По умолчанию <function>stream_filter_append</function> будет
@@ -55,7 +55,7 @@
        Константы <constant>STREAM_FILTER_READ</constant>,
        <constant>STREAM_FILTER_WRITE</constant> и (или)
        <constant>STREAM_FILTER_ALL</constant> также разрешается передавать в параметр
-       <parameter>read_write</parameter>, чтобы переопределить это поведение.
+       <parameter>mode</parameter>, чтобы переопределить это поведение.
       </para>
      </listitem>
     </varlistentry>
@@ -85,7 +85,7 @@
 
   <para>
    Функция вернёт &false;, если поток <parameter>stream</parameter> — не ресурс или если
-   функция не нашла фильтр <parameter>filtername</parameter>.
+   функция не нашла фильтр <parameter>filter_name</parameter>.
   </para>
  </refsect1>
 
@@ -142,7 +142,7 @@ Guvf vf n grfg
    <title>Передача пользовательских фильтров</title>
    <simpara>
     Сначала требуется вызвать функцию <function>stream_filter_register</function>,
-    чтобы зарегистрировать необходимый пользовательский фильтр для параметра <parameter>filtername</parameter>.
+    чтобы зарегистрировать необходимый пользовательский фильтр для параметра <parameter>filter_name</parameter>.
    </simpara>
   </note>
   <note>

--- a/reference/stream/functions/stream-filter-prepend.xml
+++ b/reference/stream/functions/stream-filter-prepend.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: mch Status: ready -->
+<!-- EN-Revision: a684294e0b7ce0c18e2212b002b442b6ceba321d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-filter-prepend" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -11,12 +11,12 @@
   <methodsynopsis>
    <type>resource</type><methodname>stream_filter_prepend</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filtername</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>read_write</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filter_name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Добавляет <parameter>filtername</parameter> к списку фильтров,
+   Добавляет <parameter>filter_name</parameter> к списку фильтров,
    прикреплённых к потоку <parameter>stream</parameter>.
   </para>
  </refsect1>
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>filtername</parameter></term>
+     <term><parameter>filter_name</parameter></term>
      <listitem>
       <para>
        Название потока.
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>read_write</parameter></term>
+     <term><parameter>mode</parameter></term>
      <listitem>
       <para>
        По умолчанию, функция <function>stream_filter_prepend</function> будет
@@ -55,7 +55,7 @@
        Константы <constant>STREAM_FILTER_READ</constant>,
        <constant>STREAM_FILTER_WRITE</constant> и/или
        <constant>STREAM_FILTER_ALL</constant> также могут быть переданы в параметре
-       <parameter>read_write</parameter>, чтобы переопределить это поведение.
+       <parameter>mode</parameter>, чтобы переопределить это поведение.
        Смотрите функцию <function>stream_filter_append</function> для примера
        использования этого параметра.
       </para>
@@ -86,7 +86,7 @@
 
   <para>
    Вернёт &false;, если <parameter>stream</parameter> не является ресурсом или если
-   <parameter>filtername</parameter> не найден.
+   <parameter>filter_name</parameter> не найден.
   </para>
  </refsect1>
 
@@ -96,7 +96,7 @@
    <title>При использовании пользовательских фильтров</title>
    <simpara>
     Сначала должна быть вызвана функция <function>stream_filter_register</function>
-    для того, чтобы зарегистрировать желаемый пользовательский фильтр на имя <parameter>filtername</parameter>.
+    для того, чтобы зарегистрировать желаемый пользовательский фильтр на имя <parameter>filter_name</parameter>.
    </simpara>
   </note>
   <note>


### PR DESCRIPTION
Синхронизация с php/doc-en#5356 : имена параметров приведены в соответствие с php-src: <parameter>filtername</parameter> -> <parameter>filter_name</parameter>, <parameter>read_write</parameter> -> <parameter>mode</parameter>.

Fixes #1174