### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 6

### DIFF
--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,23 +15,23 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет команду на сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Этот метод не применяет специальной логики к команде.
    Значения по умолчанию для параметров <literal>readPreference</literal>,
    <literal>readConcern</literal> и <literal>writeConcern</literal>
    метод получит из активной транзакции, которую обозначает параметр
    <literal>session</literal>. Если активной транзакции нет,
    для выбора сервера будет использоваться основное предпочтение чтения.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Метод <emphasis>не</emphasis> получает значения по умолчанию
    <link linkend="mongodb-driver-manager.construct-uri">из URI-идентификатора соединения</link>.
    Поэтому пользователям рекомендуют по возможности использовать конкретные
    методы команд чтения и (или) записи.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -89,50 +89,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
-        как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опцию <literal>"session"</literal> указать вместе
-        с неподтверждаемым уровнем записи.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
+       как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опцию <literal>"session"</literal> указать вместе
+       с неподтверждаемым уровнем записи.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет запрос на сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значения по умолчанию для опциии <literal>"readPreference"</literal> и Query-опции
    <literal>"readConcern"</literal> метод получит из активной
    транзакции, за которой следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
    Активную транзакцию обозначает опция <literal>session</literal>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -77,41 +77,39 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
-        как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\ReadPreference</classname>
+       как опции параметра <parameter>options</parameter> устарела, а с версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,17 +16,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет команду на сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Этот метод будет применять логику, специфичную для команд, которые читают и пишут
    (например <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Значения по умолчанию для параметров <literal>readConcern</literal>
    <literal>writeConcern</literal> метод получит из активной
    транзакции (указывает параметр <literal>session</literal>), за которой следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -80,28 +80,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Метод выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опция <literal>session</literal> используется
-        в сочетании с неподтверждённой записью.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Метод выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опция <literal>session</literal> используется
+       в сочетании с неподтверждённой записью.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,17 +16,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет команду на сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Метод будет применять логику, специфичную для команд, которые пишут (например,
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    Значение по умолчанию для параметра <literal>writeConcern</literal> метод
    получит из активной транзакции (указывает параметр
    <literal>session</literal>), за которой следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Метод не предназначен для выполнения запросов
@@ -89,27 +89,25 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опция <literal>session</literal> используется в сочетании с неподтверждённой записью.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опция <literal>session</literal> используется в сочетании с неподтверждённой записью.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/server/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,16 +13,16 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает массив информации, описывающий сервер. Этот массив получен из последнего ответа команды <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>,
    полученного с помощью
    <link xlink:href="&url.mongodb.sdam;">мониторинга сервера</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Когда драйвер подключён к балансировщику нагрузки, метод вернёт ответ на команду <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link> от резервного сервера при первоначальном подтверждении соединения.
     Это отличается от других методов (например, <function>MongoDB\Driver\Server::getType</function>), которые возвращают информацию о самом балансировщике нагрузки.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает массив информации, описывающий сервер.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -199,27 +199,25 @@ array(23) {
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Когда драйвер подключён к подсистеме балансировки нагрузки, метод возвращает ответ на команду <literal>hello</literal>
-        вспомогательного сервера при первоначальном подтверждении соединения.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Когда драйвер подключён к подсистеме балансировки нагрузки, метод возвращает ответ на команду <literal>hello</literal>
+       вспомогательного сервера при первоначальном подтверждении соединения.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/getlatency.xml
+++ b/reference/mongodb/mongodb/driver/server/getlatency.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getlatency" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>integer</type><type>null</type></type><methodname>MongoDB\Driver\Server::getLatency</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод возвращает задержку сервера в миллисекундах.
    <link xlink:href="&url.mongodb.sdam;#round-trip-time">Время прохождения</link>
    команды <literal>hello</literal>, которое измерил клиент.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает задержку сервера в миллисекундах или &null;,
    если клиент не измерил задержку (например, клиент подключён к балансировщику нагрузки).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,28 +42,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Метод вернёт &null;, если задержку не измерили.
-        В предыдущих версиях при каждом вызове возвращалось целое число,
-        а неустановленное значение иногда отображалось как <literal>-1</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Метод вернёт &null;, если задержку не измерили.
+       В предыдущих версиях при каждом вызове возвращалось целое число,
+       а неустановленное значение иногда отображалось как <literal>-1</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,15 +14,15 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Запускает многодокументную транзакцию, связанную с сеансом. В любой
    момент времени вы можете иметь не более одной открытой транзакции для сеанса. После запуска
    транзакции объект сеанса должен быть передан каждой операции с помощью опции
    <literal>"session"</literal> (например,
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>), чтобы
    связать эту операцию с транзакцией.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Транзакции могут быть зафиксированы через
    <methodname>MongoDB\Driver\Session::commitTransaction</methodname> и
    прерваны с помощью
@@ -30,7 +30,7 @@
    Транзакции также автоматически прерываются, когда сеанс закрывается из
    сборки мусора или явно вызывается
    <methodname>MongoDB\Driver\Session::endSession</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,13 +39,13 @@
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Параметры могут быть переданы в качестве аргумента этому методу. Каждый элемент в этом
       массиве опций переопределяет соответствующую опцию из опции
       <literal>"defaultTransactionOptions"</literal>, если она установлена при
       запуске сеанса с
       <methodname>MongoDB\Driver\Manager::startSession</methodname>.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>options</title>
@@ -73,9 +73,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -91,28 +91,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.6.0</entry>
-       <entry>
-        <para>
-         Добавлен параметр <literal>"maxCommitTimeMS"</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       <simpara>
+        Добавлен параметр <literal>"maxCommitTimeMS"</literal>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Синхронизация разметки с английской версией: замена para на simpara в разделах MongoDB. Текст перевода не изменялся.