### PR TITLE
[Sync EN] ldap/pgsql: синхронизация разметки

### DIFF
--- a/reference/ldap/ldap.resultentry.xml
+++ b/reference/ldap/ldap.resultentry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ldap-result-entry" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Класс LDAP\ResultEntry</title>
@@ -20,13 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>LDAP\ResultEntry</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>LDAP</package>
 
-   </classsynopsis>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>ResultEntry</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pgsql/pgsql.connection.xml
+++ b/reference/pgsql/pgsql.connection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.pgsql-connection" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Класс PgSql\Connection</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Connection</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pgsql/pgsql.lob.xml
+++ b/reference/pgsql/pgsql.lob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.pgsql-lob" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Класс PgSql\Lob</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Lob</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Lob</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pgsql/pgsql.result.xml
+++ b/reference/pgsql/pgsql.result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.pgsql-result" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Класс PgSql\Result</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Result</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Result</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>


### PR DESCRIPTION
Синхронизация разметки классов LDAP\ResultEntry и PgSql\* с английской версией: classsynopsis обёрнут в packagesynopsis. Изменений в тексте нет.