### PR TITLE
[Sync-EN] Fix broken examples in snmp2_getnext and SOAP pages

### DIFF
--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-getnext">
  <refnamediv>
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Функция <function>snmp2_get_next</function> используется для чтения значения
+   Функция <function>snmp2_getnext</function> используется для чтения значения
    объекта <acronym>SNMP</acronym>, который следует за указанным <parameter>object_id</parameter>.
   </simpara>
  </refsect1>
@@ -80,11 +80,11 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <function>snmp2_get_next</function></title>
+   <title>Пример использования <function>snmp2_getnext</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1');
+$nameOfSecondInterface = snmp2_getnext('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
    </programlisting>

--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-getnext">
  <refnamediv>
   <refname>snmp2_getnext</refname>
-  <refpurpose>Получает объект <acronym>SNMP</acronym>, который следует за данным идентификатором объекта</refpurpose>
+  <refpurpose>Получает следующий <acronym>SNMP</acronym>-объект</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,8 +18,8 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Функция <function>snmp2_getnext</function> используется для чтения значения
-   объекта <acronym>SNMP</acronym>, который следует за указанным <parameter>object_id</parameter>.
+   Функция <function>snmp2_getnext</function> считывает значение
+   <acronym>SNMP</acronym>-объекта, который идёт после объекта с идентификатором <parameter>object_id</parameter>.
   </simpara>
  </refsect1>
 
@@ -30,7 +30,7 @@
     <term><parameter>hostname</parameter></term>
     <listitem>
      <simpara>
-      Имя хоста агента (сервера) <acronym>SNMP</acronym>.
+      Имя хоста <acronym>SNMP</acronym>-агента.
      </simpara>
     </listitem>
    </varlistentry>
@@ -46,7 +46,7 @@
     <term><parameter>object_id</parameter></term>
     <listitem>
      <simpara>
-      Идентификатор объекта <acronym>SNMP</acronym>, который предшествует желаемому.
+      Идентификатор <acronym>SNMP</acronym>-объекта, который идёт перед целевым.
      </simpara>
     </listitem>
    </varlistentry>
@@ -72,20 +72,20 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает значение объекта <acronym>SNMP</acronym> в случае успешного выполнения или &false; в случае возникновения ошибки.
-   В случае возникновения ошибки выводится ошибка уровня E_WARNING.
+   При успешном выполнени функция возвращает значение объекта <acronym>SNMP</acronym> или &false;, если возникла ошибка;
+   при ошибке выводится сообщение уровня E_WARNING.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Пример использования <function>snmp2_getnext</function></title>
+   <title>Пример получения SNMP-объекта функцией <function>snmp2_getnext</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $nameOfSecondInterface = snmp2_getnext('localhost', 'public', 'IF-MIB::ifName.1');
-?>
 ]]>
    </programlisting>
   </example>

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: bfl Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: bfl Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.getlastrequestheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "ЗАГОЛОВКИ ЗАПРОСА:\n" . $client->__getLastRequestHeaders() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -14,12 +14,12 @@
    <void/>
   </methodsynopsis>
   <para>
-   Возвращает SOAP-заголовки последнего запроса.
+   Метод возвращает SOAP-заголовки последнего запроса.
   </para>
   <note>
    <para>
-    Функция работает только, если объект <classname>SoapClient</classname>
-    был создан с настройкой <literal>trace</literal>, равной &true;.
+    Метод работает, только если объект <classname>SoapClient</classname>
+    создали с настройкой <literal>trace</literal> со значением &true;.
    </para>
   </note>
  </refsect1>
@@ -40,14 +40,14 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования SoapClient::__getLastRequestHeaders()</title>
+    <title>Пример получения заголовков последнего запроса методом SoapClient::__getLastRequestHeaders()</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "ЗАГОЛОВКИ ЗАПРОСА:\n" . $client->__getLastRequestHeaders() . "\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/soap/soapclient/getlastresponse.xml
+++ b/reference/soap/soapclient/getlastresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: mch Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "Ответ:\n" . $client->__getLastResponse() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponse.xml
+++ b/reference/soap/soapclient/getlastresponse.xml
@@ -14,12 +14,12 @@
    <void/>
   </methodsynopsis>
   <para>
