### PR TITLE
[Sync-EN] luasandbox: sync installation section with EN

### DIFF
--- a/reference/luasandbox/setup.xml
+++ b/reference/luasandbox/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c40251a81d8f369c184e83fd142c4cc656a7261 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: b02a43722e8c255cc112b829c725747079943f72 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="luasandbox.setup">
  &reftitle.setup;
@@ -25,23 +25,35 @@
 
  <section xml:id="luasandbox.installation">
   &reftitle.install;
-  <simpara>
-   &pecl.moved;
-  </simpara>
-  <simpara>
-   &pecl.info;
-   <link xlink:href="&url.pecl.package;luasandbox">&url.pecl.package;luasandbox</link>.
-  </simpara>
+
   <para>
    На операционную систему Debian 10 и новее или Ubuntu 18.04 и новее
    модуль LuaSandbox обычно устанавливают из пакета
    <literal>php-luasandbox</literal>:
-   <screen>
+
+   <programlisting role="shell">
 <![CDATA[
 sudo apt-get install php-luasandbox
 ]]>
-   </screen>
+   </programlisting>
   </para>
+
+  <para>
+   Чтобы установить модуль LuaSandbox через <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pie;">PIE</link>,
+   выполняют следующую команду:
+   <programlisting role="shell">
+<![CDATA[
+pie install wikimedia/luasandbox
+]]>
+   </programlisting>
+  </para>
+
+  <note>
+   <simpara>
+    Старые выпуски доступны в <link xlink:href="&url.pecl.package;luasandbox">PECL-пакете LuaSandbox</link>.
+   </simpara>
+  </note>
+
  </section>
 
 </chapter>

--- a/reference/luasandbox/setup.xml
+++ b/reference/luasandbox/setup.xml
@@ -7,19 +7,19 @@
  <section xml:id="luasandbox.requirements">
   &reftitle.required;
   <simpara>
-   Для работы модуля требуется установить библиотеку Lua 5.1, которая доступна для скачивания
+   Для работы модуля потребуется установить библиотеку Lua 5.1. Исходный код библиотеки доступен для скачивания
    <link xlink:href="&url.lua;">на сайте</link> языка программирования Lua.
   </simpara>
   <simpara>
-   Чтобы использовать возможности таймера в полной мере, в системе Linux требуется установить модуль LuaSandbox.
+   Полный набор функций таймера при установке модуля LuaSandbox поддерживается только в системах Linux.
   </simpara>
   <simpara>
-   В Linux-дистрибутиве FreeBSD или операционной системе Mac OS X поддерживается только реальное время (настенные часы),
-   функции для возврата времени процессора фактически будут возвращать
-   время настенных часов.
+   В Linux-дистрибутиве FreeBSD или операционной системе Mac OS X поддерживается только реальное время по настенным часам:
+   функции измерения времени работы процессора возвращают не фактическое время выполнения процессорных операций,
+   а время с учётом ожидания ввода-вывода, работы сети, диска и других задержек.
   </simpara>
   <simpara>
-   В ОС Windows функции таймера не поддерживаются. Сроки не будут действовать.
+   В ОС Windows функции таймера не поддерживаются. Сроки не действуют.
   </simpara>
  </section>
 
@@ -28,7 +28,7 @@
 
   <para>
    На операционную систему Debian 10 и новее или Ubuntu 18.04 и новее
-   модуль LuaSandbox обычно устанавливают из пакета
+   модуль LuaSandbox устанавливают стандартно — в виде пакета
    <literal>php-luasandbox</literal>:
 
    <programlisting role="shell">
@@ -39,7 +39,8 @@ sudo apt-get install php-luasandbox
   </para>
 
   <para>
-   Чтобы установить модуль LuaSandbox через <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pie;">PIE</link>,
+   Для установки модуля LuaSandbox через пакетный менеджер
+   <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pie;">PIE</link>
    выполняют следующую команду:
    <programlisting role="shell">
 <![CDATA[
@@ -50,7 +51,8 @@ pie install wikimedia/luasandbox
 
   <note>
    <simpara>
-    Старые выпуски доступны в <link xlink:href="&url.pecl.package;luasandbox">PECL-пакете LuaSandbox</link>.
+    Пакеты со старыми версиями модуля LuaSandbox
+    доступны для скачивания <link xlink:href="&url.pecl.package;luasandbox">в репозитории PECL</link>.
    </simpara>
   </note>
 


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5725: adds the PIE installation command, switches the shell snippets to `programlisting role="shell"`, and moves the old PECL releases into a note.

Fixes: #1584
