### PR TITLE
[Sync EN] Fix example in Error::getPrevious: use TypeError instead of InvalidArgumentError

### DIFF
--- a/language/predefined/error/getprevious.xml
+++ b/language/predefined/error/getprevious.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09c49da6f0167fcdfe53a76e3ea28ecfc0eb337b Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: e565d17dc87b0c5946ea603fbcfb1777316fb6fc Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="error.getprevious" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,7 +47,7 @@ class MyCustomError extends Error {}
 
 function doStuff() {
     try {
-        throw new InvalidArgumentError("Вы делаете это неправильно!", 112);
+        throw new TypeError("Вы делаете это неправильно!", 112);
     } catch(Error $e) {
         throw new MyCustomError("Что-то случилось", 911, $e);
     }
@@ -68,7 +68,7 @@ try {
     <screen>
 <![CDATA[
 /home/bjori/ex.php:8 Что-то случилось (911) [MyCustomError]
-/home/bjori/ex.php:6 Вы делаете это неправильно! (112) [InvalidArgumentError]
+/home/bjori/ex.php:6 Вы делаете это неправильно! (112) [TypeError]
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Closes #1516