### PR TITLE
Sync EN: страница HTTP Basic-аутентификации, удаление устаревшего содержимого (#5383)

### DIFF
--- a/features/http-auth.xml
+++ b/features/http-auth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bdf9a4e40204c805f2c2a5c94c2f2f8f5556195a Maintainer: shein Status: ready -->
+<!-- EN-Revision: cd4180557a185469a64a7eb26f7be98d0a5f1ebb Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="features.http-auth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>HTTP-аутентификация в PHP</title>
@@ -32,8 +32,8 @@
 <?php
 
 if (!isset($_SERVER['PHP_AUTH_USER'])) {
+    header('HTTP/1.1 401 Unauthorized');
     header('WWW-Authenticate: Basic realm="My Realm"');
-    header('HTTP/1.0 401 Unauthorized');
 
     echo 'Текст, который скрипт отправит,
     если пользователь нажмёт кнопку «Отмена»';
@@ -50,12 +50,12 @@ if (!isset($_SERVER['PHP_AUTH_USER'])) {
   </para>
 
   <note>
-   <title>Примечание о совместимости</title>
+   <title>Совместимость</title>
    <para>
     При определении HTTP-заголовков соблюдают осторожность. Слово "Basic"
     требуется писать с заглавной буквы "B", значение для ключа realm берут
     в двойные, но не одинарные кавычки, а перед кодом <emphasis>401</emphasis>
-    в строке заголовка <emphasis>HTTP/1.0 401</emphasis>
+    в строке заголовка <emphasis>HTTP/1.1 401</emphasis>
     указывают ровно один пробел, чтобы гарантировать максимальную совместимость
     с клиентами. Параметры аутентификации разделяют запятыми.
    </para>
@@ -68,15 +68,8 @@ if (!isset($_SERVER['PHP_AUTH_USER'])) {
    или через поиск пользователя в dbm-файле.
   </para>
 
-  <para>
-   Остерегайтесь браузеров Internet Explorer, которые часто работают с ошибками.
-   Эти браузеры требовательны к порядку заголовков. Трюк с указанием
-   заголовка <emphasis>WWW-Authenticate</emphasis> перед отправкой статуса
-   <literal>HTTP/1.0 401</literal>, похоже, пока помогает.
-  </para>
-
   <note>
-   <title>Примечание о конфигурации</title>
+   <title>Настройка Apache</title>
    <para>
     PHP использует директиву <literal>AuthType</literal>, чтобы определить,
     действует ли внешняя аутентификация.
@@ -88,73 +81,34 @@ if (!isset($_SERVER['PHP_AUTH_USER'])) {
    кто контролирует неаутентифицированный URL-адрес,
    воровать пароли от аутентифицированных URL-адресов на том же сервере.
   </simpara>
-  <simpara>
-   Браузеры Netscape Navigator и Internet Explorer очистят кеш аутентификации
-   текущего окна для заданного региона (realm) при получении от сервера статуса 401.
-   Это может отменить авторизацию пользователя и заставит его
-   повторно вводить имя пользователя и
-   пароль. Иногда разработчики используют это для ограничения авторизации
-   по времени ожидания или для предоставления кнопки «Выход».
-  </simpara>
-  <para>
-   <example>
-    <title>Пример HTTP-аутентификации с принудительным вводом новой пары логин-пароль</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-function authenticate()
-{
-    header('WWW-Authenticate: Basic realm="Test Authentication System"');
-    header('HTTP/1.0 401 Unauthorized');
-
-    echo "Вы должны ввести корректный логин и пароль для получения доступа к ресурсу \n";
-
-    exit;
-}
-
-if (
-    !isset($_SERVER['PHP_AUTH_USER'])
-    || ($_POST['SeenBefore'] == 1 && $_POST['OldAuth'] == $_SERVER['PHP_AUTH_USER'])
-) {
-    authenticate();
-} else {
-    echo "<p>Добро пожаловать: " . htmlspecialchars($_SERVER['PHP_AUTH_USER']) . "<br />";
-    echo "Предыдущий логин: " . htmlspecialchars($_REQUEST['OldAuth']);
-    echo "<form action='' method='post'>\n";
-    echo "<input type='hidden' name='SeenBefore' value='1' />\n";
-    echo "<input type='hidden' name='OldAuth' value=\"" . htmlspecialchars($_SERVER['PHP_AUTH_USER']) . "\" />\n";
-    echo "<input type='submit' value='Авторизоваться повторно' />\n";
-    echo "</form></p>\n";
-}
-
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
-  <simpara>
-   Стандарт базовой аутентификации по протоколу HTTP <literal>HTTP Basic</literal> не требует такого поведения,
-   поэтому разработчик не должен зависеть от этого. Тестирование браузера <literal>Lynx</literal>
-   показало, что <literal>Lynx</literal> не очищает учётные данные аутентификации при ответе сервера
-   кодом 401, поэтому последовательное нажатие кнопок «Назад» и «Вперёд» откроет ресурс,
-   если требования к учётным данным не изменились.
-   Однако пользователь может нажать клавишу <literal>'_'</literal> для очистки кеша аутентификации.
-  </simpara>
-  <simpara>
-   Чтобы добиться корректной работы HTTP-аутентификации на IIS-сервере
-   с CGI-версией PHP, требуется отредактировать
-   опцию конфигурации IIS-сервера "<literal>Directory Security</literal>".
-   Щёлкните «<literal>Изменить</literal>» и поставьте галочку только в поле
-   «<literal>Анонимный доступ</literal>»,
-   остальные поля остаются неотмеченными.
-  </simpara>
   <note>
-   <title>Примечание по теме аутентификации на IIS-севере:</title>
+   <title>Поведение браузеров</title>
    <simpara>
-    Чтобы HTTP-аутентификация корректно работала на IIS-сервере, для PHP-директивы
-    <link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link> требуется установить
-    значение <literal>0</literal> (значение по умолчанию).
+    Basic-аутентификация по HTTP действительно простая (basic) и не была рассчитана
+    на поддержку выхода из системы. Поскольку HTTP — это протокол без сохранения
+    состояния, большинство браузеров кешируют переданные учётные данные сразу же,
+    как только получат код состояния <literal>2xx</literal>, и отправляют их
+    в каждом запросе, пока браузер не закроют. Определённого способа, которым сервер
+    мог бы запросить повторный ввод учётных данных, не существует.
+
+    За прошедшие годы в интернете в качестве советов разошлись разные обходные
+    приёмы, но все они зависят от того, как разные браузеры решили обрабатывать
+    неопределённые крайние случаи (или даже нарушения стандарта HTTP). Лучше
+    избегать таких приёмов и не использовать Basic-аутентификацию для чего-либо
+    серьёзного.
+   </simpara>
+  </note>
+
+  <note>
+   <title>Настройка IIS</title>
+   <simpara>
+    Чтобы HTTP-аутентификация работала на IIS-сервере с CGI-версией PHP, для
+    php.ini-директивы <link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link>
+    требуется установить значение <literal>0</literal> (значение по умолчанию),
+    а также отредактировать опцию конфигурации IIS-сервера
+    "<literal>Directory Security</literal>". Щёлкните «<literal>Изменить</literal>»
+    и поставьте галочку только в поле «<literal>Анонимный доступ</literal>»,
+    остальные поля остаются неотмеченными.
    </simpara>
   </note>
 


### PR DESCRIPTION
Синхронизация с php/doc-en#5383 : убраны устаревшие сведения про старые IE/Netscape и пример принудительной повторной аутентификации; порядок заголовков и текст приведены к HTTP/1.1; добавлены примечания «Поведение браузеров» и «Настройка IIS».

Fixes #1172