### PR TITLE
PHP 8.4: Document some changes to ext/date

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 82f00c8d4d4f09fa5a363bc0c6f48e0c80eea72d Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -81,6 +81,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь имеет предварительный тип возврата <type>DateInterval</type>.
+       Раньше это был <type class="union"><type>DateInterval</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -84,8 +84,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Теперь имеет предварительный тип возврата <type>DateInterval</type>.
-       Раньше это был <type class="union"><type>DateInterval</type><type>false</type></type>.
+       Теперь предварительный тип возвращаемого значения — <type>DateInterval</type>;
+       ранее был <type class="union"><type>DateInterval</type><type>false</type></type>.
       </entry>
      </row>
      <row>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,8 +33,8 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Вместо этого следует использовать статический
-    фабричный метод <methodname>DatePeriod::createFromISO8601String</methodname>.
+    Этот вариант конструктора устарел, начиная с PHP 8.4.0, вместо него
+    используйте метод <methodname>DatePeriod::createFromISO8601String</methodname>.
    </simpara>
   </warning>
   <para>
@@ -157,6 +157,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Сигнатура с использованием <parameter>isostr</parameter> устарела,
+        вместо неё используйте метод <methodname>DatePeriod::createFromISO8601String</methodname>.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -33,7 +33,7 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Этот вариант конструктора устарел, начиная с PHP 8.4.0, вместо него
+    Вариант конструктора устарел, начиная с PHP 8.4.0, вместо него
     используйте метод <methodname>DatePeriod::createFromISO8601String</methodname>.
    </simpara>
   </warning>
@@ -160,7 +160,7 @@
       <row>
        <entry>8.4.0</entry>
        <entry>
-        Сигнатура с использованием <parameter>isostr</parameter> устарела,
+        Сигнатура с использованием параметра <parameter>isostr</parameter> устарела,
         вместо неё используйте метод <methodname>DatePeriod::createFromISO8601String</methodname>.
        </entry>
       </row>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -71,8 +71,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Теперь имеет предварительный тип возврата <type>DateTime</type>.
-       Раньше это был <type class="union"><type>DateTime</type><type>false</type></type>.
+       Теперь предварительный тип возвращаемого значения — <type>DateTime</type>;
+       ранее был <type class="union"><type>DateTime</type><type>false</type></type>.
       </entry>
      </row>
      <row>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,6 +68,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь имеет предварительный тип возврата <type>DateTime</type>.
+       Раньше это был <type class="union"><type>DateTime</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::modify() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>
@@ -61,6 +61,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь имеет предварительный тип возврата <type>DateTimeImmutable</type>.
+       Раньше это был <type class="union"><type>DateTimeImmutable</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -64,8 +64,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Теперь имеет предварительный тип возврата <type>DateTimeImmutable</type>.
-       Раньше это был <type class="union"><type>DateTimeImmutable</type><type>false</type></type>.
+       Теперь предварительный тип возвращаемого значения — <type>DateTimeImmutable</type>;
+       ранее был <type class="union"><type>DateTimeImmutable</type><type>false</type></type>.
       </entry>
      </row>
      <row>


### PR DESCRIPTION
Sync EN: types de retour tentatifs 8.4.0 pour createFromDateString, DateTime::modify et DateTimeImmutable::modify, dépréciation de la signature isostr du constructeur DatePeriod, et message du #[\NoDiscard] sur DateTimeImmutable::modify.

Fixes #1466