### PR TITLE
[Sync-EN] Remove 72 unused entities from language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 9eb61e3573bc9af825caa0aba34932850aa1b666 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <!ENTITY installation.enabled.disable 'Модуль включён по умолчанию. Модуль отключается во время выполнения опцией:'>
 
-<!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook">
 <entry>4.2.0</entry><entry>Генератор случайных чисел инициализируется автоматически.</entry></row>'>
-
-<!ENTITY warn.deprecated.feature-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>С PHP 5.3.0 функция
-<emphasis>УСТАРЕЛА</emphasis>. Полагаться на функцию настоятельно не рекомендуют.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>С PHP 5.3.0 функция
-<emphasis>УСТАРЕЛА</emphasis>. Полагаться на функцию настоятельно не рекомендуют.</simpara></warning>'>
 
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
@@ -123,10 +114,6 @@ PHP зависнет до завершения выполнения програ
 <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>Изменения аргументов
 отразятся на значениях, которые возвращает функция, если аргументы передали по ссылке.
 В PHP 7 также вернутся текущие значения, если аргументы передали по значению.</simpara></note>'>
-
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>Функцию нельзя передать
-как аргумент в версиях PHP до 5.3.0, поскольку для определения параметров функции необходим контекст выполнения.
-Если функцию всё же требуется передать, функцию присваивают переменной, которую уже разрешается передавать.</simpara></note>'>
 
 <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>Начиная с PHP 8.0.0
 семейство функций func_*() стремится к большей прозрачности в отношении именованных аргументов,
@@ -278,7 +265,6 @@ PHP зависнет до завершения выполнения програ
 </tip>'
 >
 
-
 <!-- Warnings -->
 
 <!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook">
@@ -299,30 +285,9 @@ PHP зависнет до завершения выполнения програ
 <!ENTITY deprecated.function 'Функция устарела.'>
 <!ENTITY removed.function 'Функцию удалили.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функция настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Начиная с PHP 5.3.0 функция <emphasis>УСТАРЕЛА</emphasis>, а в PHP 5.4.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 функция <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 5.4.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.5.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
  </simpara>
 </warning>'>
 
@@ -333,25 +298,10 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </warning>'>
 
-<!ENTITY warn.deprecated.feature-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.0.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.feature-7-1-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>
  Начиная с PHP 7.1.0 функция <emphasis>УСТАРЕЛА</emphasis>.
  Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-7-1-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.1.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
  </simpara>
 </warning>'>
 
@@ -390,14 +340,6 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </warning>'>
 
-<!ENTITY warn.deprecated.function-7-2-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.2.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
-</simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -415,28 +357,12 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </warning>'>
 
-<!ENTITY warn.deprecated.function-7-3-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.3.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Начиная с PHP 7.3.0 функция <emphasis>УСТАРЕЛА</emphasis>,
   а в PHP 8.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
   Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.feature-7-4-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.4.0 функциональность <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функциональность настоятельно не рекомендуют.
  </simpara>
 </warning>'>
 
@@ -509,14 +435,6 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </warning>'>
 
-<!ENTITY warn.deprecated.feature-8-4-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 8.4.0 функциональность <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функциональность настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -552,35 +470,6 @@ PHP зависнет до завершения выполнения програ
 <!ENTITY removed.php.future '
 Функция устарела и ее <emphasis xmlns="http://docbook.org/ns/docbook">удалят</emphasis> в будущем.'>
 
-<!ENTITY warn.deprecated.function.removed-5-3-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Функция <emphasis>УСТАРЕЛА</emphasis> и в PHP 5.3.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function.removed-5-5-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Функция <emphasis>УСТАРЕЛА</emphasis> и в PHP 5.5.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 псевдоним <emphasis>УСТАРЕЛ</emphasis>.
-  Полагаться на псевдоним настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
- Начиная с PHP 5.4.0 функция <emphasis>УСТАРЕЛА</emphasis>.
- Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.alias-5-4-0 '
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -589,59 +478,11 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </warning>'>
 
