### PR TITLE
[Sync EN] sscanf/fscanf: Clarify negative -1 return value (#5580)

### DIFF
--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: shein Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,67 +15,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция <function>fscanf</function> аналогична функции
    <function>sscanf</function>, но берёт входные данные из файла,
    который связан с потоком <parameter>stream</parameter>, и интерпретирует входные данные
    по условиям формата <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Любой пробельный символ в строке формата эквивалентен любому
    пробельному символу во входящем потоке. Это означает, что даже символ табуляции
    (<literal>\t</literal>) в строке формата может соответствовать
    одному символу пробела в потоке входных данных.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Каждый вызов функции <function>fscanf</function> считывает одну строку из файла.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Необязательные переменные, которым функция присвоит значения.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Необязательные переменные, которым функция присвоит значения.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает массив с результатами разбора,
    если в функцию передали только два аргумента.
    Функция вернёт количество присвоенных значений, если передали необязательные аргументы.
    Необязательные аргументы требуется передавать по ссылке.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Если параметр <parameter>format</parameter> ожидает больше подстрок,
    чем доступно в параметре <parameter>string</parameter>, вернётся значение &null;.
    Функция вернёт &false;, если возникнут другие ошибки.
-  </para>
+  </simpara>
+  <simpara>
+   Функция возвращает <literal>-1</literal>, если переданы необязательные аргументы
+   и достигнут конец входных данных, считанных из <parameter>stream</parameter>,
+   до того, как удалось разобрать хотя бы одно значение.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Пример использования функции <function>fscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Пример использования функции <function>fscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -90,36 +92,31 @@ fclose($handle);
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Содержимое файла users.txt</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>Содержимое файла users.txt</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,88 +16,91 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод считывает строку из файла и интерпретирует её по условиям
    формата <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Любой пробельный символ в строке <parameter>format</parameter> соответствует
    любому пробельный символу в строке из файла. Это означает, что
    даже символ табуляции (<literal>\t</literal>) в строке формата может соответствовать
    одному пробелу в строке файла.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Необязательные переменные, которым функция присвоит значения.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Необязательные переменные, которым функция присвоит значения.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает массив с результатами разбора,
    если передали только один аргумент.
    Метод вернёт количество присвоенных значений,
    если передали необязательные аргументы.
    Необязательные аргументы требуется передавать по ссылке.
-  </para>
+  </simpara>
+  <simpara>
+   Если параметр <parameter>format</parameter> ожидает больше подстрок,
+   чем доступно в строке, считанной из файла, вернётся значение &null;.
+  </simpara>
+  <simpara>
+   Метод возвращает <literal>-1</literal>, если переданы необязательные аргументы
+   и достигнут конец строки, считанной из файла, до того,
+   как удалось разобрать хотя бы одно значение.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Пример использования метода <methodname>SplFileObject::fscanf</methodname></title>
-    <programlisting role="php">
+  <example>
+   <title>Пример использования метода <methodname>SplFileObject::fscanf</methodname></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
 $file = new SplFileObject("misc.txt");
 
 while ($userinfo = $file->fscanf("%s %s %s")) {
-    list ($name, $profession, $countrycode) = $userinfo;
-    // Работаем с переменными $name, $profession и $countrycode
+   list ($name, $profession, $countrycode) = $userinfo;
+   // Работаем с переменными $name, $profession и $countrycode
 }
 
 ?>
 ]]>
-    </programlisting>
-    <para>Содержимое файла users.txt</para>
-    <programlisting role="txt">
+   </programlisting>
+   <simpara>Содержимое файла users.txt</simpara>
+   <programlisting role="txt">
 <![CDATA[
 javier   argonaut    pe
 hiroshi  sculptor    jp
 robert   slacker     us
 luigi    florist     it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fscanf</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: shein Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,68 +15,70 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция <function>sscanf</function> — аналог функции
    <function>printf</function> для входных данных.
    Функция <function>sscanf</function> сканирует строку <parameter>string</parameter>
    и интерпретирует строку по условиям формата <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Любые пробельные символы в строке формата соответствуют любым
    пробельным символам во входной строке. Это значит, что даже символ
    табуляции (<literal>\t</literal>) в строке формата соответствует одному
    символу пробела во входной строке.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       Входная строка (<type>string</type>) для разбора.
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Необязательные переменные, которые передаются по ссылке
-       и которые будут содержать значения с результатами разбора строки.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      Входная строка (<type>string</type>) для разбора.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Необязательные переменные, которые передаются по ссылке
+      и которые будут содержать значения с результатами разбора строки.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает массив с результатами разбора,
    если в функцию передали только два аргумента.
    Функция вернёт количество присвоенных значений,
    если передали необязательные аргументы.
    Необязательные аргументы требуется передавать по ссылке.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Если параметр <parameter>format</parameter> ожидает больше подстрок,
    чем доступно в параметре <parameter>string</parameter>,
    вернётся значение &null;.
-  </para>
+  </simpara>
+  <simpara>
+   Функция возвращает <literal>-1</literal>, если переданы необязательные аргументы
+   и достигнут конец входной строки <parameter>string</parameter>,
+   до того, как удалось разобрать хотя бы одно значение.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Пример использования функции <function>sscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Пример использования функции <function>sscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -92,19 +94,17 @@ echo "Узел $serial изготовили: $year-" . substr($month, 0, 3) . "-
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    Функция вернёт количество присвоенных значений,
    если передали необязательные аргументы.
-  </para>
-  <para>
-   <example>
-    <title>
-     Пример использования функции <function>sscanf</function> с необязательными аргументами
-    </title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title>
+    Пример использования функции <function>sscanf</function> с необязательными аргументами
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -120,26 +120,23 @@ echo "<author id='$id'>
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Apply upstream PR #5580 to doc-ru: new `-1` return value paragraph on the three files (`fscanf`, `sscanf`, `SplFileObject::fscanf`). Inline `<para>` → `<simpara>` and wrappers around `<variablelist>` / `<example>` / `<simplelist>` removed to mirror EN structure. `SplFileObject::fscanf` also gains the previously missing `&null;` paragraph. Existing Maintainers (shein, tmn) kept.

Closes #1400.