### PR TITLE
[Sync EN] eio/constants.xml: add dots at the ends of sentences

### DIFF
--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 2132501990f8e139a75021165634830f1f6a90e1 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
  &reftitle.constants;


### PR DESCRIPTION
Sync de `reference/eio/constants.xml` avec la PR upstream doc-en (ajout de points en fin de phrase et corrections cosmétiques d'indentation).

La traduction russe contenait déjà les points en fin de phrase, donc seul un bump du hash est nécessaire pour refléter la synchronisation. Maintainer `malferov` conservé.

Fixes #1388