-   Возвращает XML, полученный в последнем SOAP-ответе.
+   Метод возвращает XML-документ из последнего SOAP-ответа.
   </para>
   <note>
    <para>
-    Метод работает только для объекта <classname>SoapClient</classname>,
-    созданного с настройкой <literal>trace</literal>, равной &true;.
+    Метод работает, только если объект <classname>SoapClient</classname>
+    создали с настройкой <literal>trace</literal> со значением &true;.
    </para>
   </note>
  </refsect1>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Последний SOAP-ответ в виде строки с XML.
+   Метод возвращает последний SOAP-ответ в виде XML-строки.
   </para>
  </refsect1>
 
@@ -40,14 +40,14 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования SoapClient::__getLastResponse()</title>
+    <title>Пример получения последнего SOAP-ответа методом SoapClient::__getLastResponse()</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "Ответ:\n" . $client->__getLastResponse() . "\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/soap/soapclient/getlastresponseheaders.xml
+++ b/reference/soap/soapclient/getlastresponseheaders.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: mch Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.getlastresponseheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "ЗАГОЛОВКИ ОТВЕТА:\n" . $client->__getLastResponseHeaders() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponseheaders.xml
+++ b/reference/soap/soapclient/getlastresponseheaders.xml
@@ -14,12 +14,12 @@
    <void/>
   </methodsynopsis>
   <para>
-   Возвращает SOAP-заголовки последнего ответа.
+   Метод возвращает SOAP-заголовки последнего ответа.
   </para>
   <note>
    <para>
-    Функция работает только, если объект <classname>SoapClient</classname>
-    был создан с настройкой <literal>trace</literal>, равной &true;.
+    Метод работает только, если объект <classname>SoapClient</classname>
+    создали с настройкой <literal>trace</literal> со значением &true;.
    </para>
   </note>
  </refsect1>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Заголовки последнего SOAP-ответа.
+   Метод возвращает заголовки последнего SOAP-ответа.
   </para>
  </refsect1>
 
@@ -40,14 +40,14 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования SoapClient::__getLastResponse()</title>
+    <title>Пример получения заголовков последнего SOAP-ответа методом SoapClient::__getLastResponse()</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "ЗАГОЛОВКИ ОТВЕТА:\n" . $client->__getLastResponseHeaders() . "\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -14,12 +14,12 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Метод возвращает строку в формате XML, который сервер SOAP отправил в последнем ответе.
+   Метод возвращает XML-документ, который SOAP-сервер отправил в последнем ответе.
   </simpara>
   <note>
    <simpara>
     Метод работает, только если объект <classname>SoapServer</classname>
-    создали с опцией <literal>trace</literal>, для которой установили значение &true;.
+    создали с опцией <literal>trace</literal> со значением &true;.
    </simpara>
   </note>
  </refsect1>
@@ -46,10 +46,7 @@
 
 $server = new SoapServer("some.wsdl", ["trace" => 1]);
 $server->handle();
-
 echo "Ответ:\n", $server->__getLastResponse(), "\n";
-
-?>
 ]]>
    </programlisting>
   </example>

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e1f81cbbe7613ce7bbe65cc93c45fae38e0942b Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapserver.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,7 +44,7 @@
 <![CDATA[
 <?php
 
-$server = SoapServer("some.wsdl", ["trace" => 1]);
+$server = new SoapServer("some.wsdl", ["trace" => 1]);
 $server->handle();
 
 echo "Ответ:\n", $server->__getLastResponse(), "\n";


### PR DESCRIPTION
Syncs the RU pages with php/doc-en#5710: the `snmp2_get_next` typo becomes `snmp2_getnext`, and the SOAP examples instantiate `SoapClient`/`SoapServer` with `new`.

Fixes: #1571
