### PR TITLE
[Sync-EN] shell_exec: note that the backtick operator is deprecated

### DIFF
--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Функция идентична устаревшему оператору с <link linkend="language.operators.execution">обратным апострофом</link>.
+   Функция идентична устаревшему <link linkend="language.operators.execution">оператору выполнения</link>.
   </simpara>
   <note>
    <para>

--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7973fd533364af4dd6282ca9e7bee2dffec39b1c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 81593f08db3320d5366bf925c8561f097a9d69ad Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.shell-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>shell_exec</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Функция идентична оператору с <link linkend="language.operators.execution">обратным апострофом</link>.
-  </para>
+  <simpara>
+   Функция идентична устаревшему оператору с <link linkend="language.operators.execution">обратным апострофом</link>.
+  </simpara>
   <note>
    <para>
     В ОС Windows базовый канал межпроцессного взаимодействия открывается в текстовом режиме,


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5719.

Fixes: #1574
