### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 2

### DIFF
--- a/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 592e10fe7c16ddd3dc1c99f16f7bb1823e9f5b68 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.rewrapmanydatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,16 +14,16 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Переворачивает (т.е. расшифровывает и заново шифрует) ноль или более ключей данных
    в коллекции хранилища ключей, которые соответствуют заданному фильтру (<parameter>filter</parameter>).
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Если опция <literal>"provider"</literal> не указана, совпадающие ключи данных будут повторно зашифрованы
    с помощью текущего поставщика KMS.
    В противном случае совпадающие ключи данных будут зашифрованы заново
    в соответствии с указанными опциями <literal>"provider"</literal> и <literal>"masterKey"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,25 +49,25 @@
           <entry>provider</entry>
           <entry><type>string</type></entry>
           <entry>
-           <para>
+           <simpara>
             KMS-провайдер (например, <literal>"local"</literal>, <literal>"aws"</literal>),
             который будет использоваться для повторного шифрования совпавших ключей данных.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Если провайдер KMS не указан, то совпадающие ключи данных будут
             повторно зашифрованы с помощью текущего провайдера KMS.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>masterKey</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Параметр masterKey определяет специфический для KMS ключ, используемый для шифрования нового ключа данных.
             Параметр не должен указываться без параметра <literal>"provider"</literal>.
             Параметр необходим, если указан <literal>"provider"</literal>, а не <literal>"local"</literal>.
-           </para>
+           </simpara>
            &mongodb.option.encryption.masterKey-options-by-provider;
           </entry>
          </row>
@@ -82,12 +82,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает объект, у которого будет необязательное свойство <literal>bulkWriteResult</literal>,
    содержащее результат внутренней операции <literal>bulkWrite</literal> в виде объекта.
    Если ни один ключ данных не соответствует фильтру или запись не была признана,
    свойство <literal>bulkWriteResult</literal> будет равно &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -101,26 +101,24 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Добавлена опция <literal>"delegated"</literal> к параметрам masterKey поставщика KMIP.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Добавлена опция <literal>"delegated"</literal> к параметрам masterKey поставщика KMIP.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-command.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,19 +15,19 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>commandOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Создаёт новый объект класса <classname>MongoDB\Driver\Command</classname>,
    который является неизменяемым значением, представляющим команду базы данных.
    Эту команду впоследствии можно запустить с помощью
    <methodname>MongoDB\Driver\Manager::executeCommand</methodname>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Полный документ команды, включающий её имя и прочие опции,, должен
    быть задан в параметре <parameter>document</parameter>.
    Параметр <parameter>commandOptions</parameter> используется только
      для определения опций запуска команды и результирующий
      <classname>MongoDB\Driver\Cursor</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,9 +36,9 @@
    <varlistentry>
     <term><parameter>document</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Полный документ команды, который будет передан серверу.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -67,7 +67,7 @@
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Положительное целое число, определяющие ограничение времени
             в миллисекундах, на которое сервер может блокировать
             операцию getMore, если данные отсутствуют. Эта опция может использоваться
