### PR TITLE
Sync EN: document fatal_error_backtraces INI directive

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6b48f364497107ae46f926bfc99a4e3d9d546316 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.other-changes">
  <title>Другие изменения</title>
@@ -410,8 +410,9 @@
    <title>Ядро PHP</title>
 
    <simpara>
-    Добавлен параметр fatal_error_backtraces для управления тем,
-    должны ли фатальные ошибки включать обратную трассировку.
+    Добавлен параметр <link
+    linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link> для
+    управления тем, должны ли фатальные ошибки включать обратную трассировку.
    </simpara>
 
    <simpara>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -28,7 +28,7 @@
       <entry>"1"</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>
-       Доступно с PHP 8.5.0
+       Доступно, начиная с PHP 8.5.0
       </entry>
      </row>
      <row>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="errorfunc.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
@@ -22,6 +22,14 @@
       <entry>NULL</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+      <entry>"1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>
+       Доступно с PHP 8.5.0
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.display-errors">display_errors</link></entry>
@@ -196,6 +204,24 @@
      </note>
     </listitem>
    </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Определяет, должны ли фатальные ошибки включать обратную трассировку.
+      Фатальными ошибками являются <constant>E_ERROR</constant>,
+      <constant>E_CORE_ERROR</constant>, <constant>E_COMPILE_ERROR</constant>,
+      <constant>E_USER_ERROR</constant>,
+      <constant>E_RECOVERABLE_ERROR</constant> и
+      <constant>E_PARSE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
    <varlistentry xml:id="ini.display-errors">
     <term>
      <parameter>display_errors</parameter>


### PR DESCRIPTION
Translates the new `fatal_error_backtraces` INI directive into the errorfunc configuration page and the 8.5 migration appendix.

Fixes #1453