### PR TITLE
Add PHP 8.4.0 changelog entries for Session and LDAP pages

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 57c38af2b053068ad0f1dfdead8128b957ccf4f0 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -104,6 +104,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь вызов функции <function>ldap_connect</function> с более чем
+       двумя аргументами устарел.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-save-handler" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -270,6 +270,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь вызов функции <function>session_set_save_handler</function> с более чем
+       двумя аргументами устарел.
+       Вместо этого используйте сигнатуру с двумя аргументами.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sync EN: ajoute les entrées de changelog 8.4.0 (dépréciation de l'appel avec plus de deux arguments) pour ldap_connect et session_set_save_handler.

Fixes #1464