### PR TITLE
[Sync-EN] opcache_invalidate: sync file cache behaviour with EN

### DIFF
--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -15,11 +15,11 @@
    <methodparam choice="opt"><type>bool</type><parameter>force</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Функция аннулирует закешированный скрипт. Если параметр
-   <parameter>force</parameter> не задан или задан как &false;, скрипт
-   аннулируется, только если скрипт был модифицирован после помещения в кеш.
-   Если директива <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
-   включена, функция также аннулирует соответствующую запись файлового кеша.
+   Функция аннулирует скрипт в кеше операционного кода в общей памяти.
+   При пропуске аргумента <parameter>force</parameter> или при передаче в аргументе значения &false;
+   скрипт аннулируется, только если время изменения скрипта новее времени изменения закешированных опкодов.
+   При включённой директиве <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
+   функция также аннулирует запись в файловом кеше.
   </simpara>
  </refsect1>
 
@@ -30,7 +30,7 @@
     <term><parameter>filename</parameter></term>
     <listitem>
      <simpara>
-      Путь к скрипту.
+      Путь к скрипту, кеш которого требуется аннулировать.
      </simpara>
     </listitem>
    </varlistentry>
@@ -38,8 +38,8 @@
     <term><parameter>force</parameter></term>
     <listitem>
      <simpara>
-      Если установлено как &true;, кеш скрипта будет принудительно аннулирован независимо от того,
-      требуется ли это или нет
+      При установке значения &true; кеш скрипта принудительно аннулируется,
+      даже если после добавления в кеш скрипт не изменялся.
      </simpara>
     </listitem>
    </varlistentry>
@@ -49,9 +49,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает &true;, если кеш опкодов для <parameter>filename</parameter>
-   аннулирован, либо если аннулировать нечего. В случае, если кеш опкодов
-   отключён, возвращается &false;.
+   Функция возвращает &true; при аннулировании кеша опкодов файла по пути <parameter>filename</parameter>
+   или если файл не кешировался. При отключённом кешировании операционного кода
+   возвращается &false;.
   </simpara>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87d6bb1bbd5f118f5b0cf0160438f06c0f91ea45 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 82cdc19b6292e0f840e6b22ca430105d9f0aa89e Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.opcache-invalidate">
  <refnamediv>
@@ -18,7 +18,8 @@
    Функция аннулирует закешированный скрипт. Если параметр
    <parameter>force</parameter> не задан или задан как &false;, скрипт
    аннулируется, только если скрипт был модифицирован после помещения в кеш.
-   Функция аннулирует только кеш в памяти, не затрагивая файловый кеш.
+   Если директива <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
+   включена, функция также аннулирует соответствующую запись файлового кеша.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5723: `opcache_invalidate()` also invalidates the corresponding file cache entry when `opcache.file_cache` is enabled. The RU text still claimed the opposite.

Fixes: #1583
