### PR TITLE
[Sync-EN] curl: document new PHP 8.5 constants and more cURL deprecations

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dec90c90d3662c5433f7c3972f8557321da7b11d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="curl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -209,6 +209,53 @@
      auth, libcurl проверит наличие неограниченного auth,
      или, если нет, то только этот алгоритм auth является приемлемым.
      Константа доступна с cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-all">
+   <term>
+    <constant>CURLFOLLOW_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение константы <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     переход по перенаправлениям и сохраняет пользовательский метод запроса, который
+     задали константой <constant>CURLOPT_CUSTOMREQUEST</constant>, для всех запросов,
+     даже после перенаправлений.
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-obeycode">
+   <term>
+    <constant>CURLFOLLOW_OBEYCODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение константы <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     переход по перенаправлениям с учётом кода HTTP-ответа: пользовательский метод запроса,
+     который задали константой <constant>CURLOPT_CUSTOMREQUEST</constant>, сохраняется,
+     кроме случаев, когда код состояния перенаправления требует заменить метод
+     на <literal>GET</literal> (например, коды 301, 302 и 303).
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-firstonly">
+   <term>
+    <constant>CURLFOLLOW_FIRSTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Значение константы <constant>CURLOPT_FOLLOWLOCATION</constant>, которое включает
+     переход по перенаправлениям, но задействует пользовательский метод запроса,
+     который задали константой <constant>CURLOPT_CUSTOMREQUEST</constant>, только
+     для первого запроса; последующие запросы следуют методу, который диктует
+     код ответа перенаправления.
+     Константа доступна с PHP 8.5.0 и cURL 8.13.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f34918d8b2761af5b596b1b762753ee825c19cd8 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
@@ -72,6 +72,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-conn-id">
+  <term>
+   <constant>CURLINFO_CONN_ID</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Идентификатор последнего соединения, которое задействовала передача. Идентификатор соединения уникален среди всех соединений, которые используют один и тот же кеш соединений, и помогает отличить повторное использование соединения.
+    Константа доступна с PHP 8.5.0 и cURL 8.2.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-connect-time">
   <term>
    <constant>CURLINFO_CONNECT_TIME</constant>
@@ -103,7 +115,7 @@
   </term>
   <listitem>
    <simpara>
-    Получает размер полученных данных, который дескриптор прочитал из поля заголовка Content-Length.
+    Получает размер полученных данных, который дескриптор прочитал из поля заголовка Content-Length. Опция устарела с cURL 7.55.0. Вместо неё используют константу <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>.
    </simpara>
   </listitem>
  </varlistentry>
@@ -257,6 +269,18 @@
   <listitem>
    <simpara>
     Получает битовую маску доступного метода или методов аутентификации на основе данных предыдущего ответа.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-httpauth-used">
+  <term>
+   <constant>CURLINFO_HTTPAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Битовая маска, которая указывает метод или методы HTTP-аутентификации, которые фактически задействовал предыдущий запрос.
+    Константа доступна с PHP 8.5.0 и cURL 8.12.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -458,6 +482,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-proxyauth-used">
+  <term>
+   <constant>CURLINFO_PROXYAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Битовая маска, которая указывает метод или методы аутентификации на прокси-сервере, которые фактически задействовал предыдущий запрос.
+    Константа доступна с PHP 8.5.0 и cURL 8.12.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-proxy-error">
   <term>
    <constant>CURLINFO_PROXY_ERROR</constant>
@@ -483,6 +519,18 @@
     Получает результат запрошенной проверки сертификата (с опцией
     <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> option). Работает только для серверов HTTPS-прокси.
     Опция доступна с PHP 7.3.0 и cURL 7.52.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-queue-time-t">
+  <term>
+   <constant>CURLINFO_QUEUE_TIME_T</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Время в микросекундах, которое передача провела в очереди ожидания перед запуском из-за ограничений, которые задали константой <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant> или похожими опциями.
+    Константа доступна с PHP 8.5.0 и cURL 8.6.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -671,7 +719,7 @@
   </term>
   <listitem>
    <simpara>
