### PR TITLE
[Sync EN] Разное: serverHeartbeatFailedEvent, PDO fetch-modes

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatfailedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86d3fb841e0206e2588896ad3c21432333535848 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 581589d2c4d3183f1c0e67214a65cbd181a5edac Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <section xmlns="http://docbook.org/ns/docbook" xml:id="pdo.constants.fetch-modes">
  <title>Режимы выборки</title>
@@ -1096,10 +1096,12 @@ class TestEntity
 }
 
 $obj = new TestEntity();
-$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 
 $stmt = $db->query("SELECT userid, name, country, referred_by_userid FROM users");
+
+$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 $result = $stmt->fetch();
+
 var_dump($result);
 ]]>
    </programlisting>


### PR DESCRIPTION
Синхронизация с английской версией. Обновлены свойства класса ServerHeartbeatFailedEvent и пример режима PDO::FETCH_INTO.