### PR TITLE
[Sync EN] intl: getBestPattern returns an ICU date/time pattern for IntlDateFormatter

### DIFF
--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 5b6663923676dd3f48bdc916a6a2de651fd959b2 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intldatepatterngenerator.getbestpattern" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Возвращает формат, принимаемый <methodname>DateTimeInterface::format</methodname> в случае успешного выполнения,&return.falseforfailure;.
-  </para>
+  <simpara>
+   Возвращает шаблон даты/времени ICU, принимаемый <classname>IntlDateFormatter</classname> в случае успешного выполнения,&return.falseforfailure;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
php/doc-en#5567

Fixes #1366