-<!ENTITY warn.deprecated.func-5-5-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.5.0 функция <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.5.0 функциональность <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 7.0.0 функциональность <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.5.0 функция <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 4.1.0 функция <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 функция <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Начиная с PHP 5.3.0 псевдоним <emphasis>УСТАРЕЛ</emphasis>,
   а в PHP 7.0.0 псевдоним <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.6.0 функциональность <emphasis>УСТАРЕЛА</emphasis>,
-  а в PHP 7.0.0 функциональность <emphasis>УДАЛИЛИ</emphasis>.
  </simpara>
 </warning>'>
 
@@ -738,14 +579,6 @@ PHP выдаст ошибку в виде сообщения «SSL: Fatal Protoc
 За обнаружение и подавление предупреждения отвечает разработчик, который вызывает функцию
 <function>fsockopen</function>, чтобы создать сокет <literal>ssl://</literal>.</simpara></warning>'>
 
-<!ENTITY warn.undocumented.class '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  К настоящему времени этот класс ещё не был документирован; для ознакомления доступен только список свойств и методов.
- </simpara>
-</warning>
-'>
-
 <!ENTITY warn.undocumented.func '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не задокументировали;
 для знакомства доступен только список аргументов.</simpara></warning>'>
@@ -753,64 +586,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 <!-- Deprecation and removal warnings designed for use with a list of
      alternatives. See en/reference/regex/functions/ereg.xml and
      en/reference/regex/reference.xml for examples of these in action. -->
-
-<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Функция <emphasis>УСТАРЕЛА</emphasis> с PHP 4.1.0,
- а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Эта функциональность объявлена <emphasis>УСТАРЕВШЕЙ</emphasis> в PHP 5.3.0
- и <emphasis>УДАЛЕНА</emphasis> в PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Функция <emphasis>УСТАРЕЛА</emphasis> с PHP 5.3.0,
- а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Функция <emphasis>УСТАРЕЛА</emphasis> с PHP 5.5.0,
- а в PHP 7.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
-<!ENTITY warn.removed.feature.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Эта функциональность <emphasis>УДАЛЕНА</emphasis> в PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
-<!ENTITY warn.removed.function.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Эта функция <emphasis>УДАЛЕНА</emphasis> в PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -847,8 +622,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 <!-- Misc -->
 
 <!ENTITY version.exists.asof 'Доступно с PHP '>
-
-<!ENTITY version.trunk.changelog 'В будущем'>
 
 <!ENTITY no.function.parameters '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -907,12 +680,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 <!ENTITY example.outputs.71 '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Результат выполнения приведённого примера в PHP 7.1:
-</simpara>
-'>
-
-<!ENTITY example.outputs.72 '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Результат выполнения приведённого примера в PHP 7.2:
 </simpara>
 '>
 
@@ -982,8 +749,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 </simpara>
 '>
 
-<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Результат выполнения приведённого примера в PHP 8.5:</simpara>'>
-
 <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">Результат выполнения приведённого примера в PHP 8.5 аналогичен:</simpara>'>
 
 <!ENTITY example.outputs.32bit '
@@ -1007,18 +772,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 <!ENTITY examples.outputs '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Результат выполнения приведённых примеров:
-</simpara>
-'>
-
-<!ENTITY examples.outputs.32bit '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Результат выполнения приведённых примеров на 32-битных машинах:
-</simpara>
-'>
-
-<!ENTITY examples.outputs.64bit '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Результат выполнения приведённых примеров на 64-битных машинах:
 </simpara>
 '>
 
