### PR TITLE
[Sync-EN] reflection: translate ReflectionProperty::getMangledName (PHP 8.5)

### DIFF
--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 844a420240e6944d391d6ae022af239c4961ed04 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="reflectionproperty.getmangledname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getMangledName</refname>
+  <refpurpose>Возвращает искажённое имя свойства</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type>string</type><methodname>ReflectionProperty::getMangledName</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Метод возвращает искажённое (внутреннее) имя свойства, которое кодирует
+   область видимости закрытых и защищённых свойств.
+  </simpara>
+  <simpara>
+   Для открытых свойств искажённое имя совпадает с именем свойства.
+   Для защищённых свойств искажённое имя имеет вид
+   <literal>\0*\0<replaceable>имя</replaceable></literal>.
+   Для закрытых свойств искажённое имя имеет вид
+   <literal>\0<replaceable>ИмяКласса</replaceable>\0<replaceable>имя</replaceable></literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Метод возвращает искажённое имя свойства, которое отражает.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Метод добавили.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionProperty::getName</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionproperty.getmangledname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::getMangledName</refname>
-  <refpurpose>Возвращает искажённое имя свойства</refpurpose>
+  <refpurpose>Возвращает искажённое название свойства</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,15 +14,15 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Метод возвращает искажённое (внутреннее) имя свойства, которое кодирует
-   область видимости закрытых и защищённых свойств.
+   Метод возвращает искажённое — внутреннее — название свойства.
+   В искажённом представлении кодируется область видимости свойства:
   </simpara>
   <simpara>
-   Для открытых свойств искажённое имя совпадает с именем свойства.
-   Для защищённых свойств искажённое имя имеет вид
-   <literal>\0*\0<replaceable>имя</replaceable></literal>.
-   Для закрытых свойств искажённое имя имеет вид
-   <literal>\0<replaceable>ИмяКласса</replaceable>\0<replaceable>имя</replaceable></literal>.
+   Искажённые названия открытых свойств совпадают с исходными.
+   Названия защищённых свойств кодируются
+   как <literal>\0*\0<replaceable>название</replaceable></literal>.
+   Закрытые свойств кодируются в виде
+   <literal>\0<replaceable>НазваниеКласса</replaceable>\0<replaceable>название</replaceable></literal>.
   </simpara>
  </refsect1>
 
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Метод возвращает искажённое имя свойства, которое отражает.
+   Метод возвращает искажённое название отражаемого свойства.
   </simpara>
  </refsect1>
 
@@ -52,7 +52,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       Метод добавили.
+       Метод появился в классе.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Adds the RU page for the method documented in php/doc-en#5693. The RU file did not exist yet.

Fixes: #1562
