### PR TITLE
[Sync EN] Fix various class method signatures to match stub

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1185,6 +1185,13 @@ $compareFunc = static function ($item1, $item2) {
  </entry>
 </row>'>
 
+<!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Значение возврата теперь принадлежит типу &true;; раньше значение принадлежало типу <type>bool</type>.
+ </entry>
+</row>'>
+
 <!ENTITY return.falseforfailure ' или &false;, если возникла ошибка'>
 <!ENTITY return.falseforfailure.style.procedural '&style.procedural; возвращает &false;, если возникла ошибка.'>
 

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4756524479423ee3118adec1effa89171a9ffda Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,25 +12,25 @@
   &reftitle.description;
 
  <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
 
  <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_COLUMN</initializer></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
 
  <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
  <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -87,9 +87,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phar.setstub">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="Phar">
-   <modifier>public</modifier> <type>bool</type><methodname>Phar::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>Phar::setStub</methodname>
    <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
@@ -70,9 +70,9 @@ include 'phar://myphar.phar/somefile.php';
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -96,6 +96,7 @@ include 'phar://myphar.phar/somefile.php';
      </row>
     </thead>
     <tbody>
+     &return.type.true.84;
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
  <refnamediv>
@@ -9,9 +9,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="PharData">
-   <modifier>public</modifier> <type>bool</type><methodname>PharData::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
    <methodparam><type>string</type><parameter>stub</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        Параметр игнорируется.
@@ -47,9 +47,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -57,6 +57,23 @@
   <para>
    Выбрасывает исключение <classname>PharException</classname>
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: aur Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.getstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis role="ReflectionClass">
    <modifier>public</modifier> <type>mixed</type><methodname>ReflectionClass::getStaticPropertyValue</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">def_value</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter role="reference">default</parameter></methodparam>
   </methodsynopsis>
   <para>
    Возвращает значение статического свойства класса.
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>def_value</parameter></term>
+     <term><parameter>default</parameter></term>
      <listitem>
       <para>
        Значение по умолчанию, возвращаемое в случае, если в классе не определено статическое


### PR DESCRIPTION
Синхронизация RU с коммитом EN 8a910daa: сигнатуры приведены в соответствие со стабами (тип возврата `true`, переименование параметров `def_value` → `default` и `len` → `length`), `return.success` заменён на `return.true.always`, добавлены записи в журнал изменений для 8.4.0.

Fixes #1406