### PR TITLE
Document missing PHP 8.4.0 constants and deprecations

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 26c2246aacfdbf8a40cc2ceccc71c6d878571120 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -382,7 +382,26 @@
      <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>,
      <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>,
      <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>,
-     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-max">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Определяет максимальную версию протокола. Одна из констант:
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>.
+     Доступна, начиная с PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1164,6 +1183,18 @@
    <listitem>
     <simpara>
      Протокол TLS 1.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-3">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Протокол TLS 1.3.
+     Доступна, начиная с PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-get-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -197,6 +197,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>7.1</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>8.4</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 85d9a34e16732043af52954a069a020b8c30ec50 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-set-option" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -177,6 +177,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>PHP 7.1.0</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>PHP 8.4.0</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: aur Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -81,6 +81,30 @@
     <listitem>
      <simpara>
 
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-ocsp-helper">
+    <term>
+     <constant>X509_PURPOSE_OCSP_HELPER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Проверяет сертификат на пригодность для использования в качестве помощника OCSP-ответчика.
+      Доступна, начиная с PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-timestamp-sign">
+    <term>
+     <constant>X509_PURPOSE_TIMESTAMP_SIGN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Проверяет сертификат на пригодность для использования в качестве доверенного подписанта меток времени.
+      Доступна, начиная с PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: aur Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="session.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -17,6 +17,11 @@
      идентификаторами сессии через блоки данных cookies.
      Константа содержит тот же идентификатор, который возвращает функция <function>session_id</function>.
     </simpara>
+    <warning>
+     <simpara>
+      Константа устарела, начиная с PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-session-disabled">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="soap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -59,7 +59,9 @@
       (<type>int</type>)
      </entry>
      <entry>999</entry>
-     <entry/>
+     <entry>
+      Устарела, начиная с PHP 8.4.0.
+     </entry>
     </row>
     <row xml:id="constant.soap-encoded">
      <entry>


### PR DESCRIPTION
Sync EN: constantes 8.4.0 manquantes (LDAP_OPT_X_TLS_PROTOCOL_MAX/TLS1_3, X509_PURPOSE_OCSP_HELPER/TIMESTAMP_SIGN) et dépréciations (SID, SOAP_FUNCTIONS_ALL), plus les lignes LDAP_OPT_X_TLS_PROTOCOL_MAX dans ldap_get_option/ldap_set_option.

Couvre deux issues qui se recoupent sur les mêmes fichiers de constantes.

Fixes #1460
Fixes #1461