### PR TITLE
Sync EN: proc_close closes pipes and waits for termination

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 970d3aa7fdf5c714b584cbe67ebf9e32a1e8b0d3 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
   <refpurpose>
-   Завершает процесс, который открыла функция <function>proc_open</function>,
-   и возвращает код возврата этого процесса
+   Закрывает каналы процесса, который открыла функция <function>proc_open</function>,
+   ожидает его завершения и возвращает код возврата этого процесса
   </refpurpose>
  </refnamediv>
 
@@ -45,10 +45,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает код завершения запущенного процесса.
    Функция возвращает <literal>-1</literal>, если возникла ошибка.
-  </para>
+  </simpara>
   &note.sigchild;
  </refsect1>
 


### PR DESCRIPTION
Updates the `proc_close` refpurpose and return values to match the EN wording.

Fixes #1451