### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 4

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.getreadconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,11 +14,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadConcern</type><methodname>MongoDB\Driver\Manager::getReadConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает <classname>MongoDB\Driver\ReadConcern</classname> для
    Manager, полученный из его URI-опций. Это гарантия чтения
    по умолчанию для запросов и команд, выполняемых в Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <classname>MongoDB\Driver\ReadConcern</classname> для Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.getreadpreference" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,11 +14,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadPreference</type><methodname>MongoDB\Driver\Manager::getReadPreference</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод возвращает экземпляр класса <classname>MongoDB\Driver\ReadPreference</classname>
    для объекта Manager, который метод получил из URI-опций диспетчера. Это предпочтение чтения
    по умолчанию для запросов и команд, которые выполняются в диспетчере Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает экземпляр класса <classname>MongoDB\Driver\ReadPreference</classname> для диспетчера Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getservers.xml
+++ b/reference/mongodb/mongodb/driver/manager/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2de5fb458e886b011050a210c6f406ca9ed51c75 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Manager::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает массив (<type>array</type>) экземпляров <classname>MongoDB\Driver\Server</classname>,
    к которым подключён текущий менеджер.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Поскольку драйвер подключается к базе данных лениво, этот метод может возвращать
@@ -34,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает массив (<type>array</type>) экземпляров <classname>MongoDB\Driver\Server</classname>,
    к которым подключён менеджер.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.getwriteconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,11 +14,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteConcern</type><methodname>MongoDB\Driver\Manager::getWriteConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Возвращает <classname>MongoDB\Driver\WriteConcern</classname> для
    Manager, полученный из его URI-опций. Это гарантия записи
    по умолчанию для запросов и команд, выполняемых в Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <classname>MongoDB\Driver\WriteConcern</classname> для Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40dbbc56e321e36deee0f82df820c91fa79087cb Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-manager.removesubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,10 +16,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::removeSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Отменяет регистрацию подписчика на событие мониторинга в данном объекте
    Manager.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Если <parameter>subscriber</parameter> ещё не зарегистрирован в данном
@@ -34,10 +34,10 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Подписчик на событие мониторинга, которому необходимо отменить
       регистрацию в данном объекте Manager.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/selectserver.xml
+++ b/reference/mongodb/mongodb/driver/manager/selectserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 929fb17986921c8aadadb7c7bd877ee6f7a7126e Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.selectserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Manager::selectServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Выбирает <classname>MongoDB\Driver\Server</classname>, соответствующий
    <parameter>readPreference</parameter>.
    Если параметр <parameter>readPreference</parameter> равен &null; или опущен, по умолчанию будет выбран первичный сервер.
    Это можно использовать для предварительного выбора сервера,
    чтобы выполнить проверку версии перед выполнением операции.
-  </para>
+  </simpara>
   <note>
    <simpara>
     В отличие от <function>MongoDB\Driver\Manager::getServers</function>, этот метод
@@ -36,10 +36,10 @@
    <varlistentry>
     <term><parameter>readPreference</parameter> (<classname>MongoDB\Driver\ReadPreference</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       Предпочтение чтения используется для выбора сервера.
       Если &null; или опущен, по умолчанию будет выбран первичный сервер.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -47,9 +47,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает <classname>MongoDB\Driver\Server</classname>, соответствующий предпочтению чтения.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -64,27 +64,25 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Параметр <parameter>readPreference</parameter> теперь необязателен.
-        Если указано значение &null; или опущен, по умолчанию будет выбран первичный сервер.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Параметр <parameter>readPreference</parameter> теперь необязателен.
+       Если указано значение &null; или опущен, по умолчанию будет выбран первичный сервер.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-commandsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\Monitoring\CommandSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-commandsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Классы реализуют этот интерфейс для регистрации подписчика событий, который
     уведомляется о каждом успешном или неудачном событии команды. Более подробная информация доступна на странице
     <xref linkend="mongodb.tutorial.apm" />.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -47,22 +47,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-logsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,18 +11,18 @@
 <!-- {{{ MongoDB\Driver\Monitoring\LogSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Классам, которые реализуют этот интерфейс, разрешено регистрироваться в качестве подписчиков
     и получать сообщения журнала от модуля. Это похоже на ведение журнала отладки
     на основе потоков через директиву <link linkend="ini.mongodb.debug">mongodb.debug</link>,
     за исключением того, что сообщения журнала уровня трассировки <emphasis>не</emphasis> принимаются.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Как и в случае с потоковым журналированием, глобально зарегистрировать логгер
     можно только методом <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
     Модуль не умеет различать сообщения журнала для отдельных объектов
     <classname>MongoDB\Driver\Manager</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -97,59 +97,59 @@
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-error">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Уровень журнала ошибок. Состояние ошибки, о котором модуль не в состоянии сообщить
        через свой API. Это самый серьёзный уровень журнала в модуле.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-critical">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Критический уровень журнала. Состояние ошибки с несколько меньшей серьёзностью.
        Эта константа существует для согласованности с библиотекой libmongoc,
        однако, модуль вряд ли будет использовать его на практике.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-warning">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Уровень журнала предупреждений. Указывает на ситуацию, при которой есть риск
        нежелательного поведения приложения.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-message">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Уровень журнала сообщений или уведомлений. Указывает на необычное,
        но не проблематичное событие.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-info">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Информационный уровень журнала. Информация высокого уровня о нормальном поведении драйвера.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-debug">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Уровень журнала отладки. Подробная информация, полезная при отладке приложения.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Синхронизация с английской версией: замена para на simpara в разметке MongoDB. Перевод не менялся.

Refs: php/doc-en@9f4cb232d01a06077a2324e38f767d63f87f2e5f