-    Общее количество переданных байтов.
+    Общее количество переданных байтов. Опция устарела с cURL 7.55.0. Вместо неё используют константу <constant>CURLINFO_SIZE_UPLOAD_T</constant>.
    </simpara>
   </listitem>
  </varlistentry>
@@ -694,7 +742,7 @@
   </term>
   <listitem>
    <simpara>
-    Средняя скорость получения данных.
+    Средняя скорость получения данных. Опция устарела с cURL 7.55.0. Вместо неё используют константу <constant>CURLINFO_SPEED_DOWNLOAD_T</constant>.
    </simpara>
   </listitem>
  </varlistentry>
@@ -717,7 +765,7 @@
   </term>
   <listitem>
    <simpara>
-    Средняя скорость передачи данных.
+    Средняя скорость передачи данных. Опция устарела с cURL 7.55.0. Вместо неё используют константу <constant>CURLINFO_SPEED_UPLOAD_T</constant>.
    </simpara>
   </listitem>
  </varlistentry>
@@ -798,6 +846,18 @@
    <simpara>
     Общее время предыдущей передачи в микросекундах, включая разрешение имени, TCP-соединение и т. д.
     Опция доступна с PHP 7.3.0 и cURL 7.61.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-used-proxy">
+  <term>
+   <constant>CURLINFO_USED_PROXY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Задействовала ли предыдущая передача прокси-сервер; возвращает <literal>1</literal>, если прокси-сервер задействовали, и <literal>0</literal> в противном случае.
+    Константа доступна с PHP 8.5.0 и cURL 8.7.0.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
@@ -1360,6 +1360,20 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infilesize-large">
+   <term>
+    <constant>CURLOPT_INFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ожидаемый размер файла в байтах, когда файл выгружают на удалённый сайт.
+     Это 64-битный вариант константы <constant>CURLOPT_INFILESIZE</constant>,
+     который разрешает указывать размеры больше 2 ГБ.
+     Константа доступна с PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-interface">
    <term>
     <constant>CURLOPT_INTERFACE</constant>
@@ -1485,7 +1499,7 @@
      Если строка (<type>string</type>) установлена, но не соответствует ни одной из них, используется <literal>private</literal>.
      Установка опции в &null; отключит поддержку kerberos для FTP.
      По умолчанию &null;.
-     Доступно с cURL 7.16.4.
+     Доступно с cURL 7.16.4, устарела с cURL 8.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2193,13 +2207,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Битовая маска значений <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
      Если используется, эта битовая маска ограничивает, какие протоколы cURL может использовать в передаче.
      По умолчанию <constant>CURLPROTO_ALL</constant>, то есть cURL будет принимать все поддерживаемые им протоколы.
-     Смотрите также <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
+     Смотрите также <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>.
      Доступно с cURL 7.19.4 и устарела с cURL 7.85.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-protocols-str">
@@ -3564,12 +3578,12 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Значение &true; для включения и &false; для отключения ложного старта TLS,
      который представляет собой режим, в котором TLS-клиент начинает отправку данных приложения
      до проверки сообщения <literal>Finished</literal> сервера.
-     Доступно с PHP 7.0.7 и cURL 7.42.0.
-    </para>
+     Доступно с PHP 7.0.7 и cURL 7.42.0. Опция устарела с cURL 8.15.0.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-options">


### PR DESCRIPTION
Syncs the RU curl constant pages with php/doc-en#5606 and php/doc-en#5678, plus the follow-up commit e7e81a1 that turned the `CURLOPT_INFILESIZE_LARGE` description into a `simpara`.

The two upstream PRs both touch `constants_curl_getinfo.xml` and `constants_curl_setopt.xml`, so they are synced together to avoid conflicting branches.

Fixes: #1487
Fixes: #1559
