### PR TITLE
Перевести отсутствующую сущность (отображалась на английском)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3595,6 +3595,8 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 
 <!ENTITY trader.arg.fastd.ma.type 'Тип скользящей средней для линии Fast-D. Параметр принимает константы семейства
 <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>
+<!ENTITY trader.arg.fastk.ma.type 'Тип скользящей средней для линии Fast-K. Параметр принимает константы семейства
+<link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>
 
 <!ENTITY trader.arg.slowk.ma.type 'Тип скользящей средней для линии Fast-K. Параметр принимает константы семейства
 <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>


### PR DESCRIPTION
Сущность `&trader.arg.fastk.ma.type;` определена в doc-en, но отсутствовала здесь — из-за механизма подмены %-сущностей она отображалась **на английском** на страницах trader. Переведена в стиле соседних сущностей (`trader.arg.fastd.ma.type` и т.д.), с сохранением структуры (`<link>` на `TRADER_MA_TYPE_*`).
