### PR TITLE
[Sync-EN] security/database: note that mssql_query belongs to a removed extension

### DIFF
--- a/security/database.xml
+++ b/security/database.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: irker Status: ready -->
+<!-- EN-Revision: 0009ebd09f938e8f066779bb9bb774baed10bd8a Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="security.database" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Безопасность баз данных</title>
@@ -327,6 +327,17 @@ $result = mssql_query($query);
    а службу MSSQLSERVER запустили бы с достаточными привилегиями,
    у злоумышленника появилась бы учётная запись с доступом к локальной машине.
   </para>
+  <note>
+   <simpara>
+    Функция <function>mssql_query</function> принадлежала расширению
+    <literal>mssql</literal>, которое
+    <link linkend="migration70.removed-exts-sapis">удалили в PHP 7.0.0</link>.
+    Её приводят здесь только для иллюстрации атаки; текущий код, который
+    подключается к MSSQL Server, вместо неё задействует расширения
+    <link linkend="book.sqlsrv">sqlsrv</link> или
+    <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link>.
+   </simpara>
+  </note>
   <note>
    <para>
     Часть приведённых примеров привязана к конкретному серверу базы данных,

--- a/security/database.xml
+++ b/security/database.xml
@@ -329,13 +329,12 @@ $result = mssql_query($query);
   </para>
   <note>
    <simpara>
-    Функция <function>mssql_query</function> принадлежала расширению
-    <literal>mssql</literal>, которое
-    <link linkend="migration70.removed-exts-sapis">удалили в PHP 7.0.0</link>.
-    Её приводят здесь только для иллюстрации атаки; текущий код, который
-    подключается к MSSQL Server, вместо неё задействует расширения
-    <link linkend="book.sqlsrv">sqlsrv</link> или
-    <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link>.
+    Функция <function>mssql_query</function> принадлежала модулю <literal>mssql</literal>,
+    который <link linkend="migration70.removed-exts-sapis">удалили в PHP 7.0.0</link>.
+    Функцию включили в примеры только для иллюстрации атаки; в текущем коде
+    к MSSQL Server подключаются через модуль
+    <link linkend="book.sqlsrv">sqlsrv</link>
+    или <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link>.
    </simpara>
   </note>
   <note>


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5709: the `mssql` extension was removed in PHP 7.0.0, so the example now points readers to sqlsrv and pdo_sqlsrv.

Fixes: #1578
