### PR TITLE
Document IntlDateFormatter::parseToCalendar and Spoofchecker::setAllowedChars (PHP 8.4)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>Разбирает строку в метку времени, обновляя открытый календарь</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Преобразует строку <parameter>string</parameter> в инкрементное значение времени,
+   начиная с позиции <parameter>offset</parameter> и поглощая как можно большую
+   часть входного значения.
+  </simpara>
+  <simpara>
+   Этот метод работает так же, как метод <methodname>IntlDateFormatter::parse</methodname>,
+   за исключением того, что часовой пояс форматировщика обновляется в соответствии
+   с информацией о часовом поясе, которая содержится в разобранной строке
+   <parameter>string</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      Строка для преобразования во время.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Позиция, с которой начинается разбор строки <parameter>string</parameter> (отсчёт от нуля).
+      Если до полного поглощения строки <parameter>string</parameter> не возникнет ошибки,
+      <parameter>offset</parameter> будет содержать -1, иначе будет содержать позицию,
+      на которой завершился разбор (и возникла ошибка).
+      Если разбор завершится неудачей, эта переменная будет содержать конечную позицию.
+      Если <parameter>offset</parameter> &gt; <code>strlen($string)</code>, разбор немедленно завершается неудачей.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Метка времени разобранного значения или &false;, если значение не удалось разобрать.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -19,7 +19,7 @@
    часть входного значения.
   </simpara>
   <simpara>
-   Этот метод работает так же, как метод <methodname>IntlDateFormatter::parse</methodname>,
+   Метод работает так же, как метод <methodname>IntlDateFormatter::parse</methodname>,
    за исключением того, что часовой пояс форматировщика обновляется в соответствии
    с информацией о часовом поясе, которая содержится в разобранной строке
    <parameter>string</parameter>.
@@ -56,14 +56,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Метка времени разобранного значения или &false;, если значение не удалось разобрать.
+   Метод возвращает метку времени разобранного значения или &false;, если значение не удалось разобрать.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
+   <title>Пример использования метода <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -70,7 +70,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <methodname>Spoofchecker::setAllowedChars</methodname></title>
+   <title>Пример использования метода <methodname>Spoofchecker::setAllowedChars</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>Задаёт набор символов, допустимых при выполнении проверок</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Ограничивает символы, которые последующие проверки считают допустимыми, набором,
+   описанным в параметре <parameter>pattern</parameter>. Любой символ вне этого набора
+   приводит к тому, что метод <methodname>Spoofchecker::isSuspicious</methodname> сообщает о результате.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      Набор символов, описанный как шаблон <literal>UnicodeSet</literal>, то есть класс
+      символов в стиле регулярного выражения. Он должен начинаться с <literal>[</literal>
+      и заканчиваться <literal>]</literal>, например <literal>[a-z0-9]</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      Битовая маска, управляющая тем, как интерпретируется параметр <parameter>pattern</parameter>.
+      Должна быть <literal>0</literal> или <constant>Spoofchecker::IGNORE_SPACE</constant>
+      по отдельности либо в сочетании ровно с одной из констант
+      <constant>Spoofchecker::CASE_INSENSITIVE</constant>,
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant> или
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Метод не возвращает значения.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Выбрасывает исключение <exceptionname>ValueError</exceptionname>, если параметр
+   <parameter>pattern</parameter> не является допустимым шаблоном набора символов
+   или если параметр <parameter>patternOptions</parameter> не является допустимой
+   комбинацией настроек.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования <methodname>Spoofchecker::setAllowedChars</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Sync EN: traduction des nouvelles pages IntlDateFormatter::parseToCalendar et Spoofchecker::setAllowedChars (PHP 8.4).

Fixes #1462