### PR TITLE
[Sync EN] precedence.xml: приоритет унарных операторов и instanceof, присваивание в префиксных операторах

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7428462fea1c0387cf5e8473b4c48c3c8ac8c2c Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 80dfa568e602649eb13585bf59a7b6239eddaac3 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.precedence">
  <title>Приоритет оператора</title>
@@ -334,6 +334,18 @@
    </tgroup>
   </table>
  </para>
+ <note>
+  <simpara>
+   Унарные операторы, которые находятся в одной строке с операторами приведения
+   типа (<literal>~</literal>, <literal>@</literal> и унарные
+   <literal>+</literal>/<literal>-</literal>), имеют более высокий приоритет, чем
+   <literal>instanceof</literal>, тогда как у оператора <literal>!</literal>
+   приоритет ниже. Поэтому выражение <literal>(int) $x instanceof Foo</literal>
+   группируется как <literal>((int) $x) instanceof Foo</literal>, а выражение
+   <literal>!$x instanceof Foo</literal> группируется как
+   <literal>!($x instanceof Foo)</literal>.
+  </simpara>
+ </note>
  <para>
   <example>
    <title>Ассоциативность</title>
@@ -454,6 +466,16 @@ x минус 1 равно 3, ну, я надеюсь
    в этом примере результат выполнения функции <literal>foo()</literal> присвоится
    переменной <varname>$a</varname>.
   </para>
+  <simpara>
+   Это возможно потому, что левая часть присваивания обязана быть переменной,
+   поэтому присваивание группируется с этой переменной, а не с окружающим
+   префиксным оператором, у которого приоритет выше. То же касается других
+   префиксных операторов, которые принимают выражение в качестве операнда, таких
+   как <literal>clone</literal>, операторы приведения типа, <literal>@</literal>
+   и <literal>~</literal>: например, <literal>clone $a = $b</literal>
+   группируется как <literal>clone ($a = $b)</literal>, а не как
+   <literal>(clone $a) = $b</literal>.
+  </simpara>
  </note>
  <sect2 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
Sync EN `language/operators/precedence.xml`.

Переведены две добавленные в upstream заметки: приоритет унарных операторов относительно `instanceof` и группировка присваивания внутри префиксных операторов.

Fixes #1491