### PR TITLE
Sync EN: document FILTER_THROW_ON_FAILURE and Filter exception classes

### DIFF
--- a/reference/filter/book.xml
+++ b/reference/filter/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53054bf8decc8648cf2e90a493692a161e2371af Maintainer: shein Status: ready -->
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <book xml:id="book.filter" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="bundled" ?>
@@ -48,6 +48,9 @@
  &reference.filter.constants;
  &reference.filter.examples;
  &reference.filter.reference;
+
+ &reference.filter.filter.filterexception;
+ &reference.filter.filter.filterfailedexception;
 
 </book>
 <!-- Keep this comment at the end of the file

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -152,6 +152,25 @@
     <simpara>
      Флаг указывают при проверке значений фильтрами семейства
      <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-throw-on-failure">
+   <term>
+    <constant>FILTER_THROW_ON_FAILURE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Выбрасывает исключение <exceptionname>Filter\FilterFailedException</exceptionname>,
+     когда фильтр проверки завершается неудачей, вместо возврата &false;.
+    </simpara>
+    <simpara>
+     Флаг указывают при проверке значений фильтрами семейства
+     <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>.
+    </simpara>
+    <simpara>
+     Доступно начиная с PHP 8.5.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filter/filter.filterexception.xml
+++ b/reference/filter/filter.filterexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.filter-filterexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Filter\FilterException</title>
+ <titleabbrev>Filter\FilterException</titleabbrev>
+
+ <partintro>
+  <section xml:id="filter-filterexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Базовый класс для исключений (<type>Exception</type>), которые выбрасывает расширение Filter.
+   </simpara>
+  </section>
+
+  <section xml:id="filter-filterexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Filter</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>FilterException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filter/filter.filterfailedexception.xml
+++ b/reference/filter/filter.filterfailedexception.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.filter-filterfailedexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Класс Filter\FilterFailedException</title>
+ <titleabbrev>Filter\FilterFailedException</titleabbrev>
+
+ <partintro>
+  <section xml:id="filter-filterfailedexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Выбрасывается, когда фильтр проверки завершается неудачей и установлен флаг
+    <constant>FILTER_THROW_ON_FAILURE</constant>.
+   </simpara>
+  </section>
+
+  <section xml:id="filter-filterfailedexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Filter</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>FilterFailedException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Filter\FilterException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Syncs the RU manual with upstream doc-en PR `5607` (PHP 8.5): documents the `FILTER_THROW_ON_FAILURE` constant and adds the two new `Filter\FilterException` / `Filter\FilterFailedException` class pages. EN-Revision bumped; maintainers kept on existing files, the two new files are translated.

Fixes #1480