### PR TITLE
[Sync EN] Nits: codespell typos in standard (bundled) extensions (#5586)

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration84.new-features">
  <title>Новая функциональность</title>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <!ENTITY installation.enabled.disable 'Модуль включён по умолчанию. Модуль отключается во время выполнения опцией:'>
 

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Исключения</title>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a3ce2f9a191ad00fdd709c249e6dea16df316e3 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
  <title>Журнал изменений ООП</title>

--- a/reference/com/ini.xml
+++ b/reference/com/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 554db5a3a3ac77910d68349eefa37e2c9a9da628 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="com.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -117,12 +117,12 @@
      <parameter>com.autoregister_casesensitive</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Если включено (по умолчанию), константы, обнаруженные при автозагрузке
       библиотек типов, при инстанцировании объектов <classname>COM</classname>,
       будут зарегистрированы как регистрозависимые.
       Более подробно смотрите в описании функции <function>com_load_typelib</function>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e38c9165b91df5e9c52eb705c169938bcdc20d31 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
@@ -1709,13 +1709,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Максимальное количество HTTP-перенаправлений для следования.
      Используйте эту опцию вместе с <constant>CURLOPT_FOLLOWLOCATION</constant>.
      Значение по умолчанию <literal>20</literal> установлено для предотвращения бесконечных перенаправлений.
      Установка <literal>-1</literal> разрешает бесконечные перенаправления, а <literal>0</literal> отклоняет все перенаправления.
      Доступно с cURL 7.5.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-max-recv-speed-large">

--- a/reference/datetime/datetime/settimezone.xml
+++ b/reference/datetime/datetime/settimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,10 +53,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает объект <classname>DateTime</classname>, что помогает выстраивать цепочку вызовов.
    При вызове метода исходный момент времени не изменяется.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -37,11 +37,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает новый модифицированный объект
    <classname>DateTimeImmutable</classname> для цепочки методов.
    При вызове метода исходный объект, который представляет момент времени, не изменяется.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b5fce74a6c0760daccc79063279e102873be6d77 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="dba.setup">
  &reftitle.setup;

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: shein Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fa98755da49828e6a37049bdaf7bd16aa8adf879 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="fpm.status">
  <title>Страница статуса</title>
@@ -115,7 +115,7 @@
       <entry>Имя пула процессов FPM.</entry>
      </row>
      <row>
-      <entry>proccess manager</entry>
+      <entry>process manager</entry>
       <entry>
        Тип менеджера процесса — static (статический), dynamic (динамический) или ondemand (по требованию).
       </entry>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 213fbd9440a224f9c1da4942c85124ce0c120c52 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <book xml:id="book.image" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
@@ -56,10 +56,10 @@
    </caution>
   </para>
 
-  <para>
+  <simpara>
    Модуль GD поддерживает ряд форматов. Ниже приводится список этих форматов
    и пометки о доступности, включая поддержку чтения и записи.
-  </para>
+  </simpara>
   <para>
    <table>
     <title>Форматы, которые поддерживает модуль GD</title>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6bb90d24b240a0b81e4b203cd8b7ed56bd54033a Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.getimagesize">
  <refnamediv>

--- a/reference/image/functions/imagecolortransparent.xml
+++ b/reference/image/functions/imagecolortransparent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagecolortransparent" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -107,12 +107,12 @@ imagepng($im, './imagecolortransparent.png');
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Прозрачность копируется только функцией <function>imagecopymerge</function>
     и для truecolor-изображений. При вызове функции
     <function>imagecopy</function> или палитрового изображения значение альфа-компонента
     не копируется.
-   </para>
+   </simpara>
   </note>
   <note>
    <para>

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagecopymerge" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -92,14 +92,14 @@
     <varlistentry>
      <term><parameter>pct</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Два изображения совмещаются в зависимости от параметра
        <parameter>pct</parameter>, который варьируется в диапазоне от 0 до 100.
        Когда параметр <parameter>pct</parameter> = 0, наложение не выполняется.
        Со значением 100 поведение функции аналогично функции
        <function>imagecopy</function> для палитровых изображений,
        несмотря на поддержку прозрачности для truecolor-изображений.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagecopymergegray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -98,14 +98,14 @@
     <varlistentry>
      <term><parameter>pct</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Функция преобразует исходное изображение <parameter>src_image</parameter>
        в изображение в градациях серого на основе значения параметра
        <parameter>pct</parameter>: при значении 0 изображение становится серым,
        а со значением 100 остаётся без изменений. При передаче в параметр <parameter>pct</parameter> значения 100
        функция ведёт себя аналогично функции <function>imagecopy</function>,
        но игнорирует альфа-компонент для палитровых изображений; при этом для truecolor-изображений альфа-прозрачность поддерживается.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagefilltoborder" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imagefilter.xml
+++ b/reference/image/functions/imagefilter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagefilter" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imageftbbox.xml
+++ b/reference/image/functions/imageftbbox.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imageftbbox" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imagepalettetotruecolor.xml
+++ b/reference/image/functions/imagepalettetotruecolor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagepalettetotruecolor" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -31,11 +31,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает &true;, если преобразование завершилось,
    или если исходное изображение уже относится к truecolor-изображению,
    иначе возвращает значение &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imageresolution" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,12 +24,12 @@
    При установке двух параметров — один определяет горизонтальное,
    а другой вертикальное разрешение.
   </para>
-  <para>
+  <simpara>
    Разрешение сохраняется только как метаданные, которые доступны при чтении или записи изображений
    в форматы, которые поддерживают такой вид информации: PNG и JPEG.
    Изменение разрешения функцией не влияет на операции рисования. Разрешение по умолчанию для новых
    изображений — 96 DPI.
-  </para>
+  </simpara>
  </refsect1><!-- }}} -->
 
  <refsect1 role="parameters"><!-- {{{ -->

--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 48220b9fcde41afb13e0b7f3e806f51cd179df90 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagettfbbox" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e8fa6aa168fe2cb9bc5cae74ed22a52d1df891b Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -93,10 +93,10 @@ Array
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает массив вида "имя константы" => "значение константы",
    с возможностью сгруппировать его по имени модуля, зарегистрировавшего константу.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 30509282589c6fdee1bce55f3271caf464b5cd75 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.phpversion" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/ldap/functions/ldap-exop-passwd.xml
+++ b/reference/ldap/functions/ldap-exop-passwd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5bc68add3da3cd18c40f851e944b15095d3a26aa Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-exop-passwd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,9 +44,9 @@
    <varlistentry>
     <term><parameter>old_password</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Старый пароль. В зависимости от конфигурации может быть опущен.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/ldap/functions/ldap-mod-add.xml
+++ b/reference/ldap/functions/ldap-mod-add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b7cbd468cb4c46d55d43a44cade0eb4590d25dea Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.ldap-mod-add" xmlns="http://docbook.org/ns/docbook">
@@ -46,12 +46,12 @@
     <varlistentry>
      <term><parameter>entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Ассоциативный массив со списком добавляемых значений атрибутов. Если какой-либо
        атрибут ещё не существует, то он будет добавлен. Если атрибут уже существует, то
        вы можете только добавить к нему значение, если он поддерживает множественные
        значения.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9598935f21bc472f22383fb989625f0b22785331 Maintainer: das Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: das Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="mysqlnd.config">
 

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 35ca7f1087870c6023ef7a3dd0248501741c8194 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.dns-get-record" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/openssl/functions/openssl-pbkdf2.xml
+++ b/reference/openssl/functions/openssl-pbkdf2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5136ca8abac85850155a0ae7375124a52917b240 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-pbkdf2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -38,9 +38,9 @@
    <varlistentry>
     <term><parameter>salt</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Стандарт PBKDF2 рекомендует использовать криптографическую соль длиной как минимум 128 бита (16 байтов).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 082ddc19f53e6e254010de1a1fbbe485ff744ec1 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="phar.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/posix/functions/posix-geteuid.xml
+++ b/reference/posix/functions/posix-geteuid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f8854f6a6a7907720ed8ec8657a2f466a82c0394 Maintainer: rjhdby  Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby  Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.posix-geteuid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,11 +13,11 @@
    <type>int</type><methodname>posix_geteuid</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает число, соответствующее эффективному идентификатору пользователя текущего процесса.
    Посмотрите функцию <function>posix_getpwuid</function> для получения информации как преобразовать
    данное число в имя пользователя.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionclass/isiterateable.xml
+++ b/reference/reflection/reflectionclass/isiterateable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1046d428ad83d2ac0b22456e4106096ca2f0a991 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="reflectionclass.isiterateable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -11,13 +11,13 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&Alias; <methodname>ReflectionClass::isIterable</methodname></para>
-  <para>
+  <simpara>
    Начиная с PHP 7.2.0, вместо метода
    <methodname>RefectionClass::isIterateable</methodname>,
    , в имя которого закралась синтаксическая ошибка, стоит использовать правильно
    именованный метод
    <methodname>ReflectionClass::isIterable</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 790f63af6521908477b285ff753e454e118bb989 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionmethod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -25,14 +25,14 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает значение по умолчанию, если свойство содержит
    значение, включая &null;. Метод возвращает &null;, если значение
    по умолчанию не задали. Невозможно отличить значение по умолчанию &null;
    и неинициализированное типизированное свойство.
    Метод <methodname>ReflectionProperty::hasDefaultValue</methodname>
    умеет определять разницу.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/reflection/reflectionproperty/getdoccomment.xml
+++ b/reference/reflection/reflectionproperty/getdoccomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.getdoccomment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,10 +68,10 @@ string(52) "/**
   <para>
    <example>
     <title>Объявление нескольких свойств</title>
-    <para>
+    <simpara>
      Doc-комментарий относится только к первому свойству,
      если doc-комментарий идёт перед множественным объявлением свойств.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.walk">
  <refnamediv>

--- a/reference/sqlite3/sqlite3stmt/bindparam.xml
+++ b/reference/sqlite3/sqlite3stmt/bindparam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 855bfee2f3db70d7dbb4c60c7c4a4efa567f1c60 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="sqlite3stmt.bindparam" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -41,14 +41,14 @@
     <varlistentry>
      <term><parameter>param</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Либо строка (<type>string</type>) (для именованных параметров),
        либо целое число (<type>int</type>) (для положительных параметров),
        идентифицирующая переменную подготовленного запроса, к которому должно быть привязано значение.
        Если именованный параметр не начинается с двоеточия ((<literal>:</literal>)) или
        знака <literal>@</literal>, автоматически добавляется двоеточие (<literal>:</literal>).
        Положительные параметры начинаются с 1.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/sqlite3/sqlite3stmt/bindvalue.xml
+++ b/reference/sqlite3/sqlite3stmt/bindvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 855bfee2f3db70d7dbb4c60c7c4a4efa567f1c60 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="sqlite3stmt.bindvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,14 +34,14 @@
     <varlistentry>
      <term><parameter>param</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Либо строка (<type>string</type>) (для именованных параметров),
        либо целое число (<type>int</type>) (для положительных параметров),
        идентифицирующая переменную подготовленного запроса, к которому должно быть привязано значение.
        Если именованный параметр не начинается с двоеточия ((<literal>:</literal>)) или
        знака <literal>@</literal>, автоматически добавляется двоеточие (<literal>:</literal>).
        Положительные параметры начинаются с 1.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1702b5d45ad950c5f7a077878378a37851a2df6 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-socket-server" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -45,12 +45,12 @@
        Unix-домена часть <literal>target</literal> должна указывать
        на файл сокета в файловой системе.
       </para>
-      <para>
+      <simpara>
        Сокеты Unix-домена доступны не в каждом окружении.
        Список доступных транспортов возвращает функция
        <function>stream_get_transports</function>. Список встроенных транспортов
        приводит раздел «<xref linkend="transports"/>».
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/stream/functions/stream-wrapper-unregister.xml
+++ b/reference/stream/functions/stream-wrapper-unregister.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-wrapper-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,12 +12,12 @@
    <type>bool</type><methodname>stream_wrapper_unregister</methodname>
    <methodparam><type>string</type><parameter>protocol</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Позволяет вам отключить уже определённую обёртку потока. Как только обёртка
    будет отключена, вы можете перезаписать её пользовательской обёрткой, используя
    <function>stream_wrapper_register</function> или включить её повторно, используя
    <function>stream_wrapper_restore</function>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/stream/streamwrapper/dir-readdir.xml
+++ b/reference/stream/streamwrapper/dir-readdir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e652ed93a5ba1f87c8f2058ff2bdfe626cf4a560 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="streamwrapper.dir-readdir" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/stream/streamwrapper/url-stat.xml
+++ b/reference/stream/streamwrapper/url-stat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c79b9928aa114777d864b9c70feb1436d7344b4d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="streamwrapper.url-stat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -118,12 +118,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Должен возвращаться массив (&array;) с теми же элементами, что и в <function>stat</function>. Неизвестные или недоступные значения
    необходимо приводить к разумным значениям
    (обычно к <constant>0</constant>). Обратите особое внимание на <literal>mode</literal>, как описано в разделе <function>stat</function>.
    В случае возникновения ошибки возвращает &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors"><!-- {{{ -->

--- a/reference/tidy/tidynode/isasp.xml
+++ b/reference/tidy/tidynode/isasp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.isasp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/tidy/tidynode/iscomment.xml
+++ b/reference/tidy/tidynode/iscomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.iscomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/tidy/tidynode/ishtml.xml
+++ b/reference/tidy/tidynode/ishtml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.ishtml" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/tidy/tidynode/isjste.xml
+++ b/reference/tidy/tidynode/isjste.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.isjste" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/tidy/tidynode/isphp.xml
+++ b/reference/tidy/tidynode/isphp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.isphp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/tidy/tidynode/istext.xml
+++ b/reference/tidy/tidynode/istext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="tidynode.istext" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.var-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/xmlwriter/xmlwriter/openmemory.xml
+++ b/reference/xmlwriter/xmlwriter/openmemory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7776f9acb2fa3aeeed8a8661678b65b40db00abe Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="xmlwriter.openmemory" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/xmlwriter/xmlwriter/openuri.xml
+++ b/reference/xmlwriter/xmlwriter/openuri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a742792da6fd1ba27acd118bfeeed326c8d9aaf Maintainer: mch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="xmlwriter.openuri" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: irker Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="zip.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;


### PR DESCRIPTION
Apply upstream PR #5586 (codespell typos in bundled extensions) to doc-ru. Russian translations are independent of the English typos, so the changes are dominated by EN-Revision bumps and mirrored `<para>` → `<simpara>` tag swaps. One literal label fix in `reference/fpm/status.xml` (`proccess manager` → `process manager`, kept English as it is the FPM output column name). Existing Maintainers kept.

Closes #1399.