### PR TITLE
[Sync EN] unserialization: allowed_classes does not affect enums

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c158f4a34c8f869a43f9f0bd5a4897fb35cec89 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Перечисления</title>
@@ -858,6 +858,12 @@ print serialize(Suit::Hearts);
    PHP выдаст предупреждение и вернёт значение &false;,
    если не найдёт перечисление и вариант для сопоставления сериализованному значению.
   </para>
+
+  <simpara>
+   Опция <literal>allowed_classes</literal> функции
+   <function>unserialize</function> не влияет на
+   <link linkend="language.enumerations">перечисления</link>.
+  </simpara>
 
   <para>
    При попытке сериализовать чистое перечисление в JSON-формат выбрасывается исключение (если только функцию вызвали с флагом JSON_THROW_ON_ERROR — прим. перев.).

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -105,6 +105,9 @@
             Пропуск опции равносилен определению значения &true;: PHP
             попытается создать объекты любого класса.
            </simpara>
+           <simpara>
+            Эта опция не влияет на <link linkend="language.enumerations">перечисления</link>.
+           </simpara>
           </entry>
          </row>
          <row>
@@ -168,6 +171,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Теперь выбрасывает исключения <exceptionname>TypeError</exceptionname> и
+        <exceptionname>ValueError</exceptionname>, если элемент <literal>allowed_classes</literal>
+        параметра <parameter>options</parameter> не является массивом имён классов.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Десериализация строк с использованием тега в верхнем регистре <literal>"S"</literal>
+        теперь объявлена устаревшей; вместо него применяют тег в нижнем регистре <literal>"s"</literal>.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -106,7 +106,7 @@
             попытается создать объекты любого класса.
            </simpara>
            <simpara>
-            Эта опция не влияет на <link linkend="language.enumerations">перечисления</link>.
+            Опция не влияет на <link linkend="language.enumerations">перечисления</link>.
            </simpara>
           </entry>
          </row>


### PR DESCRIPTION
Sync EN (commit 8af3521). Fixes #1424