@@ -1147,10 +900,6 @@ $compareFunc = static function ($item1, $item2) {
 <!ENTITY info.function.alias 'Псевдоним функции '>
 
 <!ENTITY info.method.alias 'Псевдоним метода '>
-
-<!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">Эта функция-псевдоним
-устарела и сохранилась только из-за обратной совместимости.
-Функцию не рекомендуют использовать, поскольку не исключают риск удаления функции из PHP в будущем.</simpara>'>
 
 <!ENTITY ext.windows.path.dll 'Модуль работает в ОС Windows,
 только когда системной переменной <envar xmlns="http://docbook.org/ns/docbook">PATH</envar>
@@ -1287,18 +1036,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функция
  </simpara>
 </listitem>
 </varlistentry>'>
-
-<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>key</parameter></term>
-<listitem>
- <simpara>
-  Список допустимых значений смотри: <link linkend="openssl.certparams">параметры публичного/приватного ключа</link>.
- </simpara>
-</listitem>
-</varlistentry>'>
-<!-- Image (GD) Notes -->
-<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>Эта функция доступна только в
-случае, если PHP был скомпилирован с опцией <option role="configure">--with-t1lib[=DIR]</option>.</simpara></note>'>
 
 <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>Эта функция доступна только в случае, если
 PHP был скомпилирован с поддержкой freetype (<option role="configure">--with-freetype-dir=DIR</option>)
@@ -1457,10 +1194,6 @@ $font = 'SomeFont';
 Константу указывают как значение аргумента функции <function>imagesetinterpolation</function>, доступна с PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-<entry>7.0.0</entry><entry>Поддержку библиотеки T1Lib удалили из PHP и поэтому функцию тоже удалили.</entry>
-</row>'>
-
 <!ENTITY gd.deprecated.gd-formats '
  <warning xmlns="http://docbook.org/ns/docbook">
   <simpara>
@@ -1487,12 +1220,6 @@ $font = 'SomeFont';
  Значение по умолчанию для параметра <parameter>escape</parameter> — <literal>"\\"</literal>,
  поэтому рекомендуют явно указывать пустую строку. Значение по умолчанию изменят в будущей версии PHP, но не раньше PHP 9.0.
 </simpara></warning>'>
-
-<!-- DBM notes -->
-
-<!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><simpara>Идентификатор соединения DBM,
-полученный из <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
@@ -1634,11 +1361,6 @@ $font = 'SomeFont';
 
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>imap</parameter></term><listitem><simpara>Экземпляр класса <classname>IMAP\Connection</classname>.</simpara></listitem></varlistentry>'>
-
-<!-- Deprecated -->
-<!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><simpara>Поток IMAP, который вернула функция
-<function>imap_open</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Определяет начало поиска в иерархии почтовых ящиков.
 </simpara><simpara xmlns="http://docbook.org/ns/docbook">Как часть параметра <parameter>pattern</parameter>
@@ -1828,17 +1550,9 @@ $font = 'SomeFont';
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Одна из констант <constant>MCRYPT_ciphername</constant> или название алгоритма в виде строки.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Указывают для инициализации в режимах CBC, CFB, OFB, а также в некоторых алгоритмах в режиме STREAM. Если IV не будет передан, в случае, если он необходим для используемого алгоритма, то функция сгенерирует предупреждение об ошибке и использует IV, все байты которого установлены в "<literal>\0</literal>".</simpara>'>
-
 <!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Указывают для инициализации в режимах CBC, CFB, OFB, а также в некоторых алгоритмах в режиме STREAM. Если переданный IV размер не поддерживается режимом сцепления или IV не был передан, а режим сцепления его требует, функция сгенерирует предупреждение об ошибке и вернёт &false;.</simpara>'>
 
 <!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">Одна из констант <constant>MCRYPT_MODE_modename</constant>, либо одна из следующих строк: "ecb", "cbc", "cfb", "ofb", "nofb" и "stream".</simpara>'>
-
-<!-- MCVE notes -->
-
-<!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><simpara>Ресурс MCVE_CONN, полученный из
-<function>m_initengine</function>.</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1958,8 +1672,6 @@ linkend="memcached.expiration" xmlns="http://docbook.org/ns/docbook">Время 
 
 <!ENTITY gearman.parameter.workload 'Сериализованные данные, которые подлежат обработке'>
 
-<!ENTITY gearman.parameter.data 'Дополнительные данные, которые иногда требуются для завершения работы'>
-
 <!ENTITY gearman.parameter.context 'Контекст приложения, который связывается с задачей'>
 
 <!ENTITY gearman.parameter.unique 'Уникальный ID, который назначается конкретной задаче'>
@@ -2044,12 +1756,6 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
  или <literal>Australia/Perth</literal> для приведённого примера.
 </simpara>'>
 
-<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-Аббревиатуры часовых поясов могут быть крайне изменчивыми, т. е. они могут меняться
-с каждым новым релизом "timezonedb".
-Крайне не рекомендуется использовать аббревиатуры часовых поясов.
-</simpara>'>
-
 <!ENTITY date.timezone.errors.description '
 <simpara xmlns="http://docbook.org/ns/docbook">
 Каждый вызов функции для работы с датой и временем генерирует ошибку уровня <constant>E_WARNING</constant>
@@ -2083,9 +1789,7 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
 который возвращает функция
 <function>timezone_open</function>.</simpara></listitem></varlistentry>'>
 
-<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Возвращает модифицированный объект <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> для применения в цепи методов&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Возвращает модифицированный объект <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> для применения в цепи методов.'>
-<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Метод возвращает новый объект <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> с модифицированными данными&return.falseforfailure;.'>
 <!ENTITY date.datetimeimmutable.return.modifiedobject 'Метод возвращает новый объект <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> с модифицированными данными.'>
 
 <!ENTITY date.timezone.dbversion 'Список основан на версии базы данных часовых поясов'>
@@ -2101,7 +1805,6 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
 <!ENTITY date.timezone.indian 'Индийский'>
 <!ENTITY date.timezone.pacific 'Тихоокеанский'>
 <!ENTITY date.timezone.others 'Другие'>
-<!ENTITY date.timezone.abbreviations 'Аббревиатуры'>
 
 <!ENTITY date.formats 'Объяснение корректных форматов даёт раздел «<link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">Форматы даты и времени</link>».'>
 <!ENTITY date.formats.parameter 'Строка даты и времени. &date.formats;'>
@@ -2190,7 +1893,6 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
 <!-- Dom Examples -->
 <!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">Следующие примеры используют файл <filename>book.xml</filename>, который содержит следующие данные:</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
- <!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE books [
@@ -2380,10 +2082,6 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
 GnuPG: или ресурс, который вернула функция <function>gnupg_init</function>, или объект класса <classname>gnupg</classname>.</simpara>'>
 
 <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">Отпечаток ключа.</simpara>'>
-
-<!-- HaruDoc -->
-<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Вызывает исключение <classname>HaruException</classname>
-в случае ошибки.</simpara>'>
 
 <!-- ODBC -->
 <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">Объект ODBC-соединения.
@@ -2577,7 +2275,6 @@ Oracle сделает всё возможное, чтобы преобразов
 или вызова функции <function>oci_set_prefetch</function>.
 </simpara>'>
 
-
 <!ENTITY oci.arg.statement.id
 "<simpara xmlns='http://docbook.org/ns/docbook'>Корректный идентификатор
 выражения OCI8, полученный из функции <function>oci_parse</function>
@@ -2594,7 +2291,6 @@ Oracle сделает всё возможное, чтобы преобразов
 <!-- XSLT Notes -->
 
 <!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>На поведение этой функции влияет значение директивы <link linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
-
 
 <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -2621,8 +2317,6 @@ Oracle сделает всё возможное, чтобы преобразов
 <!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Краткое разъяснение конфигурационных
 директив.</simpara>'>
 
-<!-- Common pieces for reference part BEGIN-->
-
 <!-- Used in reference/$extname/ini.xml -->
 <!ENTITY extension.runtime '<simpara xmlns="http://docbook.org/ns/docbook">
 Поведение функций зависит от установок в файле &php.ini;.
@@ -2642,13 +2336,6 @@ INI_* даёт раздел «<xref xmlns="http://docbook.org/ns/docbook" linken
 <!-- For STANDARD Constants used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">
 Следующие константы доступны как часть ядра PHP.
-</simpara>'>
-
-<!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
-Модуль определяет следующие классы
-и открывает к доступ к ним только тогда, когда модуль либо собрали в PHP,
-либо динамически загрузили при выполнении кода.
 </simpara>'>
 
 <!-- PDO entities -->
@@ -2680,8 +2367,6 @@ INI_* даёт раздел «<xref xmlns="http://docbook.org/ns/docbook" linken
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'Модуль &link.pecl; не поставляется вместе с PHP.'>
 
-<!ENTITY pecl.bundled 'Модуль &link.pecl; поставляется вместе с PHP.'>
-
 <!ENTITY pecl.info 'Информацию об установке этого PECL-модуля
 даёт глава руководства
 «<link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Установка PECL-модулей</link>».
@@ -2705,7 +2390,6 @@ INI_* даёт раздел «<xref xmlns="http://docbook.org/ns/docbook" linken
 Смотрите также раздел <link xmlns="http://docbook.org/ns/docbook" linkend="install.windows.building">сборка на Windows</link>.'>
 <!ENTITY pecl.windows.download.avail 'Бинарные файлы ОС Windows (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym>-файлы)
 для этого <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym>-модуля доступны на сайте репозитория PECL.'>
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
 <!ENTITY pecl.moved-ver 'Модуль переместили в репозиторий &link.pecl; и он больше не поставляется с PHP '>
 
@@ -2790,13 +2474,9 @@ INI_* даёт раздел «<xref xmlns="http://docbook.org/ns/docbook" linken
 
 <!-- Common pieces for reference part END -->
 
-
 <!ENTITY windows.builtin '<simpara xmlns="http://docbook.org/ns/docbook">В версию PHP для Windows
 встроили поддержку модуля PCRE. Доступ к функциям модуля открыт без загрузки
 дополнительных модулей.</simpara>'>
-
-<!-- These are here as helpers for manual consistency and brievety-->
-<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">безопасный режим</link>'>
 
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">SQL safe mode</link>'>
 
@@ -2891,37 +2571,6 @@ linkend="book.mysqlnd">mysqlnd</link>.'>
 итеративных свойств к большинству методов. Они не могут быть просмотрены с использованием
 <function>var_dump</function> или каких-либо других средств анализа объектов.</simpara></note>'>
 
-<!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Имена столбцов, возвращаемые
-<constant>SQLITE_ASSOC</constant> и <constant>SQLITE_BOTH</constant>, будут
-приведены к нужному регистру согласно значению конфигурационной опции
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</simpara>'>
-
-<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Когда параметр
-<parameter>decode_binary</parameter> установлен в &true; (по умолчанию),
-PHP будет декодировать бинарный код, применённый к данным, как если бы они были закодированы функцией
-<function>sqlite_escape_string</function>. Обычно вам следует оставлять
-это значение по умолчанию, если только вы не работаете с базой данных
-sqlite, которая была создана в ином приложении.</simpara>'>
-
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Эта функция не может быть использована
-с идентификаторами результатов небуферизированных запросов.</simpara></note>'>
-
-<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Поддерживаются два альтернативных
-синтаксиса для совместимости с другими модулями баз данных (например, MySQL).
-Предпочитаемая форма — первая, в которой параметр <parameter>dbhandle</parameter>
-является первым параметром функции.</simpara></note>'>
-
-<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">Необязательный параметр
-<parameter>result_type</parameter> принимает константу, определяющую, как будет
-индексирован возвращаемый массив.
-При использовании <constant>SQLITE_ASSOC</constant> будет возвращён
-ассоциативный массив, а при использовании <constant>SQLITE_NUM</constant>
-- числовой. <constant>SQLITE_BOTH</constant> вернёт массив как с
-ассоциативными, так и с числовыми индексами.
-Значением по умолчанию для этой функции является
-<constant>SQLITE_BOTH</constant>.</simpara>'>
-
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Имена полей, возвращаемые этой
 функцией являются <emphasis>зависимыми от регистра</emphasis>.</simpara></note>'>
@@ -2929,7 +2578,6 @@ sqlite, которая была создана в ином приложении.
 <!ENTITY database.fetch-null '<note xmlns="http://docbook.org/ns/docbook"><simpara>Эта функция устанавливает NULL-поля
 в значение &null; PHP.</simpara></note>'>
 
-<!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>link_identifier</parameter></term><listitem><simpara>Соединение MySQL. Если идентификатор соединения не был указан,
@@ -2993,17 +2641,6 @@ xmlns="http://docbook.org/ns/docbook"><term>
  Разработчикам доступны следующие альтернативы:
 </simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Функция устарела с PHP 5.5.0, а в PHP 7.0.0 функцию удалили
- вместе <link linkend="book.mysql">с модулем MySQL</link>.
- Вместо этой функции пользуются модулями <link linkend="book.mysqli">MySQLi</link>
- или <link linkend="ref.pdo-mysql">PDO_MySQL</link>, которые активно развиваются.
- Смотрите также раздел «<link linkend="mysqlinfo.api.choosing">MySQL: выбор API</link>».
- Разработчикам доступны следующие альтернативы:
-</simpara>
-'>
-
 <!ENTITY mysql.close.connections.result.sets '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Открытые непостоянные соединения MySQL и результирующие наборы автоматически удаляются
@@ -3030,20 +2667,6 @@ xmlns="http://docbook.org/ns/docbook"><term>
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'Объект <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>.'>
-
-<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">Параметр <parameter>config</parameter> передают
-как в виде строки, так и в виде массива. При передаче строки параметр оценивается
-как путь к конфигурационному файлу, иначе как конфигурация оценивается содержание массива.
-Подробная информация по каждой опции доступна на странице
-<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>.</simpara>
-<simpara>Параметр <parameter>encoding</parameter> устанавливает кодировку вводимых и выводимых документов.
- Параметр <parameter>encoding</parameter> принимает следующие значения:
- <literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
- <literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
- <literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
- <literal>utf16</literal>, <literal>utf16le</literal>,
- <literal>utf16be</literal>, <literal>big5</literal>
- и <literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
 <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Разработчики PHP не рекомендуют
@@ -3185,9 +2808,6 @@ xmlns="http://docbook.org/ns/docbook"><term>
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Функция в случае успешной работы возвращает &true;.'>
 <!ENTITY imagick.imagick.throws 'Функция выбрасывает исключение ImagickException, если возникла ошибка.'>
-<!ENTITY imagick.imagickdraw.throws 'Функция выбрасывает исключение ImagickDrawException, если возникла ошибка.'>
-<!ENTITY imagick.imagickpixel.throws 'Функция выбрасывает исключение ImagickPixelException, если возникла ошибка.'>
-<!ENTITY imagick.imagickpixeliterator.throws 'Функция выбрасывает исключение ImagickPixelIteratorException, если возникла ошибка.'>
 
 <!-- Imagick version infos -->
 <!ENTITY imagick.method.available.0x629 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.2.9 или старше.'>
@@ -3198,14 +2818,10 @@ xmlns="http://docbook.org/ns/docbook"><term>
 <!ENTITY imagick.method.available.0x638 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.3.8 или старше.'>
 <!ENTITY imagick.method.available.0x639 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.3.9 или старше.'>
 <!ENTITY imagick.method.available.0x640 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.0 или старше.'>
-<!ENTITY imagick.method.available.0x641 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.1 или старше.'>
-<!ENTITY imagick.method.available.0x642 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.2 или старше.'>
-<!ENTITY imagick.method.available.0x643 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.3 или старше.'>
 <!ENTITY imagick.method.available.0x644 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.4 или старше.'>
 <!ENTITY imagick.method.available.0x645 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.5 или старше.'>
 <!ENTITY imagick.method.available.0x647 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.7 или старше.'>
 <!ENTITY imagick.method.available.0x649 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.4.9 или старше.'>
-<!ENTITY imagick.method.available.0x653 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.5.3 или старше.'>
 <!ENTITY imagick.method.available.0x657 'Метод доступен, если модуль Imagick скомпилировали с версией ImageMagick 6.5.7 или старше.'>
 
 <!ENTITY imagick.method.not.available.0x700 'Этот метод недоступен, если Imagick
@@ -3327,8 +2943,6 @@ PHP скомпилирован с поддержкой libxml 20620 или ст�
 <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
 будет обновлено, если корректный контекст был передан в вызываемую функцию.</simpara></note>'>
 
-<!-- Gmagick -->
-<!ENTITY gmagick.return.success 'Функция возвращает &true; в случае успешного завершения работы.'>
 <!ENTITY gmagick.gmagickexception.throw 'Вызывает
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname>, если возникла ошибка.'>
 
@@ -3389,8 +3003,6 @@ PHP скомпилирован с поддержкой libxml 20620 или ст�
 или <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">
 код ошибки Win32</link>, если возникла ошибка.'
 >
-
-<!ENTITY win32service.success.false.error 'Функция возвращает &true; в случае успешного завершения&win32service.false.error;'>
 
 <!ENTITY win32service.noerror.false.error 'Функция возвращает
 <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant>
@@ -3594,8 +3206,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>
 
 <!ENTITY trader.arg.fastd.ma.type 'Тип скользящей средней для линии Fast-D. Параметр принимает константы семейства
-<link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>
-<!ENTITY trader.arg.fastk.ma.type 'Тип скользящей средней для линии Fast-K. Параметр принимает константы семейства
 <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link>.'>
 
 <!ENTITY trader.arg.slowk.ma.type 'Тип скользящей средней для линии Fast-K. Параметр принимает константы семейства
@@ -4345,9 +3955,6 @@ local: {
 '>
 <!ENTITY mongodb.throws.unacknowledged '<member xmlns="http://docbook.org/ns/docbook">При записи без подтверждения метод выбрасывает исключение <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>'>
 
-<!-- Больше не используется в EN-версии -->
-<!ENTITY mongodb.note.queryable-encryption-preview ''>
-
 <!ENTITY mongodb.note.decimal128 '
 <note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -4640,7 +4247,6 @@ local: {
    </itemizedlist>
 '>
 
-
 <!ENTITY strings.parameter.characters.optional '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Параметр <parameter>characters</parameter> принимает символы, которые удалит функция.
@@ -4655,7 +4261,6 @@ local: {
   принимает список символов, которые требуется удалить.
  </simpara>
 '>
-
 
 <!ENTITY strings.parameter.encoding '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -5064,16 +4669,6 @@ local: {
  </entry>
 </row>'>
 
-<!ENTITY strings.changelog.encoding '
-<row xmlns="http://docbook.org/ns/docbook">
- <entry>5.6.0</entry>
- <entry>
-  Значение по умолчанию для параметра <parameter>encoding</parameter> было изменено
-  на значение конфигурационной опции <link linkend="ini.default-charset">default_charset</link>.
- </entry>
-</row>
-'>
-
 <!ENTITY strings.changelog.ascii-case-conversion '
 <row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
@@ -5253,30 +4848,6 @@ local: {
   </simpara>
 '>
 
-<!-- filter snippets -->
-<!-- TODO: Remove -->
-<!ENTITY filter.param.filter '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>filter</parameter></term>
- <listitem>
-  <simpara>
-   Фильтр, который требуется применить.
-   Параметр принимает фильтры проверки в виде константы семейства
-   <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>,
-   фильтр очистки в виде константы семейства
-   <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>
-   или фильтр <constant>FILTER_UNSAFE_RAW</constant>, или пользовательский фильтр в виде
-   константы <constant>FILTER_CALLBACK</constant>.
-  </simpara>
-  <simpara>
-   По умолчанию функция применяет фильтр <constant>FILTER_DEFAULT</constant> —
-   псевдоним фильтра <constant>FILTER_UNSAFE_RAW</constant>.
-   В результате поведением по умолчанию становится отсутствие фильтрации.
-  </simpara>
- </listitem>
-</varlistentry>
-'>
-
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -5381,7 +4952,6 @@ local: {
    Вместо возврата объекта при недопустимом URL-адресе метод выбрасывает исключение <exceptionname>Uri\WhatWg\InvalidUrlException</exceptionname>.
   </simpara>
 '>
-
 
 <!-- UOPZ snippets -->
 


### PR DESCRIPTION
Syncs the RU file with php/doc-en#5625. None of the 72 removed entities is referenced anywhere in doc-ru, so the removal is safe. The comments dropped on the EN side are dropped here too.

Fixes: #1570
