### PR TITLE
CI: check the EN-Revision hash of changed files

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/actions
+# Checks that the EN-Revision comment of the .xml files changed in a PR points to
+# the latest doc-en commit for that file. Emits a ::error annotation and fails if
+# the hash is missing, wrong, from another file, or outdated.
+
+name: "Structure"
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  revision:
+    name: "Check EN-Revision"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout translation"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-en"
+        uses: actions/checkout@v4
+        with:
+          path: en
+          repository: php/doc-en
+          fetch-depth: 0
+
+      - name: "Check EN-Revision"
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE"
+          fail=0
+          while IFS= read -r f; do
+            [ -f "$f" ] && [ -f "en/$f" ] || continue
+            declared=$(grep -oiP 'EN-Revision:\s*\K[0-9a-f]+' "$f" | head -1 || true)
+            latest=$(git -C en log -1 --format=%H -- "$f")
+            if [ "$declared" != "$latest" ]; then
+              echo "::error file=$f::EN-Revision ${declared:-missing} != latest doc-en commit $latest"
+              fail=1
+            fi
+          done < <(git diff --name-only "$BASE"...HEAD -- '*.xml')
+          exit $fail


### PR DESCRIPTION
Adds a workflow that, on every PR, checks that the `EN-Revision:` comment of the changed .xml files points to the latest doc-en commit for that file. A missing, wrong, mismatched or outdated hash produces a `::error` annotation.

The same check already runs on `php/doc-fr` (on every PR) and `php/doc-es`:
https://github.com/php/doc-fr/blob/master/.github/workflows/check-en-revision.yml

It only needs a checkout of doc-en, no doc-base. To make it warn without blocking the PR, change the final `exit $fail` to `exit 0`.

A shared translation toolchain is being built in `php/doc-base` so every language can get these checks from a single place. Until that lands, this workflow is a useful stopgap: it is fully self-contained (doc-en checkout only) and provides the check today.