### PR TITLE
[Sync EN] appendix 8.4 property hooks: confusing use of terms

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: d7efc67559999c1dda0f65c90617b60c6872a61b Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration84.new-features">
  <title>Новая функциональность</title>
@@ -26,7 +26,7 @@
 
 class Person
 {
-    // «Виртуальное» свойство. Невозможно установить значение виртуального свойства явным образом
+    // «Виртуальное» свойство. Установить его значение явным образом нельзя
     public string $fullName
     {
         get => $this->firstName . ' ' . $this->lastName;
@@ -60,6 +60,8 @@ print $p->firstName; // Конструкция выведет "Пётр"
 
 $p->lastName = 'Петров';
 print $p->fullName; // Конструкция выведет "Пётр Петров"
+
+$p->fullName = "Пётр 'Петя' Петров"; // Выбросит ошибку Error: "Property Person::$fullName is read-only"
 
 ?>
 ]]>


### PR DESCRIPTION
Sync EN (commit d7efc67). Fixes #1415