### PR TITLE
Document HashContext::__debugInfo (PHP 8.4)

### DIFF
--- a/reference/hash/hashcontext/debuginfo.xml
+++ b/reference/hash/hashcontext/debuginfo.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Этот метод не предназначен для прямого вызова; его вызывает функция
+   Метод не предназначен для прямого вызова; его вызывает функция
    <function>var_dump</function> и подобные ей функции при инспектировании
    экземпляра класса <classname>HashContext</classname>.
   </simpara>
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает ассоциативный массив с отладочной информацией. Он содержит
+   Метод возвращает ассоциативный массив с отладочной информацией. Он содержит
    ключ <literal>algo</literal>, в котором хранится имя алгоритма хеширования,
    используемого контекстом.
   </simpara>
@@ -37,7 +37,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <methodname>HashContext::__debugInfo</methodname></title>
+   <title>Пример использования метода <methodname>HashContext::__debugInfo</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/hash/hashcontext/debuginfo.xml
+++ b/reference/hash/hashcontext/debuginfo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ed4d79beef8c9abd379088eefc8901a6fece7a3b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="hashcontext.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>HashContext::__debugInfo</refname>
+  <refpurpose>Возвращает отладочную информацию о контексте хеширования</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="HashContext">
+   <modifier>public</modifier> <type>array</type><methodname>HashContext::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Этот метод не предназначен для прямого вызова; его вызывает функция
+   <function>var_dump</function> и подобные ей функции при инспектировании
+   экземпляра класса <classname>HashContext</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает ассоциативный массив с отладочной информацией. Он содержит
+   ключ <literal>algo</literal>, в котором хранится имя алгоритма хеширования,
+   используемого контекстом.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования <methodname>HashContext::__debugInfo</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ctx = hash_init('sha256');
+var_dump($ctx);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(HashContext)#1 (1) {
+  ["algo"]=>
+  string(6) "sha256"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>hash_init</function></member>
+   <member><function>var_dump</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Sync EN: traduction de la nouvelle page HashContext::__debugInfo (PHP 8.4).

Fixes #1463