### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 3

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,21 +15,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет одну или несколько операций записи на основном сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Объект класса <classname>MongoDB\Driver\BulkWrite</classname> создают
    с одной или несколькими операциями записи: обновления, удаления
    или вставки. Драйвер попытается отправить операции одного и того же типа
    на сервер с минимальным количества запросов, чтобы сократить обращения к серверу.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значение по умолчанию для опции <literal>"writeConcern"</literal>
    автоматически определяется на основе активной транзакции
    или <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатора соединения</link>, если транзакция не содержит значения.
    На активную транзакцию указывает опция <literal>"session"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -88,59 +88,57 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\WriteConcern</classname>
-        как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опцию <literal>"session"</literal> указать вместе
-        с неподтверждаемым уровнем записи.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.3.0</entry>
-       <entry>
-        Метод теперь выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если параметр <parameter>bulk</parameter> не содержит операций записи.
-        Раньше выбрасывалось исключение
-        <classname>MongoDB\Driver\Exception\BulkWriteException</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\WriteConcern</classname>
+       как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опцию <literal>"session"</literal> указать вместе
+       с неподтверждаемым уровнем записи.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.3.0</entry>
+      <entry>
+       Метод теперь выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если параметр <parameter>bulk</parameter> не содержит операций записи.
+       Раньше выбрасывалось исключение
+       <classname>MongoDB\Driver\Exception\BulkWriteException</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,22 +14,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет одну или несколько операций записи на первичном сервере
    через команду <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>,
    которая появилась в MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Объект класса <classname>MongoDB\Driver\BulkWriteCommand</classname> создают
    с одной или несколькими операциями записи: вставки, обновления
    или удаления. Каждую операцию записи возможно нацелить на разные коллекции.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значение по умолчанию для опции <literal>"writeConcern"</literal>
    автоматически определяется на основе активной транзакции
    или <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатора соединения</link>, если транзакция не содержит значения.
    На активную транзакцию указывает опция <literal>"session"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -92,12 +92,12 @@
   &reftitle.examples;
   <example>
    <title>Пример смешанных операций записи</title>
-   <para>
+   <simpara>
     Смешанные операции записи наподобие вставки, обновления или удаления отправляются
     на сервер одной командой
     <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
     command.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,11 +15,11 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выбирает сервер в соответствии с опцией <literal>readPreference</literal>
    и выполняет команду на этом сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
 
    Метод не применяет особую логику к команде. Значения
    по умолчанию для опций <literal>readPreference</literal>,
@@ -27,13 +27,13 @@
    метод получит из активной транзакции (указывает
    опция <literal>session</literal>). Для выбора сервера метод использует
    основное предпочтение чтения, если активной транзакции нет.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Метод <emphasis>не получает</emphasis> значения по умолчанию
    <link linkend="mongodb-driver-manager.construct-uri">из URI-идентификатора соединения</link>.
    Поэтому пользователям рекомендуют использовать методы команд чтения и (или) записи,
    если это возможно.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -90,50 +90,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
-        как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опцию <literal>"session"</literal> указать вместе
-        с неподтверждаемым уровнем записи.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
+       как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опцию <literal>"session"</literal> указать вместе
+       с неподтверждаемым уровнем записи.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -230,13 +228,13 @@ object(stdClass)#7 (2) {
 
   <example>
    <title>Ограничение времени выполнения запроса</title>
-   <para>
+   <simpara>
     Опция <literal>"maxTimeMS"</literal> класса <classname>MongoDB\Driver\Query</classname>
     ограничивает время выполнения запроса. Обратите внимание,
     что этот срок применяется на стороне сервера и не учитывает задержки сети.
     Дополнительную информацию дает страница <link xlink:href="&url.mongodb.docs.maxtimems;">Завершение выполнения операций</link>
     в руководстве MongoDB.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -256,10 +254,10 @@ var_dump($cursor->toArray()[0]);
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Метод выбросит исключение <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>,
     если запрос не завершится через секунду после начала выполнения на сервере.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выбирает сервер в соответствии с опцией <literal>readPreference</literal> и выполняет запрос на этом сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значения по умолчанию для опциии <literal>"readPreference"</literal> и Query-опции
    <literal>"readConcern"</literal> метод получит из активной
    транзакции, за которой следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
    Активную транзакцию обозначает опция <literal>session</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -76,41 +76,39 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
-        как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
+       как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -162,13 +160,13 @@ object(stdClass)#7 (1) {
 
   <example>
    <title>Ограничение времени выполнения запроса</title>
-   <para>
+   <simpara>
     Опция <literal>maxTimeMS</literal> класса <classname>MongoDB\Driver\Query</classname>
     ограничивает время выполнения запроса. Обратите внимание,
     что этот срок применяется на стороне сервера и не учитывает задержки сети.
     Дополнительную информацию даёт страница <link xlink:href="&url.mongodb.docs.maxtimems;">Завершение выполнения операций</link>
     в руководстве СУБД MongoDB.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -190,10 +188,10 @@ foreach ($cursor as $document) {
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Метод выбросит исключение <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>,
     если запрос не завершится через секунду после начала выполнения на сервере.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,18 +16,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выбирает сервер в соответствии с опцией <literal>readPreference</literal>
    и выполняет команду на сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Этот метод будет применять логику, специфичную для команд, которые читают (например,
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Значения по умолчанию для параметров <literal>"readPreference"</literal>
    и <literal>readConcern</literal> метод получит из активной транзакции
    (обозначена параметром <literal>session</literal>), за которой
    следует <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c90167b57a4b5a81acc18f9f952022e062b08104 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,17 +16,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет команду на основном сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Этот метод будет применять логику, специфичную для команд, которые читают и пишут
    (например, <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Значения по умолчанию для параметров <literal>readConcern</literal>
    и <literal>writeConcern</literal> метод получит из активной
    транзакции (обозначена параметром <literal>session</literal>),
    за которой следует <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -80,28 +80,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опция <literal>session</literal> используется
-        в сочетании с неподтверждённой записью.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опция <literal>session</literal> используется
+       в сочетании с неподтверждённой записью.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,17 +16,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет команду на основном сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Этот метод будет применять логику, специфичную для команд, которые пишут (например,
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    Значение по умолчанию для параметра <literal>"writeConcern"</literal>
    метод получит из активной транзакции (обозначена
    параметром <literal>session</literal>), за которым следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Метод не предназначен для выполнения запросов
@@ -89,28 +89,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опция <literal>session</literal> используется в
-        сочетании с неподтверждённой записью.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опция <literal>session</literal> используется в
+       сочетании с неподтверждённой записью.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
+++ b/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6c44e7b831d1ee04c932847b83a19cecfd51c98e Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getencryptedfieldsmap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Manager::getEncryptedFieldsMap</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает параметр <literal>encryptedFieldsMap</literal> автоматического шифрования для Manager,
    если он указан.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Параметр <literal>encryptedFieldsMap</literal> автоматического шифрования для Manager
    или &null;, если он не был указан.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
Синхронизация разметки с английской версией: замена <para> на <simpara> и снятие лишней обёртки вокруг таблиц. Текст перевода не менялся.