### PR TITLE
[Sync-EN] Sync new cURL constants (PHP 8.5)

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dec90c90d3662c5433f7c3972f8557321da7b11d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="curl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -209,6 +209,54 @@
      auth, libcurl проверит наличие неограниченного auth,
      или, если нет, то только этот алгоритм auth является приемлемым.
      Константа доступна с cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-all">
+   <term>
+    <constant>CURLFOLLOW_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение для <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     следование перенаправлениям и сохраняет пользовательский метод запроса,
+     заданный через <constant>CURLOPT_CUSTOMREQUEST</constant>, для всех запросов,
+     даже после перенаправлений.
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-obeycode">
+   <term>
+    <constant>CURLFOLLOW_OBEYCODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение для <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     следование перенаправлениям с соблюдением кода ответа HTTP: пользовательский
+     метод запроса, заданный через <constant>CURLOPT_CUSTOMREQUEST</constant>,
+     сохраняется, за исключением того, что он меняется на <literal>GET</literal>
+     для кодов состояния перенаправления, которые этого требуют
+     (таких как 301, 302 и 303).
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-firstonly">
+   <term>
+    <constant>CURLFOLLOW_FIRSTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение для <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     следование перенаправлениям, но использует пользовательский метод запроса,
+     заданный через <constant>CURLOPT_CUSTOMREQUEST</constant>, только для первого
+     запроса; последующие запросы следуют методу, определённому кодом ответа
+     перенаправления.
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f34918d8b2761af5b596b1b762753ee825c19cd8 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
@@ -69,6 +69,18 @@
   <listitem>
    <simpara>
     Получает информацию о невыполненных за отведённое время условиях.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-conn-id">
+  <term>
+   <constant>CURLINFO_CONN_ID</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Идентификатор последнего соединения, использованного передачей. Идентификатор соединения уникален среди всех соединений, использующих один и тот же кеш соединений, и полезен для различения повторного использования соединений.
+    Опция доступна с PHP 8.5.0 и cURL 8.2.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -257,6 +269,18 @@
   <listitem>
    <simpara>
     Получает битовую маску доступного метода или методов аутентификации на основе данных предыдущего ответа.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-httpauth-used">
+  <term>
+   <constant>CURLINFO_HTTPAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Битовая маска, указывающая метод(ы) аутентификации HTTP, фактически использованные в предыдущем запросе.
+    Опция доступна с PHP 8.5.0 и cURL 8.12.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -458,6 +482,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-proxyauth-used">
+  <term>
+   <constant>CURLINFO_PROXYAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Битовая маска, указывающая метод(ы) аутентификации прокси, фактически использованные в предыдущем запросе.
+    Опция доступна с PHP 8.5.0 и cURL 8.12.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-proxy-error">
   <term>
    <constant>CURLINFO_PROXY_ERROR</constant>
@@ -483,6 +519,18 @@
     Получает результат запрошенной проверки сертификата (с опцией
     <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> option). Работает только для серверов HTTPS-прокси.
     Опция доступна с PHP 7.3.0 и cURL 7.52.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-queue-time-t">
+  <term>
+   <constant>CURLINFO_QUEUE_TIME_T</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Время в микросекундах, в течение которого передача удерживалась в очереди ожидания перед началом из-за ограничений, заданных через <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant> или аналогичные опции.
+    Опция доступна с PHP 8.5.0 и cURL 8.6.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -798,6 +846,18 @@
    <simpara>
     Общее время предыдущей передачи в микросекундах, включая разрешение имени, TCP-соединение и т. д.
     Опция доступна с PHP 7.3.0 и cURL 7.61.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-used-proxy">
+  <term>
+   <constant>CURLINFO_USED_PROXY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Использовала ли предыдущая передача прокси; возвращает <literal>1</literal>, если прокси использовался, и <literal>0</literal> в противном случае.
+    Опция доступна с PHP 8.5.0 и cURL 8.7.0.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
@@ -1358,6 +1358,20 @@
      Опция принимает любое значение, которое может быть приведено к допустимому целому числу (<type>int</type>).
      Доступно с cURL 7.1.0.
     </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infilesize-large">
+   <term>
+    <constant>CURLOPT_INFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ожидаемый размер в байтах файла при загрузке файла на удалённый сайт.
+     Это 64-битный вариант <constant>CURLOPT_INFILESIZE</constant>, позволяющий
+     задавать размеры больше 2 ГБ.
+     Доступно с PHP 8.5.0.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-interface">


### PR DESCRIPTION
Синхронизация новых констант cURL из PHP 8.5: CURLFOLLOW_*, несколько CURLINFO_* и CURLOPT_INFILESIZE_LARGE (файл constants_curl_setopt.xml приведён к финальному состоянию EN с simpara).

Fixes #1487