### PR TITLE
[Sync-EN] Sync new OpenSSL constants (PHP 8.5)

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -444,6 +444,45 @@
         По умолчанию в PKCS7-структуру включаются данные и подпись данных. При установке флага данные не включаются.
        </entry>
       </row>
+      <row xml:id="constant.pkcs7-nosmimecap">
+       <entry>
+        <constant>PKCS7_NOSMIMECAP</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Флаг доступен с PHP 8.5.0. Не включает возможности S/MIME
+        (SMIMECapabilities) в подпись.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-crlfeol">
+       <entry>
+        <constant>PKCS7_CRLFEOL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Флаг доступен с PHP 8.5.0. Использует <literal>CRLF</literal>
+        в качестве конца строки в выводе.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-nocrl">
+       <entry>
+        <constant>PKCS7_NOCRL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Флаг доступен с PHP 8.5.0. Не включает CRL в структуру PKCS7.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-no-dual-content">
+       <entry>
+        <constant>PKCS7_NO_DUAL_CONTENT</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Флаг доступен с PHP 8.5.0. Не включает дублирующее содержимое,
+        избегая дублирования подписанного содержимого.
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </table>


### PR DESCRIPTION
Синхронизация новых констант OpenSSL из PHP 8.5: OPENSSL_PKCS1_PSS_PADDING и флаги PKCS7 (NOSMIMECAP, CRLFEOL, NOCRL, NO_DUAL_CONTENT).

Fixes #1488