### PR TITLE
Sync EN: document file mode element for proc_open descriptors

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6667724b8a42ba501172bc874dd1644a6744be0f Maintainer: tmn Status: ready -->
+<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -78,11 +78,12 @@
        <simplelist>
         <member>
          Массивом, описывающим канал (pipe) для передачи процессу. Первый
-         элемент — это дескриптор типа, второй - настройка для выбранного типа.
+         элемент — это дескриптор типа, а последующие элементы — настройки для выбранного типа.
          Возможные типы: <literal>pipe</literal> (второй элемент либо
          <literal>r</literal> для передачи процессу стороны канала для
          чтения, либо <literal>w</literal> для передачи стороны записи)
-         и <literal>file</literal> (второй элемент - имя файла).
+         и <literal>file</literal> (второй элемент - имя файла, а третий
+         элемент - режим файла, такой же, как у функции <function>fopen</function>).
          Обратите внимание, что всё, кроме <literal>w</literal>, обрабатывается как <literal>r</literal>.
         </member>
         <member>


### PR DESCRIPTION
Documents the third `file` descriptor element (file mode, same as `fopen`) for `proc_open`.

Fixes #1452