### PR TITLE
[Sync EN] Add deprecation notice for mysqli_execute (PHP 8.5)

### DIFF
--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: mch Status: ready -->
+<!-- EN-Revision: d7a97693b4683a8c116ac4ba2e25731f5dcb8890 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mysqli-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -7,20 +7,15 @@
   <refpurpose>&Alias; <function>mysqli_stmt_execute</function></refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
    &info.function.alias; <function>mysqli_stmt_execute</function>.
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    Функция <function>mysqli_execute</function> устарела и будет удалена.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Sync EN (commit d7a9769). Fixes #1417