@@ -75,7 +75,7 @@
             курсоры. (например <link
             xlink:href="&url.mongodb.docs;changeStreams/">Change
             Streams</link>).
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -96,29 +96,27 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        <para>
-         Добавлен второй аргумент <parameter>commandOptions</parameter>,
-         позволяющий определить опцию <literal>"maxAwaitTimeMS"</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       <simpara>
+        Добавлен второй аргумент <parameter>commandOptions</parameter>,
+        позволяющий определить опцию <literal>"maxAwaitTimeMS"</literal>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -191,11 +189,11 @@ array(13) {
   </example>
   <example>
    <title>Пример использования <function>MongoDB\Driver\Command::__construct</function></title>
-   <para>
+   <simpara>
     Команды также могут принимать опции, как часть нормальной структуры, которую вы
     создаёте и отправляете на сервер. К примеру, с большинством команд можно
     передавать опцию <literal>maxTimeMS</literal> для ограничения времени их выполнения.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/cursor/construct.xml
+++ b/reference/mongodb/mongodb/driver/cursor/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d88708b86fa2e642dc3b5c1d9903a149aa0c185 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-cursor.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Cursor::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Объекты <classname>MongoDB\Driver\Cursor</classname> возвращаются в
    результате выполнения команды или запроса и не могут быть созданы напрямую.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/cursor/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursor/getid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-cursor.getid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Int64</type><methodname>MongoDB\Driver\Cursor::getId</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод возвращает идентификатор текущего курсора.
    На сервере каждому курсору присваивается уникальный идентификатор.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает идентификатор текущего курсора. Метод вернёт идентификатор
    как объект <classname>MongoDB\BSON\Int64</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -41,36 +41,34 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Тип значения возврата изменили на <classname>MongoDB\BSON\Int64</classname>.
-        Параметр <parameter>asInt64</parameter> удалили.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.20.0</entry>
-       <entry>
-        Возврат объекта <classname>MongoDB\Driver\CursorId</classname> устарел.
-        Добавили параметр <parameter>asInt64</parameter>, чтобы упростить переход
-        на будущие версии. Идентификатор вернётся как объект <classname>MongoDB\BSON\Int64</classname>,
-        если для параметра <parameter>asInt64</parameter> установили значение &true;.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Тип значения возврата изменили на <classname>MongoDB\BSON\Int64</classname>.
+       Параметр <parameter>asInt64</parameter> удалили.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.20.0</entry>
+      <entry>
+       Возврат объекта <classname>MongoDB\Driver\CursorId</classname> устарел.
+       Добавили параметр <parameter>asInt64</parameter>, чтобы упростить переход
+       на будущие версии. Идентификатор вернётся как объект <classname>MongoDB\BSON\Int64</classname>,
+       если для параметра <parameter>asInt64</parameter> установили значение &true;.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-cursorinterface.getid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Int64</type><methodname>MongoDB\Driver\CursorInterface::getId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод возвращает идентификатор текущего курсора.
    На сервере каждому курсору присваивается уникальный идентификатор.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает уникальный идентификатор текущего курсора.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -40,29 +40,27 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 1.20.0</entry>
-       <entry>
-        В предварительный тип значения, которое возвращает метод,
-        добавили тип <classname>MongoDB\BSON\Int64</classname>.
-        Тип <classname>MongoDB\Driver\CursorId</classname> удалят из типа возврата
-        в версии 2.0.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 1.20.0</entry>
+      <entry>
+       В предварительный тип значения, которое возвращает метод,
+       добавили тип <classname>MongoDB\BSON\Int64</classname>.
+       Тип <classname>MongoDB\Driver\CursorId</classname> удалят из типа возврата
+       в версии 2.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af5f2f87b3b0bb9ee0f83ccb787a4e7db1eb6bd4 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-exception-executiontimeoutexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -12,11 +12,11 @@
   <!-- {{{ MongoDB\Driver\Exception\ExecutionTimeoutException intro -->
   <section xml:id="mongodb-driver-exception-executiontimeoutexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Выбрасывается, когда запрос или команда не завершается в течение определённого
     периода времени (например,
     <link xlink:href="&url.mongodb.docs.maxtimems;">maxTimeMS</link>).
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -63,31 +63,29 @@
 
   <section role="changelog">
    &reftitle.changelog;
-     <para>
-      <informaltable>
-       <tgroup cols="2">
-        <thead>
-         <row>
-          <entry>&Version;</entry>
-          <entry>&Description;</entry>
-         </row>
-        </thead>
-        <tbody>
-         <row>
-          <entry>PECL mongodb 1.5.0</entry>
-          <entry>
-           <para>
-            Теперь этот класс расширяет
-            <classname>MongoDB\Driver\Exception\ServerException</classname>
-            вместо
-            <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
-           </para>
-          </entry>
-         </row>
-        </tbody>
-       </tgroup>
-      </informaltable>
-     </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        <simpara>
+         Теперь этот класс расширяет
+         <classname>MongoDB\Driver\Exception\ServerException</classname>
+         вместо
+         <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.addsubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::addSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Регистрирует подписчика на событие мониторинга в данном объекте Manager.
    Подписчик будет уведомлен обо всех событиях для этого объекта Manager.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Если <parameter>subscriber</parameter> уже зарегистрирован в данном объекте
@@ -35,10 +35,10 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Подписчик событий мониторинга, который должен быть зарегистрирован в
       данном объекте Manager.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
+++ b/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.createclientencryption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ClientEncryption</type><methodname>MongoDB\Driver\Manager::createClientEncryption</methodname>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Создаёт новый объект
    <classname>MongoDB\Driver\ClientEncryption</classname> с заданными
    параметрами.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -53,9 +53,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-   <para>
+   <simpara>
     Возвращает новый экземпляр <classname>MongoDB\Driver\ClientEncryption</classname>.
-   </para>
+   </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -71,71 +71,69 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.16.0</entry>
-       <entry>
-        <para>
-         Провайдер AWS KMS для шифрования на стороне клиента теперь принимает параметр
-         <literal>"sessionToken"</literal>, который можно использовать для аутентификации
-         с временными учётными данными AWS.
-        </para>
-        <para>
-         Для опции <literal>"tlsOptions"</literal>
-         добавлена настройка <literal>"tlsDisableOCSPEndpointCheck"</literal>.
-        </para>
-        <para>
-         Если для KMS-провайдеров <literal>"azure"</literal> или
-         <literal>"gcp"</literal> указан пустой документ,
-         драйвер попытается сконфигурировать провайдера, заполнив
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        <para>
-         Если для KMS-провайдера <literal>"aws"</literal> указан пустой документ,
-         драйвер попытается сконфигурировать провайдера, заполнив
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.12.0</entry>
-       <entry>
-        <para>
-         KMIP теперь поддерживается в качестве KMS провайдера для шифрования на стороне клиента
-         и может быть настроен с помощью параметра <literal>"kmsProviders"</literal>.
-        </para>
-        <para>
-         Добавлен параметр <literal>"tlsOptions"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.10.0</entry>
-       <entry>
-        Azure и GCP теперь поддерживаются в качестве поставщиков KMS
-         для шифрования на стороне клиента и могут быть настроены в поле <literal>"kmsProviders"</literal> параметра драйвера <literal>"autoEncryption"</literal>.
-         Строки в кодировке Base64 теперь принимаются в качестве альтернативы <classname>MongoDB\BSON\Binary</classname>
-         для параметров внутри <literal>"kmsProviders"</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.16.0</entry>
+      <entry>
+       <simpara>
+        Провайдер AWS KMS для шифрования на стороне клиента теперь принимает параметр
+        <literal>"sessionToken"</literal>, который можно использовать для аутентификации
+        с временными учётными данными AWS.
+       </simpara>
+       <simpara>
+        Для опции <literal>"tlsOptions"</literal>
+        добавлена настройка <literal>"tlsDisableOCSPEndpointCheck"</literal>.
+       </simpara>
+       <simpara>
+        Если для KMS-провайдеров <literal>"azure"</literal> или
+        <literal>"gcp"</literal> указан пустой документ,
+        драйвер попытается сконфигурировать провайдера, заполнив
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       <simpara>
+        Если для KMS-провайдера <literal>"aws"</literal> указан пустой документ,
+        драйвер попытается сконфигурировать провайдера, заполнив
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.12.0</entry>
+      <entry>
+       <simpara>
+        KMIP теперь поддерживается в качестве KMS провайдера для шифрования на стороне клиента
+        и может быть настроен с помощью параметра <literal>"kmsProviders"</literal>.
+       </simpara>
+       <simpara>
+        Добавлен параметр <literal>"tlsOptions"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.10.0</entry>
+      <entry>
+       Azure и GCP теперь поддерживаются в качестве поставщиков KMS
+        для шифрования на стороне клиента и могут быть настроены в поле <literal>"kmsProviders"</literal> параметра драйвера <literal>"autoEncryption"</literal>.
+        Строки в кодировке Base64 теперь принимаются в качестве альтернативы <classname>MongoDB\BSON\Binary</classname>
+        для параметров внутри <literal>"kmsProviders"</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Синхронизация разметки MongoDB с английской версией: замена `para` на `simpara` и распаковка `informaltable`. Текст перевода не менялся.