### PR TITLE
[Sync EN] Fix copy-pasted descriptions referencing the wrong function

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-cache-info">
  <refnamediv>
@@ -43,7 +43,7 @@
   <note>
    <simpara>
     <function>apcu_cache_info</function> вызывает предупреждение, если
-    невозможно получить данные кеша APC. Обычно это происходит, если APC не разрешён.
+    невозможно получить данные кеша APCu. Обычно это происходит, если APCu не разрешён.
    </simpara>
   </note>
  </refsect1>

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-key-info">
  <refnamediv>
@@ -27,7 +27,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      Получить детальную информацию о ключе в кеше
+      Ключ, для которого требуется получить информацию.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-lob2-import">
  <refnamediv>
@@ -18,7 +18,7 @@
    Функция <function>cubrid_lob2_import</function> используется для сохранения содержимого
    данных BLOB/CLOB из файла. Чтобы использовать эту функцию, необходимо использовать
    <function>cubrid_lob2_new</function> или сначала получить LOB-объект из базы данных CUBRID.
-   Если файл уже существует, операция завершится ошибкой.
+   Если файл не существует, операция завершится ошибкой.
    Функция не будет влиять на положение курсора LOB-объекта.
    Она управляет всем LOB-объектом.
   </simpara>

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-pconnect">
  <refnamediv>
@@ -75,7 +75,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <function>cubrid_connect</function></title>
+   <title>Пример использования <function>cubrid_pconnect</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-seq-insert">
  <refnamediv>
@@ -18,7 +18,7 @@
    <methodparam><type>string</type><parameter>seq_element</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Функция <function>cubrid_col_insert</function> используется для вставки
+   Функция <function>cubrid_seq_insert</function> используется для вставки
    элемента в атрибут типа последовательности в запрошенном месте.
   </simpara>
  </refsect1>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
   <refname>eio_chown</refname>
-  <refpurpose>Изменяет права доступа к файлу/директории</refpurpose>
+  <refpurpose>Изменяет владельца файла/директории</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -19,7 +19,9 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Изменяет права доступа к файлу/директории.
+   Функция <function>eio_chown</function> изменяет владельца файла или директории.
+   Новый владелец задаётся параметром <parameter>uid</parameter>, а группа — параметром
+   <parameter>gid</parameter>.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fchown">
  <refnamediv>
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_chmod</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
+   <function>eio_fchown</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fstat">
  <refnamediv>
@@ -60,14 +60,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
+   <function>eio_fstat</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <function>eio_lstat</function></title>
+   <title>Пример использования <function>eio_fstat</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-nready">
  <refnamediv>
@@ -36,7 +36,6 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>eio_nreqs</function></member>
-   <member><function>eio_nready</function></member>
    <member><function>eio_nthreads</function></member>
   </simplelist>
  </refsect1>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-truncate">
  <refnamediv>
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
+   <function>eio_truncate</function> возвращает указатель на запрос в случае успешного выполнения&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
  <refnamediv>

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
  <refnamediv>
   <refname>EvChild::createStopped</refname>
-  <refpurpose>Создаёт остановленный экземпляр наблюдателя EvCheck</refpurpose>
+  <refpurpose>Создаёт остановленный экземпляр наблюдателя EvChild</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.construct">
  <refnamediv>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.event" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Класс Event</title>
@@ -174,11 +174,11 @@
       <constant>Event::WRITE</constant>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Флаг указывает событие, которое становится
        активным, когда предоставленный файл — часто
        потоковый ресурс или сокет — готов к записи.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="event.constants.signal">

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5d7cfa894ddb7d30f5b63ef272f33e80e1c63f3 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventhttprequest.getbufferevent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <type>EventBufferEvent</type>
-   <methodname>EventHttpRequest::closeConnection</methodname>
+   <methodname>EventHttpRequest::getBufferEvent</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-activation-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -58,10 +58,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Константа <link linkend="constants.fann-train">функций обучения</link> или -1,
+  <simpara>
+   Константа <link linkend="constants.fann-activation-funcs">функций активации</link> или -1,
    если нейрон не определён в нейронной сети или &false; в случае возникновения ошибки.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be295015d068095fc92880baef4e47038646adbd Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="zmqdevice.settimercallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -32,22 +32,22 @@
    <varlistentry>
     <term><parameter>cb_func</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Callback-функция для запуска по таймеру.
       Возврат &false; или значения, которое приводится к &false; приведёт
       к остановке устройства.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timeout</parameter></term>
     <listitem>
-     <para>
-      Время ожидания в миллисекундах. Callback-функция будет
-      вызываться через заданные промежутки времени.
-      Гарантирует, что между запусками функции будет происходить
-      не менее заданного количества миллисекунд.
-     </para>
+     <simpara>
+      Как часто вызывать callback-функцию таймера, в миллисекундах.
+      Callback-функция таймера вызывается периодически.
+      Значение <parameter>timeout</parameter> гарантирует, что между запусками
+      функции будет происходить не менее заданного количества миллисекунд.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
Sync de 18 fichiers avec la PR upstream doc-en qui corrige des descriptions copiées-collées pointant vers la mauvaise fonction (refpurpose, exemples, titres, valeurs de retour, etc.).

Fixes #1382