### PR TITLE
[Sync-EN] intl_get_error_message: sync example with EN

### DIFF
--- a/reference/intl/functions/intl-get-error-message.xml
+++ b/reference/intl/functions/intl-get-error-message.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.intl-get-error-message">
  <refnamediv>
   <refname>intl_get_error_message</refname>
-  <refpurpose>Получить описание ошибки</refpurpose>
+  <refpurpose>Получает описание последней ошибки</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Получить описание последней произошедшей ошибки в функциях ICU.
+   Функция получает сообщение об ошибке из последнего вызова функции интернационализации.
   </para>
  </refsect1>
 
@@ -26,14 +26,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Описание последней произошедшей ошибки в функциях ICU.
+   Функция возвращает описание ошибки, которую сгенерировала библиотека ICU при последнем вызове функции из API интернационализации.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <function>intl_get_error_message</function></title>
+   <title>Пример получения описания ошибки функцией <function>intl_get_error_message</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -43,8 +43,8 @@ $bundle = resourcebundle_create('en_US', __DIR__ . '/does-not-exist', false);
 if ($bundle === null) {
     $errorCode = intl_get_error_code();
 
-    printf("Error name: %s\n", intl_error_name($errorCode));
-    printf("Error message: %s\n", intl_get_error_message());
+    printf("Название ошибки: %s\n", intl_error_name($errorCode));
+    printf("Сообщение об ошибке: %s\n", intl_get_error_message());
 }
 ]]>
    </programlisting>
@@ -52,8 +52,8 @@ if ($bundle === null) {
   &example.outputs;
   <screen>
 <![CDATA[
-Error name: U_MISSING_RESOURCE_ERROR
-Error message: resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
+Название ошибки: U_MISSING_RESOURCE_ERROR
+Сообщение об ошибке: resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/functions/intl-get-error-message.xml
+++ b/reference/intl/functions/intl-get-error-message.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fed3682684f1af372dc9a7f15d0468e5a884ab16 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: d5e705df751e5d590449c2f910be5753896a7722 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.intl-get-error-message">
  <refnamediv>
@@ -32,20 +32,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Пример использования <function>intl_get_error_message</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Пример использования <function>intl_get_error_message</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-if( Collator::getAvailableLocales() === false ) {
-    show_error( intl_get_error_message() );
+
+$bundle = resourcebundle_create('en_US', __DIR__ . '/does-not-exist', false);
+
+if ($bundle === null) {
+    $errorCode = intl_get_error_code();
+
+    printf("Error name: %s\n", intl_error_name($errorCode));
+    printf("Error message: %s\n", intl_get_error_message());
 }
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Error name: U_MISSING_RESOURCE_ERROR
+Error message: resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
+]]>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5708: the example now uses `resourcebundle_create()` and shows its output. The stray `para` wrapper around the `example` is dropped.

Fixes: #1573
