### PR TITLE
MongoDB: исправление перевода (Server вместо Manager, лишнее слово)

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
@@ -95,8 +95,7 @@
    <simpara>
     Смешанные операции записи наподобие вставки, обновления или удаления отправляются
     на сервер одной командой
-    <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
-    command.
+    <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>.
    </simpara>
    <programlisting role="php">
 <![CDATA[

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -34,7 +34,7 @@
     <link xlink:href="&url.mongodb.docs;reference/command/update/">update</link>,
     или <link xlink:href="&url.mongodb.docs;reference/command/delete/">delete</link>
     команд. Пользователям рекомендуется пользоваться методом
-    <function>MongoDB\Driver\Manager::executeBulkWrite</function> для этих операций.
+    <function>MongoDB\Driver\Server::executeBulkWrite</function> для этих операций.
    </simpara>
   </note>
  </refsect1>


### PR DESCRIPTION
Две мелкие правки перевода в страницах MongoDB:

- Server::executeWriteCommand: ссылка указывала на MongoDB\Driver\Manager::executeBulkWrite, тогда как в EN указан MongoDB\Driver\Server::executeBulkWrite.
- Manager::executeBulkWriteCommand: убрано непереведённое английское слово command в конце фразы.