### PR TITLE
[Sync EN] ldap: document ldap_exop_sync and deprecate 4+ params for ldap_exop (PHP 8.4)

### DIFF
--- a/reference/ldap/functions/ldap-exop-sync.xml
+++ b/reference/ldap/functions/ldap-exop-sync.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: db22a7cfcbc3af221f67e228336ac3e2d62aaf2c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-exop-sync" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,84 +18,95 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>
+   Выполняет расширенную операцию для заданного соединения <parameter>ldap</parameter> с
+   <acronym>OID</acronym> операции <parameter>request_oid</parameter> и данными
+   <parameter>request_data</parameter>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>ldap</parameter></term>
-     <listitem>
-      <para>
-       &ldap.parameter.ldap;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>controls</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <simpara>
+      &ldap.parameter.ldap;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_oid</parameter></term>
+    <listitem>
+     <simpara>
+      <acronym>OID</acronym> запроса расширенной операции.
+      Может быть одной из констант
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>
+      или строкой с <acronym>OID</acronym> операции.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_data</parameter></term>
+    <listitem>
+     <simpara>
+      Данные запроса расширенной операции.
+      Может быть &null; для некоторых операций, например <constant>LDAP_EXOP_WHO_AM_I</constant>;
+      также может потребоваться кодирование в <acronym>BER</acronym>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <simpara>
+      Массив <link linkend="ldap.controls">управляющих объектов протокола LDAP</link> для отправки в запросе.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_data</parameter></term>
+    <listitem>
+     <simpara>
+      Функция заполнит параметр данными расширенного ответа на операцию,
+      если параметр задали. Если параметр не задали, получить данные
+      можно вызовом на результирующем объекте функции <function>ldap_parse_exop</function> позже.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Функция заполнит параметр значением идентификатора <acronym>OID</acronym> ответа,
+      который обычно совпадает с <acronym>OID</acronym> запроса, если параметр задали.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Функция возвращает &true; или &false;, если функцию вызвали
+   с параметром <parameter>response_data</parameter>. Функция возвращает
+   идентификатор ресурса или &false;, если функцию вызвали без параметра
+   <parameter>response_data</parameter>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_exop</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b37727abaf0e731a05c516fd85b44e86f4bf5c75 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: yes Maintainer: sergey -->
 <refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -18,11 +18,17 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Выполняет расширенную операцию для заданного соединения <parameter>ldap</parameter> с OID
+  <simpara>
+   Выполняет расширенную операцию для заданного соединения <parameter>ldap</parameter> с <acronym>OID</acronym>
    операции <parameter>request_oid</parameter> и данными
    <parameter>request_data</parameter>.
-  </para>
+  </simpara>
+  <warning>
+   <simpara>
+    Использование более 4 параметров объявлено устаревшим,
+    используйте вместо этого <function>ldap_exop_sync</function>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -31,53 +37,56 @@
    <varlistentry>
     <term><parameter>ldap</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       &ldap.parameter.ldap;
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_oid</parameter></term>
     <listitem>
-     <para>
-      Идентификатор расширенной операции OID. Можно использовать одну из констант <constant>LDAP_EXOP_START_TLS</constant>, <constant>LDAP_EXOP_MODIFY_PASSWD</constant>, <constant>LDAP_EXOP_REFRESH</constant>, <constant>LDAP_EXOP_WHO_AM_I</constant>, <constant>LDAP_EXOP_TURN</constant> или строку с OID необходимой операции.
-     </para>
+     <simpara>
+      <acronym>OID</acronym> запроса расширенной операции.
+      Может быть одной из констант
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>
+      или строкой с <acronym>OID</acronym> операции.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Данные для запроса расширенной операции. Может быть &null; для операций типа
-      <constant>LDAP_EXOP_WHO_AM_I</constant>. Может потребоваться закодировать BER.
-     </para>
+      <constant>LDAP_EXOP_WHO_AM_I</constant>. Может потребоваться закодировать <acronym>BER</acronym>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>controls</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Массив <link linkend="ldap.controls">управляющих объектов протокола LDAP</link> для отправки в запросе.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>response_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Функция заполнит параметр данными расширенного ответа на операцию,
       если параметр задали. Если параметр не задали, получить данные
-      можно вызовом на результирующем объекте функции ldap_parse_exop позже.
-     </para>
+      можно вызовом на результирующем объекте функции <function>ldap_parse_exop</function> позже.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>retoid</parameter></term>
+    <term><parameter>response_oid</parameter></term>
     <listitem>
-     <para>
-      Функция заполнит параметр значением идентификатора OID ответа,
-      который обычно совпадает с OID запроса, если параметр задали.
-     </para>
+     <simpara>
+      Функция заполнит параметр значением идентификатора <acronym>OID</acronym> ответа,
+      который обычно совпадает с <acronym>OID</acronym> запроса, если параметр задали.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -85,43 +94,47 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает &true; или &false;, если функцию вызвали
    с параметром <parameter>response_data</parameter>. Функция возвращает
    идентификатор ресурса или &false;, если функцию вызвали без параметра
    <parameter>response_data</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &ldap.changelog.ldap-object;
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        Добавлена поддержка параметра <parameter>controls</parameter>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Использование более 4 параметров объявлено устаревшим,
+       используйте вместо этого <function>ldap_exop_sync</function>.
+      </entry>
+     </row>
+     &ldap.changelog.ldap-object;
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Добавлена поддержка параметра <parameter>controls</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
+  <example>
     <title>Расширенная операция Whoami</title>
     <programlisting role="php">
 <![CDATA[
@@ -160,20 +173,18 @@ if ($ds) {
 ]]>
     </programlisting>
    </example>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_parse_result</function></member>
-    <member><function>ldap_parse_exop</function></member>
-    <member><function>ldap_exop_whoami</function></member>
-    <member><function>ldap_exop_refresh</function></member>
-    <member><function>ldap_exop_passwd</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop_sync</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
php/doc-en#4066

Fixes #1367