### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 5

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-sdamsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
   <!-- {{{ MongoDB\Driver\Monitoring\SDAMSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-sdamsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Классы реализуют этот интерфейс для регистрации подписчика событий,
     который получает уведомления о различных событиях SDAM. Дополнительная информация доступна
     в руководстве «<link xlink:href="&url.mongodb.sdam;">Обнаружение и мониторинг серверов</link>»
     и «<link xlink:href="&url.mongodb.sdam-monitoring;">Мониторинг SDAM</link>».
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -48,22 +48,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b95e76e41de2ffe5c75e04be1b187d80ca745359 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-monitoring-subscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -12,11 +12,11 @@
   <!-- {{{ MongoDB\Driver\Monitoring\Subscriber intro -->
   <section xml:id="mongodb-driver-monitoring-subscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Базовый интерфейс для подписчиков событий. Используется как тип параметра в функциях <function>MongoDB\Driver\Monitoring\addSubscriber</function> и
     <function>MongoDB\Driver\Monitoring\removeSubscriber</function>, и не должен
     реализовываться напрямую.
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -38,9 +38,9 @@
    </classsynopsis>
    <!-- }}} -->
 
-   <para>
+   <simpara>
     Этот интерфейс не имеет методов. Его единственная цель - быть базовым интерфейсом для всех подписчиков событий.
-   </para>
+   </simpara>
 
   </section>
 

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-query.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>queryOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод создаёт новый объект <classname>MongoDB\Driver\Query</classname> —
    неизменяемый объект значения, который представляет запрос к базе данных.
    После этого запрос готов к выполнению методом
    <methodname>MongoDB\Driver\Manager::executeQuery</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -45,26 +45,26 @@
           <entry>allowDiskUse</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Разрешает БД MongoDB при обработке операции блочной сортировки
             хранить на диске временные файлы с данными,
             размер которых превышает 100-мегабайтный предел системной памяти.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>allowPartialResults</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Для запросов к шардированной коллекции вместо выдачи
             ошибки возвращает из процесса mongos частичные результаты,
             если отдельные шарды недоступны.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшей опции <literal>"partial"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -81,16 +81,16 @@
           <entry>batchSize</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Устанавливает количество документов для возврата в первом пакете. Значение
             по умолчанию равно 101. Размер пакета 0 означает, что курсор установится,
             но документы не вернутся в первом пакете.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             В версиях MongoDB до 3.2, в которых запросы работают по устаревшему проводному
             протоколу OP_QUERY, размер пакета со значением 1 закроет курсор
             независимо от количества совпадающих документов.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -98,72 +98,72 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Добавляет произвольный комментарий, который помогает отслеживать операцию
             через профилировщик базы данных, данные, которые выводит метод CurrentOp, и журналы.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Комментарий добавляют в виде допустимого для MongoDB 4.4+ BSON-типа.
             Предыдущие версии сервера поддерживают только строковые значения.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$comment"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>exhaust</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Настраивает запрос на потоковую передачу данных клиенту на полную мощность в нескольких
             «дополнительных» пакетах при условии, что клиент прочитает все данные, которые запросил.
             Опция уменьшает задержку, когда извлекается много данных и известно, что требуется извлечь
             все данные. Примечание: клиенту требуется прочитать все данные
             или закрыть соединение.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Опция не поддерживается командой find в MongoDB 3.2+
             и заставит драйвер использовать устаревшую версию проводного протокола (то есть
             OP_QUERY).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>explain</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Со значением &true; курсор <classname>MongoDB\Driver\Cursor</classname>,
             который вернёт команда или запрос, будет содержать один документ, который
             описывает план запроса: процесс и индексы, которые БД использует, чтобы вернуть запрос.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$explain"</literal>,
             если эту опцию не указали.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Команда find в БД MongoDB 3.2+ не поддерживает эту опцию, опцию учитывает только устаревшая
             версия проводного протокола — с кодом операции OP_QUERY в заголовке сообщения.
             В БД MongoDB 3.0+ вместо этой опции пользуются командой
             <link xlink:href="&url.mongodb.docs;reference/command/explain/">explain</link>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Устанавливает спецификацию индекса. Значение опции указывают либо как название индекса в виде строки,
             либо как шаблон ключа индекса. С этой опцией система запросов будет рассматривать
             только планы запроса с подсказкой индекса.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшей опции <literal>"hint"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -171,63 +171,63 @@
           <entry>limit</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Параметр устанавливает максимальное количество документов для возврата. По умолчанию ограничений нет,
             если опцию не указали. Значение 0 — то же, что отмена ограничения.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>max</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Устанавливает <emphasis>эксклюзивную</emphasis> верхнюю границу для конкретного индекса.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$max"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Принимает положительное целое число, которое устанавливает ограничение времени в миллисекундах,
             в течение которого серверу разрешается заблокировать операцию getMore при недоступности данных.
             Опцию указывают только в сочетании с опциями
             <literal>"tailable"</literal> и <literal>"awaitData"</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Совокупный лимит времени в миллисекундах для операций
             обработки на курсоре. БД MongoDB прерывает операцию в ближайшей
             следующей точке прерывания.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$maxTimeMS"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>min</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             <emphasis>Инклюзивная</emphasis> нижняя граница для конкретного индекса.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$min"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -242,63 +242,63 @@
           <entry>projection</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             <link xlink:href="&url.mongodb.docs;tutorial/project-fields-from-query-results/">Спецификация проекции</link>,
             которая помогает определить, какие поля включать в документы, которые возвращает БД.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             В проекцию включают поле <property>__pclass</property>,
             если при работе <link linkend="mongodb.persistence.deserialization">с функциями ODM</link>
             требуется десериализовать документы в их исходный PHP-класс.
             Десериализация будет работать только с этим полем, а без него модуль по умолчанию вернёт
             объект класса <classname>stdClass</classname>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>readConcern</entry>
           <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Определяет уровень изоляции для операций чтения. По умолчанию модуль использует
             ограничения считывания
             <link linkend="mongodb-driver-manager.construct-uri">из URI-идентификатора подключения к БД MongoDB</link>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Эта опция доступна в MongoDB 3.2+ и выбросит исключение
             во время выполнения, если опцию указали для более старой
             версии сервера.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>returnKey</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Со значением &true; опция возвращает в результирующих документах только индексные ключи.
             Значением по умолчанию равно &false;. Документы, которые вернёт БД, будут пустыми,
             если для опции указали значение &true;, а команда find не использует индекс.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$returnKey"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>showRecordId</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Определяет, возвращать ли идентификатор записи для каждого
             документа. Со значением &true; опция добавляет поле <literal>"$recordId"</literal>
             верхнего уровня к документам, которые возвращает БД.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$showDiskLoc"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -321,11 +321,11 @@
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>Спецификация сортировки для упорядочения результатов.</para>
-           <para>
+           <simpara>Спецификация сортировки для упорядочения результатов.</simpara>
+           <simpara>
             Драйвер откатится к считыванию устаревшего модификатора <literal>"$orderby"</literal>,
             если эту опцию не указали.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -353,118 +353,116 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        <para>
-         Параметр <literal>"partial"</literal> удалили. Вместо него указывают
-         параметр <literal>"allowPartialResults"</literal>.
-        </para>
-        <para>
-         Параметр <literal>"maxScan"</literal> удалили. Поддержку параметра
-         удалили в MongoDB 4.2.
-        </para>
-        <para>
-         Параметр <literal>"modifiers"</literal> удалили. Параметр указывали
-         для устаревших модификаторов запроса, которые устарели.
-        </para>
-        <para>
-         Параметр <literal>"oplogReplay"</literal> удалили. Параметр игнорировали
-         СУБД MongoDB 4.4 и новее.
-        </para>
-        <para>
-         Параметр <literal>"snapshot"</literal> удалили. Поддержку параметра
-         удалили в MongoDB 4.0.
-        </para>
-        <para>
-         Отрицательное значение в параметре <literal>"limit"</literal> больше
-         не интерпретируется как значение &true; для параметра <literal>"singleBatch"</literal>. Одну
-         часть результатов получают путём объединения положительного значения
-         в параметре <literal>"limit"</literal>
-         с параметром <literal>"singleBatch"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.14.0</entry>
-       <entry>
-        <para>
-         Добавили опцию <literal>"let"</literal>. Опция
-         <literal>"comment"</literal> теперь принимает любой тип.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.8.0</entry>
-       <entry>
-        <para>
-         Добавили опцию <literal>"allowDiskUse"</literal>.
-        </para>
-        <para>
-         Опция <literal>"oplogReplay"</literal> устарела.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.5.0</entry>
-       <entry>
-        <para>
-         Опции <literal>"maxScan"</literal> и <literal>"snapshot"</literal>
-         устарели.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         Добавили опцию <literal>"maxAwaitTimeMS"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Добавили опции <literal>"allowPartialResults"</literal>,
-         <literal>"collation"</literal>, <literal>"comment"</literal>,
-         <literal>"hint"</literal>, <literal>"max"</literal>,
-         <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
-         <literal>"min"</literal>, <literal>"returnKey"</literal>,
-         <literal>"showRecordId"</literal> и <literal>"snapshot"</literal>.
-        </para>
-        <para>
-         Опцию <literal>"partial"</literal> переименовали
-         в <literal>"allowPartialResults"</literal>. В целях обратной совместимости
-         опция <literal>"partial"</literal> по-прежнему будет считываться,
-         если опцию <literal>"allowPartialResults"</literal> не указали.
-        </para>
-        <para>
-         Удалили устаревший параметр <literal>"secondaryOk"</literal>.
-         Для запросов, которые работают по устаревшему проводному протоколу OP_QUERY,
-         драйвер по мере необходимости установит бит <literal>secondaryOk</literal> по правилам
-         <link xlink:href="&url.mongodb.serverselection;">Спецификации выбора сервера</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.1.0</entry>
-       <entry>Добавили опцию <literal>"readConcern"</literal>.</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       <simpara>
+        Параметр <literal>"partial"</literal> удалили. Вместо него указывают
+        параметр <literal>"allowPartialResults"</literal>.
+       </simpara>
+       <simpara>
+        Параметр <literal>"maxScan"</literal> удалили. Поддержку параметра
+        удалили в MongoDB 4.2.
+       </simpara>
+       <simpara>
+        Параметр <literal>"modifiers"</literal> удалили. Параметр указывали
+        для устаревших модификаторов запроса, которые устарели.
+       </simpara>
+       <simpara>
+        Параметр <literal>"oplogReplay"</literal> удалили. Параметр игнорировали
+        СУБД MongoDB 4.4 и новее.
+       </simpara>
+       <simpara>
+        Параметр <literal>"snapshot"</literal> удалили. Поддержку параметра
+        удалили в MongoDB 4.0.
+       </simpara>
+       <simpara>
+        Отрицательное значение в параметре <literal>"limit"</literal> больше
+        не интерпретируется как значение &true; для параметра <literal>"singleBatch"</literal>. Одну
+        часть результатов получают путём объединения положительного значения
+        в параметре <literal>"limit"</literal>
+        с параметром <literal>"singleBatch"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.14.0</entry>
+      <entry>
+       <simpara>
+        Добавили опцию <literal>"let"</literal>. Опция
+        <literal>"comment"</literal> теперь принимает любой тип.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.8.0</entry>
+      <entry>
+       <simpara>
+        Добавили опцию <literal>"allowDiskUse"</literal>.
+       </simpara>
+       <simpara>
+        Опция <literal>"oplogReplay"</literal> устарела.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.5.0</entry>
+      <entry>
+       <simpara>
+        Опции <literal>"maxScan"</literal> и <literal>"snapshot"</literal>
+        устарели.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        Добавили опцию <literal>"maxAwaitTimeMS"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Добавили опции <literal>"allowPartialResults"</literal>,
+        <literal>"collation"</literal>, <literal>"comment"</literal>,
+        <literal>"hint"</literal>, <literal>"max"</literal>,
+        <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
+        <literal>"min"</literal>, <literal>"returnKey"</literal>,
+        <literal>"showRecordId"</literal> и <literal>"snapshot"</literal>.
+       </simpara>
+       <simpara>
+        Опцию <literal>"partial"</literal> переименовали
+        в <literal>"allowPartialResults"</literal>. В целях обратной совместимости
+        опция <literal>"partial"</literal> по-прежнему будет считываться,
+        если опцию <literal>"allowPartialResults"</literal> не указали.
+       </simpara>
+       <simpara>
+        Удалили устаревший параметр <literal>"secondaryOk"</literal>.
+        Для запросов, которые работают по устаревшему проводному протоколу OP_QUERY,
+        драйвер по мере необходимости установит бит <literal>secondaryOk</literal> по правилам
+        <link xlink:href="&url.mongodb.serverselection;">Спецификации выбора сервера</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.1.0</entry>
+      <entry>Добавили опцию <literal>"readConcern"</literal>.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод создаёт новый объект <classname>MongoDB\Driver\ReadPreference</classname> —
    неизменяемый объект значения.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,45 +41,45 @@
          <row>
           <entry><literal>"primary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Операции считываются из текущего первичного узла набора реплик.
             Это предпочтение чтения по умолчанию для БД MongoDB.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             В большей части случаев операции считываются из первичного узла,
             но если узел недоступен, операции считываются из вторичных узлов.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Операции считываются из вторичных узлов набора реплик.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             В большей части случаев операции считываются из вторичных членов,
             но если вторичные члены недоступны, операции считываются из первичного узла.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"nearest"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Операции считываются из члена набора реплик с наименьшей задержкой сети,
             независимо от типа члена.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -91,7 +91,7 @@
    <varlistentry>
     <term><parameter>tagSets</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Наборы тегов разрешают нацеливать операции чтения на конкретных членов
       набора реплик. Аргумент формируют как массив ассоциативных массивов, каждый
       из которых содержит ноль или больше пар ключ-значение. Для операции чтения драйвер выбирает
@@ -99,14 +99,14 @@
       ассоциативного массива пар ключей и значений. Драйвер
       выполнит попытку со следующими наборами, если не получилось выбрать узел. Пустой набор тегов
       <literal>array()</literal> совпадёт с любым узлом, его передают как запасной вариант.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Теги несовместимы с режимом <literal>"primary"</literal>, и по ним
       сервер чаще выбирает только вторичного члена набора для
       операции чтения. Между тем, при сочетании режима <literal>"nearest"</literal>
       с набором тегов драйвер выбирает члена с наименьшей задержкой в сети.
       Тогда членом, которого выберет драйвер, окажется первичный или вторичный узел.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -128,14 +128,14 @@
           <entry>hedge</entry>
           <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Определяет, использовать ли
             <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">
              хеджированные считывания
             </link>,
             которые БД MongoDB 4.4+ поддерживают для шардированных запросов.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Хеджированные считывания с сервера доступны для непервичных предпочтений чтения
             и включаются по умолчанию в режиме <literal>"nearest"</literal>.
             Через эту опцию явно разрешают серверу считывание с хеджированием
@@ -143,36 +143,36 @@
             <literal>['enabled' => true]</literal> или явно запрещают
             серверу чтения с хеджированием для предпочтения чтения в режиме <literal>"nearest"</literal>
             путём установки аргумента <literal>['enabled' => false]</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxStalenessSeconds</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Определяет максимальное отставание репликации (англ. staleness) для чтения
             из вторичных узлов. Когда по оценке клиента отставания репликации вторичных узлов
             превышает это значение, драйвер прекращает использовать отставание для операций чтения.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Максимальное значение отставания репликации указывают как 32-битное целое число со знаком,
             которое больше или равно значению константы
             <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Значение по умолчанию для опции равно значению константы
             <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>.
             При таком значении драйвер не будет учитывать отставания репликаций вторичных узлов
             при выборе направления для операции чтения.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Опция несовместима с режимом <literal>"primary"</literal>.
             Со значением максимального отставания репликации умеют работать
             только экземпляры MongoDB с БД MongoDB 3.4+ в развёртывании.
             Метод выбросит исключение во время выполнения, если версия сервера хотя бы одного
             экземпляра MongoDB в развёртывании старее.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -207,59 +207,57 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Передача значения с типом <type>int</type> в аргументе <parameter>mode</parameter>
-        больше не поддерживается.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.20.0</entry>
-       <entry>
-        Передача целых чисел (<type>int</type>) в аргументе <parameter>mode</parameter>
-        <emphasis>УСТАРЕЛА</emphasis>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.8.0</entry>
-       <entry>
-        Добававили опцию <literal>"hedge"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         Параметр <parameter>mode</parameter> теперь принимает строковое значение,
-         которое соответствует URI-опции <literal>"readPreference"</literal>
-         метода <function>MongoDB\Driver\Manager::__construct</function>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Добавили в сигнатуру метода третий параметр — <parameter>options</parameter>,
-         который поддерживает опцию <literal>"maxStalenessSeconds"</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Передача значения с типом <type>int</type> в аргументе <parameter>mode</parameter>
+       больше не поддерживается.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.20.0</entry>
+      <entry>
+       Передача целых чисел (<type>int</type>) в аргументе <parameter>mode</parameter>
+       <emphasis>УСТАРЕЛА</emphasis>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.8.0</entry>
+      <entry>
+       Добававили опцию <literal>"hedge"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        Параметр <parameter>mode</parameter> теперь принимает строковое значение,
+        которое соответствует URI-опции <literal>"readPreference"</literal>
+        метода <function>MongoDB\Driver\Manager::__construct</function>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Добавили в сигнатуру метода третий параметр — <parameter>options</parameter>,
+        который поддерживает опцию <literal>"maxStalenessSeconds"</literal>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/getmode.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.getmode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Метод <emphasis>УСТАРЕЛ</emphasis> с модуля версии
     1.20.0, а в версии 2.0 метод удалили. Вместо этого метода приложениям лучше вызывать
     метод <methodname>MongoDB\Driver\ReadPreference::getModeString</methodname>.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает параметр "mode" ReadPreference
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -46,21 +46,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/server/construct.xml
+++ b/reference/mongodb/mongodb/driver/server/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dcfd0933c0adfb15d1efafa5c553b2e57c03d3a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,13 +14,13 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Server::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Объекты <classname>MongoDB\Driver\Server</classname> создаются внутри
    <classname>MongoDB\Driver\Manager</classname>, когда соединение с базой данных
    установлено и могут быть возвращены
    <function>MongoDB\Driver\Manager::getServers</function> и
    <function>MongoDB\Driver\Manager::selectServer</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,21 +15,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет одну или несколько операций записи на первичном сервере.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Объект <classname>MongoDB\Driver\BulkWrite</classname> создают
    с одной или набором операций записи разного типа, например обновления, удаления
    и вставки. Драйвер попытается отправить операции одного типа на сервер
    как можно меньшим количеством запросов, чтобы сократить обращения к серверу.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значение по умолчанию для параметра <literal>writeConcern</literal>
    метод получит из активной транзакции (указывает параметр
    <literal>session</literal>), за которой следует
    <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатор соединения</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -93,58 +93,56 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 2.0.0</entry>
-       <entry>
-        Параметр <parameter>options</parameter> больше не принимает
-        объекты <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.21.0</entry>
-       <entry>
-        Передача объекта <classname>MongoDB\Driver\WriteConcern</classname>
-        как опции параметра <parameter>options</parameter> устарела, а в версии 2.0 передачу объекта запретят.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.4</entry>
-       <entry>
-        Метод выбросит исключение
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если опцию <literal>"session"</literal> указать вместе
-        с неподтверждаемым уровнем записи.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.4.0</entry>
-       <entry>
-        Третий параметр <parameter>options</parameter> стал массивом опций,
-        но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.3.0</entry>
-       <entry>
-        Метод выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
-        если параметр <parameter>bulk</parameter> не содержит операций записи.
-        Раньше метод выбрасывал исключение <classname>MongoDB\Driver\Exception\BulkWriteException</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 2.0.0</entry>
+      <entry>
+       Параметр <parameter>options</parameter> больше не принимает
+       объекты <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.21.0</entry>
+      <entry>
+       Передача объекта <classname>MongoDB\Driver\WriteConcern</classname>
+       как опции параметра <parameter>options</parameter> устарела, а в версии 2.0 передачу объекта запретят.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.4</entry>
+      <entry>
+       Метод выбросит исключение
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если опцию <literal>"session"</literal> указать вместе
+       с неподтверждаемым уровнем записи.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.4.0</entry>
+      <entry>
+       Третий параметр <parameter>options</parameter> стал массивом опций,
+       но в целях обратной совместимости пока ещё принимает объект <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.3.0</entry>
+      <entry>
+       Метод выбрасывает исключение <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>,
+       если параметр <parameter>bulk</parameter> не содержит операций записи.
+       Раньше метод выбрасывал исключение <classname>MongoDB\Driver\Exception\BulkWriteException</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,22 +14,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод выполняет одну или несколько операций записи на текущем сервере
    командой <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>,
    которая появилась в MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Объект класса <classname>MongoDB\Driver\BulkWriteCommand</classname> создают
    с одной или несколькими операциями записи: вставки, обновления
    или удаления. Каждую операцию записи возможно нацелить на разные коллекции.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Значение по умолчанию для опции <literal>"writeConcern"</literal>
    автоматически определяется на основе активной транзакции
    или <link linkend="mongodb-driver-manager.construct-uri">URI-идентификатора соединения</link>, если транзакция не содержит значения.
    На активную транзакцию указывает опция <literal>"session"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Синхронизация разметки с английской версией: замена para на simpara и упрощение таблиц changelog. Текст перевода не изменён.