### PR TITLE
[Sync EN] Fix spelling typos in ps-hyphenate

### DIFF
--- a/reference/ps/functions/ps-hyphenate.xml
+++ b/reference/ps/functions/ps-hyphenate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: evvc Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: evvc Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ps-hyphenate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,12 +42,12 @@
     <varlistentry>
      <term><parameter>text</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Параметр <parameter>text</parameter> не должен содержать символов, которые отличаются от букв.
        Возможные позиции для переносов возвращаются в виде массива целых чисел.
        Каждое число — позиция символа в значении <parameter>text</parameter>,
        после которой может быть выполнен перенос.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Sync de `reference/ps/functions/ps-hyphenate.xml` avec la PR upstream doc-en (le fichier n'avait pas été couvert par le sync précédent). Conversion `<para>` → `<simpara>` en miroir EN.

Refs #1391