### PR TITLE
[Sync EN] image: Fix examples and description

### DIFF
--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -94,7 +94,7 @@ $im = imagecreatetruecolor(100, 100);
 
 // Заливаем фон белым цветом
 $white = imagecolorallocate($im, 255, 255, 255);
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 99, 99, $white);
 
 // Устанавливаем кисть
 imagesetbrush($im, $php);

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -74,7 +74,7 @@ $white = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
 $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
 
 // Устанавливаем белый фон
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 199, 99, $white);
 
 // Устанавливаем толщину линий на 5 пикселей
 imagesetthickness($im, 5);


### PR DESCRIPTION
Синхронизация RU с коммитом EN d56953fc: исправлены координаты в примерах `imagesetbrush` и `imagesetthickness`. Описания параметров `imagedashedline` и `imagerectangle` уже соответствовали EN, обновлён только хеш EN-Revision.

Fixes #1407