### PR TITLE
[Sync-EN] session: add PHP 8.4 deprecation notices for session directives

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -117,13 +117,13 @@
       <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
       <entry>"1"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Отключение этой настройки объявлено устаревшим с PHP 8.4.0.</entry>
+      <entry>Отключение настройки устарело с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
       <entry>""</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Установка непустого значения объявлена устаревшей с PHP 8.4.0.</entry>
+      <entry>Установка директиве значения, кроме пустой строки, устарела с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
@@ -141,7 +141,7 @@
       <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Включение этой настройки объявлено устаревшим с PHP 8.4.0.</entry>
+      <entry>Включение настройки устарело с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
@@ -149,7 +149,7 @@
       <entry><constant>INI_ALL</constant></entry>
       <entry>
        Директива доступна с PHP 7.1.0.
-       Изменение этой настройки объявлено устаревшим с PHP 8.4.0.
+       Изменение настройки устарело с PHP 8.4.0.
       </entry>
      </row>
      <row>
@@ -158,20 +158,20 @@
       <entry><constant>INI_ALL</constant></entry>
       <entry>
        Директива доступна с PHP 7.1.0.
-       Установка непустого значения объявлена устаревшей с PHP 8.4.0.
+       Установка директиве значения, кроме пустой строки, устарела с PHP 8.4.0.
       </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
       <entry>"32"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Директива была доступна с PHP 7.1.0 и устарела с PHP 8.4.0.</entry>
+      <entry>Директива появилась с PHP 7.1.0 и устарела с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
       <entry>"4"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Директива была доступна с PHP 7.1.0 и устарела с PHP 8.4.0.</entry>
+      <entry>Директива появилась с PHP 7.1.0 и устарела с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>
@@ -455,15 +455,15 @@
     </term>
     <listitem>
      <simpara>
-      <literal>session.referer_check</literal> содержит подстроку, которую
-      можно использовать при проверке HTTP Referer. Если клиентом был послан
-      referer и подстрока не была выявлена, то идентификатор сессии
-      будет помечен как недействительный. По умолчанию используется пустая строка.
+      Директива <literal>session.referer_check</literal> содержит подстроку
+      для проверки HTTP-заголовка Referer. Встроенный идентификатор сессии
+      пометится недействительным, если клиентский заголовок Referer
+      не содержит подстроку. Значение по умолчанию — пустая строка.
      </simpara>
      <warning>
       <simpara>
-       Установка директиве <literal>session.referer_check</literal> непустого
-       значения объявлена устаревшей с PHP 8.4.0.
+       Установка директиве <literal>session.referer_check</literal> значения,
+       кроме пустой строки, устарела с PHP 8.4.0.
       </simpara>
      </warning>
     </listitem>
@@ -809,8 +809,8 @@
      </simpara>
      <warning>
       <simpara>
-       Установка директиве <literal>session.trans_sid_hosts</literal> непустого
-       значения объявлена устаревшей с PHP 8.4.0.
+       Установка директиве <literal>session.trans_sid_hosts</literal> значения,
+       кроме пустой строки, устарела с PHP 8.4.0.
       </simpara>
      </warning>
     </listitem>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7f1b75ed358430c1db0e37c832d2926735d5f5c2 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -117,13 +117,13 @@
       <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
       <entry>"1"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Отключение этой настройки объявлено устаревшим с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
       <entry>""</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Установка непустого значения объявлена устаревшей с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
@@ -141,19 +141,25 @@
       <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Включение этой настройки объявлено устаревшим с PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
       <entry>"a=href,area=href,frame=src,form="</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Директива доступна с PHP 7.1.0.</entry>
+      <entry>
+       Директива доступна с PHP 7.1.0.
+       Изменение этой настройки объявлено устаревшим с PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></entry>
       <entry><literal>$_SERVER['HTTP_HOST']</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Директива доступна с PHP 7.1.0.</entry>
+      <entry>
+       Директива доступна с PHP 7.1.0.
+       Установка непустого значения объявлена устаревшей с PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
@@ -454,6 +460,12 @@
       referer и подстрока не была выявлена, то идентификатор сессии
       будет помечен как недействительный. По умолчанию используется пустая строка.
      </simpara>
+     <warning>
+      <simpara>
+       Установка директиве <literal>session.referer_check</literal> непустого
+       значения объявлена устаревшей с PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -563,6 +575,12 @@
       идентификаторов сессии в URL-адресах.
       Значение по умолчанию <literal>1</literal> (включено).
      </simpara>
+     <warning>
+      <simpara>
+       Отключение директивы <literal>session.use_only_cookies</literal>
+       объявлено устаревшим с PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -720,6 +738,12 @@
       прозрачная поддержка sid или нет. По умолчанию
       <literal>0</literal> (отключено).
      </simpara>
+     <warning>
+      <simpara>
+       Включение директивы <literal>session.use_trans_sid</literal>
+       объявлено устаревшим с PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Управление сессией на основе URL имеет дополнительные риски
@@ -748,12 +772,18 @@
      <simpara>
       <literal>session.trans_sid_tags</literal> задаёт перезаписываемые теги HTML
       для включения идентификатора сессии когда включена поддержка прозрачных "sid".
-      По умолчанию <literal>a=href,area=href,frame=src,input=src,form=</literal>
+      По умолчанию <literal>a=href,area=href,frame=src,form=</literal>
      </simpara>
      <simpara>
       <literal>form</literal> — специальных тег. <literal>&lt;input hidden="session_id"
       name="session_name"&gt;</literal> добавляется в форму.
      </simpara>
+     <warning>
+      <simpara>
+       Изменение директивы <literal>session.trans_sid_tags</literal>
+       относительно значения по умолчанию объявлено устаревшим с PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        До PHP 7.1.0 для этого использовался <link
@@ -777,6 +807,12 @@
       Несколько хостов можно указать через запятую. Не допускается вставлять пробелы
       между хостами. Так правильно: <literal>php.net,wiki.php.net,bugs.php.net</literal>.
      </simpara>
+     <warning>
+      <simpara>
+       Установка директиве <literal>session.trans_sid_hosts</literal> непустого
+       значения объявлена устаревшей с PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5702: deprecation notices for `session.use_only_cookies`, `session.referer_check`, `session.use_trans_sid`, `session.trans_sid_tags` and `session.trans_sid_hosts`, in both the directive table and the descriptions.

Also corrects the documented default of `session.trans_sid_tags`, which still listed `input=src` on the RU side.

Fixes: #1575
