### PR TITLE
Add documentation for 5 new pgsql functions (PHP 8.4)

### DIFF
--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>Изменяет пароль пользователя PostgreSQL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Функция <function>pg_change_password</function> изменяет пароль пользователя
+   PostgreSQL. Функция использует функцию <literal>PQchangePassword</literal>
+   библиотеки libpq, которая автоматически выполняет шифрование пароля
+   на основе настроек сервера.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <simpara>
+      Имя пользователя PostgreSQL, пароль которого требуется изменить.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      Новый пароль.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pg-jit" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_jit</refname>
+  <refpurpose>Возвращает информацию о JIT сервера</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>pg_jit</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Функция <function>pg_jit</function> возвращает массив с информацией о JIT
+   (компиляции Just-In-Time) сервера PostgreSQL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает массив (&array;) с информацией о JIT сервера.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_version</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает массив (&array;) с информацией о JIT сервера.
+   Функция возвращает массив (&array;) с информацией о JIT сервера.
   </simpara>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
+   Функция возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
    если данные не удалось поставить в очередь (только в неблокирующем режиме),
    или <literal>-1</literal> в случае ошибки.
   </simpara>

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>Отправляет данные серверу во время операции COPY</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Отправляет данные серверу во время операции <literal>COPY FROM STDIN</literal>.
+   Перед вызовом этой функции команда <literal>COPY</literal> должна быть выполнена
+   через функцию <function>pg_query</function>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cmd</parameter></term>
+    <listitem>
+     <simpara>
+      Данные для отправки серверу. Завершающий перевод строки добавляется
+      автоматически, если он отсутствует. Данные должны быть отформатированы
+      в соответствии с форматом команды <literal>COPY</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
+   если данные не удалось поставить в очередь (только в неблокирующем режиме),
+   или <literal>-1</literal> в случае ошибки.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
+   Функция возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
    если данные не удалось поставить в очередь (только в неблокирующем режиме),
    или <literal>-1</literal> в случае ошибки.
   </simpara>

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pg-put-copy-end" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_end</refname>
+  <refpurpose>Сообщает серверу о завершении операции COPY</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_end</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>error</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Отправляет серверу признак конца данных во время операции
+   <literal>COPY FROM STDIN</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error</parameter></term>
+    <listitem>
+     <simpara>
+      Если значение не равно &null;, операция <literal>COPY</literal> принудительно
+      завершается неудачей с заданным сообщением об ошибке.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает <literal>1</literal> в случае успешного выполнения, <literal>0</literal>,
+   если данные не удалось поставить в очередь (только в неблокирующем режиме),
+   или <literal>-1</literal> в случае ошибки.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>Опрашивает сокет соединения PostgreSQL на готовность к чтению/записи</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Опрашивает сокет соединения PostgreSQL на готовность к чтению и/или записи.
+   Сокет можно получить с помощью функции <function>pg_socket</function>.
+   Функция полезна для реализации неблокирующих асинхронных процессов выполнения запросов.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <simpara>
+      Ресурс сокета, полученный из функции <function>pg_socket</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>read</parameter></term>
+    <listitem>
+     <simpara>
+      Проверять ли готовность к чтению. Передайте <literal>1</literal> для проверки,
+      <literal>0</literal>, чтобы пропустить.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>write</parameter></term>
+    <listitem>
+     <simpara>
+      Проверять ли готовность к записи. Передайте <literal>1</literal> для проверки,
+      <literal>0</literal>, чтобы пропустить.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      Максимальное число миллисекунд для ожидания. Передайте <literal>-1</literal>,
+      чтобы ждать бесконечно, или <literal>0</literal>, чтобы не ждать вовсе.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Возвращает положительное значение, если сокет готов, <literal>0</literal>,
+   если был достигнут тайм-аут, или <literal>-1</literal> в случае ошибки.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_socket</function></member>
+   <member><function>pg_consume_input</function></member>
+   <member><function>pg_send_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -67,8 +67,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает положительное значение, если сокет готов, <literal>0</literal>,
-   если был достигнут тайм-аут, или <literal>-1</literal> в случае ошибки.
+   Функция возвращает положительное значение, если сокет готов, <literal>0</literal>,
+   если было превышено время ожидания, или <literal>-1</literal> в случае ошибки.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Sync EN: traduction des nouvelles pages pg_change_password, pg_jit, pg_put_copy_data, pg_put_copy_end et pg_socket_poll (PHP 8.4).

Fixes #1459