### PR TITLE
[Sync EN] fiber/throw.xml: add an example

### DIFF
--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: sergey Status: ready -->
+<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,6 +44,40 @@
    или значение &null;, если файбер вернул результирующее значение.
    Исключение, которое файбер выбрасывает раньше очередной приостановки, выбрасывается в точке вызова этого метода.
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+   try {
+       // Приостанавливает выполнение файбера, объявляя точку прерывания
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
+});
+
+$fiber->start();
+
+// Возобновляет выполнение файбера с передачей
+// исключения, которое будет выброшено в точке прерывания
+$fiber->throw(new Exception('Сообщение исключения, которое выбрасывается в текущей точке прерывания'));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Сообщение исключения, которое выбрасывается в текущей точке прерывания
+]]>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync de `language/predefined/fiber/throw.xml` avec la PR upstream doc-en : ajout d'un exemple complet (création d'un Fiber, suspension, propagation d'exception via `Fiber::throw`).

Commentaires de code et chaîne du message d'exception traduits en russe. Maintainer `sergey` conservé.

Fixes #1387