### PR TITLE
[Sync-EN] exec: remove dead code in the example

### DIFF
--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: aur Status: ready -->
+<!-- EN-Revision: 462dddda87baa86fd760dcb1e3a0d2096e00a59b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -125,10 +125,8 @@
 
 // Выводит имя пользователя, от имени которого запустили процесс php/httpd
 // (применимо к системам с командой whoami в системном пути)
-$output = null;
-$retval = null;
-exec('whoami', $output, $retval);
-echo "Команда вернёт статус $retval и значение:\n";
+exec('whoami', $output, $result_code);
+echo "Команда вернёт статус $result_code и значение:\n";
 print_r($output);
 
 ?>


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5705: drops the redundant `$output`/`$retval` initialisation and renames the variable to `$result_code`, matching the parameter name.

Fixes: #1568
