### PR TITLE
[Sync EN] MongoDB: чистка разметки (para → simpara), часть 1

### DIFF
--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Архитектура и внутреннее устройство драйвера</titleabbrev>
@@ -9,11 +9,11 @@
   <titleabbrev>Архитектура</titleabbrev>
   <title>Обзор архитектуры</title>
 
-  <para>
+  <simpara>
    Раздел объясняет, как разные части PHP-драйвера сочетаются
    друг с другом, от базовых системных библиотек, через PHP-модули и до
    PHP-библиотек на самом верху.
-  </para>
+  </simpara>
 
   <para>
    <mediaobject>
@@ -30,7 +30,7 @@
    </mediaobject>
   </para>
 
-  <para>
+  <simpara>
    Наверху стека расположена
    <link xlink:href="&url.mongodb.library;">библиотека PHP</link>, которая распространяется
    в виде <link xlink:href="&url.packagist.package;/mongodb/mongodb">пакета Composer</link>.
@@ -40,7 +40,7 @@
    <link xlink:href="&url.mongodb.specs;">спецификации</link>.
    Хотя модуль можно использовать напрямую, библиотека даёт минимальные накладные расходы
    и должна быть общей зависимостью для большей части приложений, построенных с MongoDB.
-  </para>
+  </simpara>
 
   <para>
    На уровень ниже библиотеки располагается PHP-модуль, который распространяется
@@ -97,15 +97,15 @@
   <section>
    <title>Сохранение соединения и топологии (версия PHP начиная с 1.2.0)</title>
 
-   <para>
+   <simpara>
     Каждая версия модуля начиная с 1.2.0 сохраняет клиентский объект
     <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>
     в рабочем процессе PHP, что позволяет ему повторно использовать соединения с базой данных,
     состояния аутентификации <emphasis>и</emphasis> информацию о топологии в
     нескольких запросах.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Когда вызывается метод <methodname>MongoDB\Driver\Manager::__construct</methodname>,
     из его аргументов создаётся хеш (т. е. строка URI и параметры
     массива). Модуль попытается найти ранее сохранённый клиентский объект
@@ -113,20 +113,20 @@
     этого хеша. Если существующий клиент не может быть найден для хеша, будет создан
     новый клиент и сохранён для будущего использования. Это поведение можно выключить
     через параметр драйвера <literal>"disableClientPersistence"</literal>.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Каждый клиент содержит свои собственные подключения к базе данных и представление
     топологии сервера (например, автономный, набор реплик, кластер сегментов). Сохраняя
     клиент между PHP-запросами, модуль может переиспользовать установленные
     подключения к базе данных и устранять необходимость
     <link xlink:href="&url.mongodb.sdam;">обнаружения топологии сервера</link>
     при каждом запросе.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Рассмотрим следующий пример:
-   </para>
+   </simpara>
 
    <programlisting role="php">
 <![CDATA[
@@ -147,7 +147,7 @@ foreach ($managers as $manager) {
 ]]>
    </programlisting>
 
-   <para>
+   <simpara>
     Первые два объекта Manager будут использовать один и тот же
     клиент <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>, поскольку
     их аргументы конструктора идентичны. Третий и четвёртый объекты будут
@@ -158,21 +158,21 @@ foreach ($managers as $manager) {
     Если драйвер обнаруживает дополнительных членов набора реплик после выполнения команд
     <literal>hello</literal>, он также открывает дополнительные подключения
     к этим серверам.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Если этот же процесс снова выполнит сценарий во втором запросе, эти три
     клиента будут использованы повторно, а новых подключений установлено не будет. В зависимости
     от того, как давно был обработан предыдущий запрос, модулю может потребоваться выполнить
     дополнительные команды <literal>hello</literal> для обновления своего представления
     топологий.
-   </para>
+   </simpara>
   </section>
 
   <section>
    <title>Сохранение сокетов (версии PHP до 1.2.0)</title>
 
-   <para>
+   <simpara>
     Версии модуля до 1.2.0 используют API-интерфейс PHP-потоков
     для подключений к базам данных через внутренний API-интерфейс библиотеки
     <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>, чтобы назначить пользовательские
@@ -182,14 +182,14 @@ foreach ($managers as $manager) {
     или топологии. Поэтому модулю приходится выдавать
     команды в начале каждого запроса, чтобы проверить подлинность
     и <link xlink:href="&url.mongodb.sdam;">обнаружить топологию сервера</link>.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Соединения с базой данных сохраняются как хеш хоста,
     порта и строки URI-идентификатора сервера, которую передавали в конструктор
     менеджера <classname>MongoDB\Driver\Manager</classname>. Параметры массива конструктора
     не включаются в этот хеш.
-   </para>
+   </simpara>
 
    <note>
     <simpara>
@@ -200,12 +200,12 @@ foreach ($managers as $manager) {
     </simpara>
    </note>
 
-   <para>
+   <simpara>
     Несмотря на недостатки, которые связаны с сохранением SSL-соединений и информацией о топологии,
     эта версия модуля поддерживает все
     <link linkend="context.ssl">параметры SSL-контекста</link>, поскольку использует
     API-интерфейс потоков PHP.
-   </para>
+   </simpara>
   </section>
  </section>
 
@@ -213,10 +213,10 @@ foreach ($managers as $manager) {
   <titleabbrev>Сохранение данных</titleabbrev>
   <title>Сериализация и десериализация PHP-переменных в модуле MongoDB</title>
 
-  <para>
+  <simpara>
    В документе обсуждается, как составные структуры наподобие документов, массивов
    и объектов преобразовываются между значениями формата BSON и PHP-значениями.
-  </para>
+  </simpara>
 
   <section xml:id="mongodb.persistence.serialization">
    <title>Сериализация в BSON</title>
@@ -224,28 +224,28 @@ foreach ($managers as $manager) {
    <section>
     <title>Массивы</title>
 
-    <para>
+    <simpara>
      Если массив представляет собой <emphasis>упакованный массив</emphasis> —
      то есть пустой массив или ключи начинаются
      с 0 и идут последовательно без пробелов: <emphasis>BSON-массив</emphasis>.
-    </para>
+    </simpara>
 
-    <para>
+    <simpara>
      Если массив не упакован — то есть содержит ассоциативные (строковые) ключи,
      ключи не начинаются с 0 или содержат пробелы: <emphasis>BSON-объект</emphasis>
-    </para>
+    </simpara>
 
-    <para>
+    <simpara>
      Документ верхнего уровня (корневой) <emphasis>всегда</emphasis> сериализуется
      как BSON-документ.
-    </para>
+    </simpara>
 
     <section>
      <title>Примеры</title>
 
-     <para>
+     <simpara>
       Эти PHP-массивы сериализуются как BSON-массив:
-     </para>
+     </simpara>
 
      <programlisting role="text">
 <![CDATA[
@@ -254,9 +254,9 @@ foreach ($managers as $manager) {
 ]]>
      </programlisting>
 
-     <para>
+     <simpara>
       Эти PHP-массивы сериализуются как BSON-документ:
-     </para>
+     </simpara>
 
      <programlisting role="text">
 <![CDATA[
@@ -266,11 +266,11 @@ foreach ($managers as $manager) {
 ]]>
      </programlisting>
 
-     <para>
+     <simpara>
       Обратите внимание, что пять приведённых примеров — <emphasis>выдержки</emphasis> из полного
       документа и представляют только <emphasis>одно</emphasis> значение внутри
       документа.
-     </para>
+     </simpara>
 
     </section>
    </section>
@@ -278,12 +278,12 @@ foreach ($managers as $manager) {
    <section>
     <title>Объекты</title>
 
-     <para>
+     <simpara>
       Если объект принадлежит типу <classname>stdClass</classname>, он сериализуется
       как <emphasis>BSON-документ</emphasis>.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Если объект — поддерживаемый класс, который реализует
       интерфейс <interfacename>MongoDB\BSON\Type</interfacename>, используется
       логика сериализации BSON для этого конкретного типа.
@@ -292,66 +292,66 @@ foreach ($managers as $manager) {
       сериализовать только как значение поля документа. Попытка сериализовать такой объект
       как корневой документ выбросит исключение
       <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Если объект принадлежит неизвестному классу, который реализует интерфейс
       <interfacename>MongoDB\BSON\Type</interfacename>, выбрасывается исключение
       <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Если объект принадлежит какому-либо другому классу без реализации какого-либо специального
       интерфейса, он сериализуется как <emphasis>BSON-документ</emphasis>. Остаются только
       открытые (<emphasis>public</emphasis>) свойства, а защищённые (<emphasis>protected</emphasis>)
       и закрытые (<emphasis>private</emphasis>) свойства игнорируются.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Если объект принадлежит к классу, который реализует интерфейс
       <interfacename>MongoDB\BSON\Serializable</interfacename>, вызывают
       метод <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
       и сериализуют массив или <classname>stdClass</classname>, которые возвращает метод,
       как BSON-документ или как BSON-массив. Тип BSON определят следующие условия:
-     </para>
+     </simpara>
 
      <para>
       <orderedlist>
        <listitem>
-        <para>Корневые документы требуется сериализовать
+        <simpara>Корневые документы требуется сериализовать
          как BSON-документ.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Объекты с типом <interfacename>MongoDB\BSON\Persistable</interfacename> требуется
          сериализовать как BSON-документы.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Если метод <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
          возвращает упакованный массив, его сериализуют как BSON-массив.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Если метод <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
          возвращает неупакованный массив или объект <classname>stdClass</classname>,
          его сериализуют как BSON-документ.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Если метод <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
          не вернул массив или объект <classname>stdClass</classname>, выбрасывается исключение
          <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>.
-        </para>
+        </simpara>
        </listitem>
       </orderedlist>
      </para>
 
-     <para>
+     <simpara>
       Если объект принадлежит классу, который реализует интерфейс
       <interfacename>MongoDB\BSON\Persistable</interfacename> (что
       подразумевает реализацию метода <interfacename>MongoDB\BSON\Serializable</interfacename>),
@@ -360,9 +360,9 @@ foreach ($managers as $manager) {
       <property>__pclass</property> в виде Binary-значения с подтипом
       <literal>0x80</literal> и данными, которые содержат полное имя класса объекта,
       который сериализуется.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Свойство <property>__pclass</property> добавляется в массив или
       объект, который возвращает метод
       <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>,
@@ -373,7 +373,7 @@ foreach ($managers as $manager) {
       реализации интерфейса <interfacename>MongoDB\BSON\Persistable</interfacename>
       следует напрямую реализовать интерфейс
       <interfacename>MongoDB\BSON\Serializable</interfacename>.
-     </para>
+     </simpara>
 
      <section>
       <title>Примеры</title>
@@ -539,7 +539,7 @@ class UpperClass implements MongoDB\BSON\Persistable
 
    &mongodb.warning.duplicate-keys;
 
-   <para>
+   <simpara>
     Устаревший модуль <code>mongo</code> десериализовывал
     BSON-документы и BSON-массивы в PHP-массивы. Хотя с PHP-массивами
     удобно работать, такое поведение было проблематичным, поскольку разные
@@ -548,36 +548,36 @@ class UpperClass implements MongoDB\BSON\Persistable
     невозможным определение оригинального BSON-типа. По умолчанию модуль <code>mongodb</code>
     решает эту проблему и гарантирует, что BSON-массивы преобразуются в PHP-массивы, а BSON-документы
     в PHP-объекты.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Для составных типов существует три типа данных:
-   </para>
+   </simpara>
 
    <para>
     <variablelist>
      <varlistentry>
       <term>root</term>
       <listitem>
-       <para>
+       <simpara>
         относится <emphasis>только</emphasis> к BSON-документу верхнего уровня
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry>
       <term>document</term>
       <listitem>
-       <para>
+       <simpara>
         относится <emphasis>только</emphasis> к встроенным BSON-документам
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry>
       <term>array</term>
       <listitem>
-       <para>
+       <simpara>
         относится к BSON-массивам
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
     </variablelist>
@@ -604,10 +604,10 @@ class UpperClass implements MongoDB\BSON\Persistable
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Каждый из этих трёх типов данных, а также сопоставления конкретных полей
     можно сопоставить с различными типами PHP. Возможные значения сопоставления:
-   </para>
+   </simpara>
 
    <para>
     <variablelist>
@@ -617,35 +617,35 @@ class UpperClass implements MongoDB\BSON\Persistable
        <para>
         <itemizedlist>
          <listitem>
-          <para>
+          <simpara>
            BSON-массив будет десериализован как PHP-массив (<type>array</type>).
-          </para>
+          </simpara>
          </listitem>
          <listitem>
-          <para>
+          <simpara>
            BSON-документ (корневой или встроенный) без свойства
            <property>__pclass</property>
            <footnote xml:id="mongodb.pclass">
-            <para>
+            <simpara>
              Свойство __pclass считается существующим, только
              если существует свойство с таким именем, и оно представляет собой Binary-значение,
              а подтип Binary значения равен 0x80. Если какое-либо из этих трёх
              условий не выполняется, свойство __pclass не существует
              и должно рассматриваться как любое другое обычное свойство.
-            </para>
+            </simpara>
            </footnote>
            становится PHP-объектом <classname>stdClass</classname>, причём каждый
            ключ BSON-документа устанавливается как открытое
            свойство объекта <classname>stdClass</classname>.
-          </para>
+          </simpara>
          </listitem>
          <listitem>
-          <para>
+          <simpara>
            BSON-документ (корневой или встроенный) со свойством
            <property>__pclass</property> <footnoteref linkend="mongodb.pclass"/> становится PHP-объектом
            имени класса, как это определяет свойство <property>__pclass</property>.
-          </para>
-          <para>
+          </simpara>
+          <simpara>
            Если именованный класс реализует интерфейс
            M<interfacename>MongoDB\BSON\Persistable</interfacename>,
            то свойства BSON-документа, включая свойство
@@ -653,21 +653,21 @@ class UpperClass implements MongoDB\BSON\Persistable
            массив в метод
            <methodname>MongoDB\BSON\Unserializable::bsonUnserialize</methodname>,
            чтобы инициализировать свойства объекта.
-          </para>
-          <para>
+          </simpara>
+          <simpara>
            Если именованный класс не существует или не реализует интерфейс
            <interfacename>MongoDB\BSON\Persistable</interfacename>,
            будет использоваться объект <classname>stdClass</classname>, и каждый ключ BSON-документа
            (включая свойство <property>__pclass</property>) будет установлен
            как открытое свойство объекта <classname>stdClass</classname>.
-          </para>
-          <para>
+          </simpara>
+          <simpara>
            Функциональность свойства <property>__pclass</property> зависит от того, представляет ли
            собой свойство часть извлечённого документа БД MongoDB. Если при запросе документов
            используется <link linkend="mongodb-driver-query.construct-queryOptions">проекция</link>,
            необходимо включить в проекцию поле <property>__pclass</property>,
            чтобы эта функциональность работала.
-          </para>
+          </simpara>
          </listitem>
         </itemizedlist>
        </para>
@@ -677,37 +677,37 @@ class UpperClass implements MongoDB\BSON\Persistable
      <varlistentry>
       <term><literal>«array»</literal></term>
       <listitem>
-       <para>
+       <simpara>
         Превращает BSON-массив или BSON-документ в PHP-массив. Специальной обработки
         свойства <property>__pclass</property> <footnoteref linkend="mongodb.pclass"/> не будет,
         но его можно установить как элемент в возвращаемом массиве, если он
         содержался в BSON-документе.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
 
      <varlistentry>
       <term><literal>«object»</literal> или <literal>«stdClass»</literal></term>
       <listitem>
-       <para>
+       <simpara>
         Превращает BSON-массив или BSON-документ в объект
         <classname>stdClass</classname>. Специальной
         обработки свойства <property>__pclass</property> <footnoteref linkend="mongodb.pclass"/> не будет,
         но его можно установить как открытое свойство в возвращаемом объекте, если оно присутствовало
         в BSON-документе.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
 
      <varlistentry>
       <term><literal>«bson»</literal></term>
       <listitem>
-       <para>
+       <simpara>
         Превращает BSON-массив в объект <classname>MongoDB\BSON\PackedArray</classname>,
         а BSON-документ в объект <classname>MongoDB\BSON\Document</classname>,
         независимо от того, есть ли у BSON-документа свойство <property>__pclass</property>
         <footnoteref linkend="mongodb.pclass"/>.
-       </para>
+       </simpara>
        <note>
         <simpara>
          Значение <literal>bson</literal> доступно только для трёх корневых типов,
@@ -720,33 +720,33 @@ class UpperClass implements MongoDB\BSON\Persistable
      <varlistentry>
       <term>любая другая строка</term>
       <listitem>
-       <para>
+       <simpara>
         Определяет имя класса, который должен десериализовать BSON-массив
         или BSON-объект. Для BSON-объектов, которые содержат свойства
         <property>__pclass</property>, этот класс будет приоритетным.
-       </para>
+       </simpara>
 
-       <para>
+       <simpara>
         Если именованный класс не существует, не представляет собой конкретный класс (то есть это
         абстрактный класс или интерфейс) или не реализует
         интерфейс <interfacename>MongoDB\BSON\Unserializable</interfacename>, выбрасывается исключение
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>.
-       </para>
+       </simpara>
 
-       <para>
+       <simpara>
         Если BSON-объект содержит свойство <property>__pclass</property> и
         этот класс существует и реализует
         интерфейс <interfacename>MongoDB\BSON\Persistable</interfacename>,
         он заменит класс, представленный в карте типов.
-       </para>
+       </simpara>
 
-       <para>
+       <simpara>
         Свойства BSON-документа, <emphasis>включая</emphasis>
         свойство <property>__pclass</property>, если оно существует, отправляются
         как ассоциативный массив в метод
         <methodname>MongoDB\BSON\Unserializable::bsonUnserialize</methodname>,
         чтобы инициализировать свойства объекта.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
     </variablelist>
@@ -755,7 +755,7 @@ class UpperClass implements MongoDB\BSON\Persistable
    <section xml:id="mongodb.persistence.typemaps">
     <title>TypeMaps</title>
 
-     <para>
+     <simpara>
       Функции настройки TypeMaps можно установить методом
       <methodname>MongoDB\Driver\Cursor::setTypeMap</methodname> для объекта
       <classname>MongoDB\Driver\Cursor</classname> или аргумента
@@ -766,55 +766,55 @@ class UpperClass implements MongoDB\BSON\Persistable
       классов (<emphasis>root</emphasis>, <emphasis>document</emphasis>, и
       <emphasis>array</emphasis>) можно задать индивидуально, в дополнение
       к типам полей.
-     </para>
+     </simpara>
 
-     <para>
+     <simpara>
       Если значение на карте равно <type>NULL</type>, это означает то же,
       что и значение <emphasis>по умолчанию</emphasis> для этого элемента.
-     </para>
+     </simpara>
     </section>
 
     <section>
      <title>Примеры</title>
 
-     <para>
+     <simpara>
       В этих примерах используются следующие классы:
-     </para>
+     </simpara>
 
      <para>
       <variablelist>
        <varlistentry>
         <term>MyClass</term>
         <listitem>
-         <para>
+         <simpara>
           <emphasis>не</emphasis> реализует интерфейсы
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
        <varlistentry>
         <term>YourClass</term>
         <listitem>
-         <para>
+         <simpara>
           реализует интерфейс
           <interfacename>MongoDB\BSON\Unserializable</interfacename>
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
        <varlistentry>
         <term>OurClass</term>
         <listitem>
-         <para>
+         <simpara>
           реализует интерфейс
           <interfacename>MongoDB\BSON\Persistable</interfacename>
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
        <varlistentry>
         <term>TheirClass</term>
         <listitem>
-         <para>
+         <simpara>
           расширяет класс OurClass
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -7,10 +7,10 @@
  <section xml:id="mongodb.installation.pecl">
   <title>Установка PHP-модуля MongoDB через репозиторий PECL</title>
 
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;mongodb">&url.pecl.package;mongodb</link>
-  </para>
+  </simpara>
 
   <para>
    Пользователи Linux, Unix и macOS запускают следующую команду для установки модуля:
@@ -21,14 +21,14 @@ $ sudo pecl install mongodb
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    На системах с несколькими установленными версиями PHP (например для macOS:
    установка по умолчанию, Homebrew
    и <link xlink:href="&url.xampp;">XAMPP</link>) у каждой версии PHP
    будет своя команда <link linkend="install.pecl">pecl</link>
    и файл (или файлы) &php.ini;. Кроме того, каждому PHP-окружению наподобие CLI или web
    разрешается использовать отдельные файлы &php.ini;.
-  </para>
+  </simpara>
 
   <para>
    Начиная с версии модуля 1.17.0 PECL будет запрашивать разные
@@ -57,14 +57,14 @@ $ sudo pecl install --configureoptions='with-mongodb-system-libs="yes" enable-mo
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    По умолчанию установка модуля через PECL использует
    встроенные версии модулей:
    <link xlink:href="&url.mongodb.libbson;">libbson</link>,
    <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>,
    <link xlink:href="&url.mongodb.libmongocrypt;">libmongocrypt</link>
    и попытается сконфигурировать их автоматически.
-  </para>
+  </simpara>
 
   <note>
    <simpara>
@@ -90,7 +90,7 @@ extension=mongodb.so
  <section xml:id="mongodb.installation.homebrew">
   <title>Установка PHP-модуля MongoDB в операционную систему macOS через менеджер пакетов Homebrew</title>
 
-  <para>
+  <simpara>
    Начиная с <link xlink:href="&url.brew.1.5.0;">Homebrew 1.5.0</link>
    пакет <link xlink:href="&url.mac.homebrew;">Homebrew/php tap</link>
    объявили устаревшим, а формулы для отдельных модулей PHP удалили.
@@ -99,19 +99,19 @@ extension=mongodb.so
    и запускать предоставленную PHP, установленным через менеджер пакетов Homebrew,
    команду <link linkend="install.pecl">pecl</link>, как рассказывает
    стандартная <link linkend="mongodb.installation.pecl">инструкция по установке из репозитория PECL</link>.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="mongodb.installation.windows">
   <title>Установка PHP-модуля MongoDB в операционную систему Windows</title>
 
-  <para>
+  <simpara>
    Предварительно скомпилированные исполняемые файлы прикрепляются
    к <link xlink:href="&url.mongodb.github.new;/releases/">выпускам проекта на GitHub</link>.
    Архивы публикуются для разных комбинаций версии PHP, потоковой безопасности (TS или NTS)
    и архитектуры (x86 или x64). Определите правильный архив для PHP-окружения
    и извлеките файл <filename>php_mongodb.dll</filename> в директорию с модулями (по умолчанию "ext").
-  </para>
+  </simpara>
 
   <para>
    Добавьте следующую строку в файл &php.ini; для каждого окружения,
@@ -142,18 +142,18 @@ PHP Warning:  PHP Startup: Unable to load dynamic library 'mongodb'
    </simplelist>
   </para>
 
-  <para>
+  <simpara>
    Просмотр этих свойств доступен в выводе функции <function>phpinfo</function>.
    Дважды проверьте, что вывод функции <function>phpinfo</function> соответствует окружению,
    если в систему установили несколько версий PHP.
-  </para>
+  </simpara>
 
   <note>
    <title>Дополнительные DLL-зависимости для пользователей Windows</title>
-   <para>
+   <simpara>
     &ext.windows.path.dll;
     <filename>libsasl.dll</filename>
-   </para>
+   </simpara>
   </note>
  </section>
 
@@ -177,15 +177,15 @@ $ sudo make install
 ]]>
    </programlisting>
   </para>
-  <para>
+  <simpara>
    В системах с несколькими установленными версиями PHP (например, macOS: установка по умолчанию,
    Homebrew, <link xlink:href="&url.xampp;">XAMPP</link>)
    у каждой версии PHP будет своя команда <link linkend="install.pecl.phpize">phpize</link>
    и файл (или файлы) &php.ini;.
    Кроме того, каждое окружение PHP (например, CLI, web) может использовать отдельные файлы &php.ini;.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    По умолчанию модуль использует встроенные версии библиотек
    <link xlink:href="&url.mongodb.libbson;">libbson</link>,
    <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>
@@ -194,13 +194,13 @@ $ sudo make install
    параметра <literal>--with-mongodb-system-libs=yes</literal>
    команде <literal>configure</literal>,
    если эти библиотеки уже установили в систему.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Полный список параметров команды <literal>configure</literal> получают
    через запуск команды: <command>configure --help</command>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    При работе со встроенными версиями библиотек libmongoc и libmongocrypt,
    модуль также попытается выбрать SSL-библиотеку
    в соответствии с параметром
@@ -208,22 +208,22 @@ $ sudo make install
    Начиная с версии модуля 1.17.0 по умолчанию предпочтение отдаётся библиотеке OpenSSL.
    Предыдущие версии драйвера на системах с macOS по умолчанию выбирали Secure Transport,
    а на остальных платформах — OpenSSL.
-  </para>
+  </simpara>
 
   <note>
-   <para>
+   <simpara>
     Потребуется проверить, установили ли пакеты для разработки наподобие <literal>libssl-dev</literal>
     и пакет <link xlink:href="&url.mongodb.wiki.pkg-config;">pkg-config</link>,
     если процесс установки не найдёт SSL-библиотеку.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Система часто содержит набор версий библиотеки OpenSSL, когда
     пакетами на macOS управляют через утилиту Homebrew.
     Дополнительный путь, по которому программа <literal>pkg-config</literal>
     будет искать файлы, указывают в переменной среды <literal>PKG_CONFIG_PATH</literal>,
     чтобы выбрать правильную версию библиотеки OpenSSL.
-   </para>
+   </simpara>
   </note>
 
   <para>
@@ -250,11 +250,11 @@ $ php -i | grep extension_dir
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    Значение директивы <link linkend="ini.extension-dir">extension_dir</link> изменяют
    в файле &php.ini; или просто перемещают файл <filename>mongodb.so</filename> в правильную директорию,
    если директории отличаются.
-  </para>
+  </simpara>
 
   <para>
    И наконец, добавьте следующую строку в файл &php.ini; для каждого окружения,

--- a/reference/mongodb/mongodb/driver/clientencryption/construct.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ClientEncryption::__construct</methodname>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Создаёт новый объект <classname>MongoDB\Driver\ClientEncryption</classname> с указанными опциями.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -70,50 +70,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.16.0</entry>
-       <entry>
-        <para>
-         Провайдер AWS KMS для шифрования на стороне клиента теперь принимает параметр
-         <literal>"sessionToken"</literal>, который можно указывать для аутентификации
-         с временными учётными данными AWS.
-        </para>
-        <para>
-         Добавлена поддержка поля <literal>"tlsDisableOCSPEndpointCheck"</literal>
-         в опции <literal>"tlsOptions"</literal>.
-        </para>
-        <para>
-         Если для KMS-провайдеров <literal>"azure"</literal> или
-         <literal>"gcp"</literal> указан пустой документ,
-         драйвер попытается сконфигурировать провайдера, заполнив
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        <para>
-         Если для KMS-провайдера <literal>"aws"</literal> указан пустой документ,
-         драйвер попытается сконфигурировать провайдера, заполнив
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.16.0</entry>
+      <entry>
+       <simpara>
+        Провайдер AWS KMS для шифрования на стороне клиента теперь принимает параметр
+        <literal>"sessionToken"</literal>, который можно указывать для аутентификации
+        с временными учётными данными AWS.
+       </simpara>
+       <simpara>
+        Добавлена поддержка поля <literal>"tlsDisableOCSPEndpointCheck"</literal>
+        в опции <literal>"tlsOptions"</literal>.
+       </simpara>
+       <simpara>
+        Если для KMS-провайдеров <literal>"azure"</literal> или
+        <literal>"gcp"</literal> указан пустой документ,
+        драйвер попытается сконфигурировать провайдера, заполнив
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       <simpara>
+        Если для KMS-провайдера <literal>"aws"</literal> указан пустой документ,
+        драйвер попытается сконфигурировать провайдера, заполнив
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Автоматические учётные данные</link>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 592e10fe7c16ddd3dc1c99f16f7bb1823e9f5b68 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.createdatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type>string</type><parameter>kmsProvider</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Создаёт новый документ с ключом шифрования и кладёт его в коллекцию
    хранилища ключей.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
    <varlistentry>
     <term><parameter>kmsProvider</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Провайдер KMS (<literal>"local"</literal>, <literal>"aws"</literal>),
       который будет использоваться для шифрования нового ключа данных.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
@@ -52,12 +52,12 @@
           <entry>masterKey</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Документ masterKey определяет специфический для KMS ключ,
             используемый для шифрования нового ключа данных.
             Параметр обязателен, если параметр <parameter>kmsProvider</parameter>
             не является <literal>"local"</literal>.
-           </para>
+           </simpara>
            &mongodb.option.encryption.masterKey-options-by-provider;
           </entry>
          </row>
@@ -65,27 +65,27 @@
           <entry>keyAltNames</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Опциональный список альтернативных имён использующихся
             для ссылки на ключ. Если ключ создан с использованием
             альтернативных имён, то при шифровании можно ссылаться
             на уникальное альтернативное имя вместо
             <literal>_id</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>keyMaterial</entry>
           <entry><classname>MongoDB\BSON\Binary</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Необязательное 96-байтовое значение для использования в качестве материала
             пользовательского ключа для создаваемого ключа данных.
             Если задан keyMaterial, то используется пользовательский материал ключа
             для шифрования и расшифровки данных. В противном случае материал ключа
             для нового ключа данных генерируется из криптографически
             защищённого случайного устройства.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -99,10 +99,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает идентификатор нового ключа в виде объекта
    <classname>MongoDB\BSON\Binary</classname> с подтипом 4 (UUID).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -115,39 +115,37 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Добавлена опция <literal>"delegated"</literal> к параметрам masterKey поставщика KMIP.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        Добавлена опция <literal>"keyMaterial"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.10.0</entry>
-       <entry>
-        В качестве поставщиков KMS для шифрования на стороне клиента
-        теперь поддерживаются Azure и GCP.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Добавлена опция <literal>"delegated"</literal> к параметрам masterKey поставщика KMIP.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       Добавлена опция <literal>"keyMaterial"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.10.0</entry>
+      <entry>
+       В качестве поставщиков KMS для шифрования на стороне клиента
+       теперь поддерживаются Azure и GCP.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b63591939951b1551d47b40650fbfb4693490d16 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\ClientEncryption::decrypt</methodname>
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод расшифровывает значение.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Объект класса <classname>MongoDB\BSON\Binary</classname>
       с подтипом 6, который содержит зашифрованные данные.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,11 +35,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает расшифрованные данные в том виде, в котором данные
    передали в метод
    <function>MongoDB\Driver\ClientEncryption::encrypt</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.deletekey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::deleteKey</methodname>
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Удаляет документ с ключом с заданным UUID <parameter>keyId</parameter>
    из коллекции хранилища ключей.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>keyId</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Экземпляр <classname>MongoDB\BSON\Binary</classname> с подтипом 4 (UUID),
       идентифицирующий документ с ключом.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,10 +36,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Возвращает результат внутренней операции <literal>deleteOne</literal>
    над коллекцией хранилища ключей.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27aaf9a626b5711866a2e6957f568e3c31143760 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод шифрует данные.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Значение для шифрования. Метод шифрует любые значения,
       которые вставляются в БД MongoDB.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
@@ -38,10 +38,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает зашифрованные данные в виде объекта
    <classname>MongoDB\BSON\Binary</classname> с подтипом 6.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -57,41 +57,39 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 1.20.0</entry>
-       <entry>
-        В список опций параметра шифрования rangeOpts добавили опцию
-        индекса диапазона <literal>"trimFactor"</literal>. Опция диапазона
-        <literal>"sparsity"</literal> теперь необязательна.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.16.0</entry>
-       <entry>
-        В список параметров шифрования добавили параметр <literal>"rangeOpts"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL-модуль mongodb 1.14.0</entry>
-       <entry>
-        В список параметров шифрования добавили параметры
-        <literal>"contentionFactor"</literal> и <literal>"queryType"</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 1.20.0</entry>
+      <entry>
+       В список опций параметра шифрования rangeOpts добавили опцию
+       индекса диапазона <literal>"trimFactor"</literal>. Опция диапазона
+       <literal>"sparsity"</literal> теперь необязательна.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.16.0</entry>
+      <entry>
+       В список параметров шифрования добавили параметр <literal>"rangeOpts"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL-модуль mongodb 1.14.0</entry>
+      <entry>
+       В список параметров шифрования добавили параметры
+       <literal>"contentionFactor"</literal> и <literal>"queryType"</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27aaf9a626b5711866a2e6957f568e3c31143760 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-clientencryption.encryptexpression" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,20 +14,20 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>expr</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод шифрует совпадение или агрегированное выражение для запроса индекса диапазона.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Для выполнения запроса с зашифрованным диапазоном полезной нагрузки
    драйвер <classname>MongoDB\Driver\Manager</classname> конфигурируют
    с опцией <literal>"autoEncryption"</literal>.
    Опция <literal>"bypassQueryAnalysis"</literal> автоматического шифрования принимает значение &true;.
    Для опции автоматического шифрования <literal>"bypassAutoEncryption"</literal> устанавливают значение &false;.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Модуль пока не поддерживает запросы диапазонов для BSON-полей с типом Decimal128.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -37,18 +37,18 @@
    <varlistentry>
     <term><parameter>expr</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Соответствие или агрегированное выражение, которое требуется зашифровать.
       В выражениях указывают хотя бы один оператор из списка:
       <literal>$gt</literal>, <literal>$gte</literal>,
       <literal>$lt</literal> или <literal>$lte</literal>.
       Оператор верхнего уровня <literal>$and</literal> необходим,
       даже если используется только один оператор сравнения.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Пример поддерживаемого выражения соответствия (применяется для запросов
       и этапа агрегации <literal>$match</literal>) выглядит следующим образом:
-     </para>
+     </simpara>
      <programlisting role="text">
 <![CDATA[
 [
@@ -59,9 +59,9 @@
 ]
 ]]>
      </programlisting>
-     <para>
+     <simpara>
       Пример поддерживаемого агрегированного выражения выглядит следующим образом:
-     </para>
+     </simpara>
      <programlisting role="text">
 <![CDATA[
 [
@@ -80,9 +80,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Метод возвращает зашифрованное выражение в виде объекта.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -98,28 +98,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL-модуль mongodb 1.20.0</entry>
-       <entry>
-        В список опций параметра шифрования rangeOpts добавили опцию
-        индекса диапазона <literal>"trimFactor"</literal>.
-        Опция диапазона <literal>"sparsity"</literal> теперь необязательна.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL-модуль mongodb 1.20.0</entry>
+      <entry>
+       В список опций параметра шифрования rangeOpts добавили опцию
+       индекса диапазона <literal>"trimFactor"</literal>.
+       Опция диапазона <literal>"sparsity"</literal> теперь необязательна.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Синхронизация разметки с EN: замена `<para>` на `<simpara>` для встроенного содержимого и снятие обёртки `<para>` вокруг таблиц. Текст перевода не менялся.