### PR TITLE
[Sync-EN] imagick: fix broken methodsynopsis xpointers in exception classes

### DIFF
--- a/reference/imagick/imagickdrawexception.xml
+++ b/reference/imagick/imagickdrawexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <reference role="exception" xml:id="class.imagickdrawexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Исключение ImagickDrawException</title>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickdrawexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickDrawException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickDrawException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickexception.xml
+++ b/reference/imagick/imagickexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <reference role="exception" xml:id="class.imagickexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Исключение ImagickException</title>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickkernelexception.xml
+++ b/reference/imagick/imagickkernelexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.imagickkernelexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -24,7 +24,7 @@
    <classsynopsis>
     <ooclass><classname>ImagickKernelException</classname></ooclass>
 
-    <!-- {{{ Class synopsis -->
+<!-- {{{ Class synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>ImagickKernelException</classname>
@@ -35,21 +35,14 @@
       <classname>Exception</classname>
      </ooclass>
     </classsynopsisinfo>
-    <!-- }}} -->
+<!-- }}} -->
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickkernelexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickKernelException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickKernelException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
    <!-- }}} -->

--- a/reference/imagick/imagickpixelexception.xml
+++ b/reference/imagick/imagickpixelexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <reference role="exception" xml:id="class.imagickpixelexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Исключение ImagickPixelException</title>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickpixelexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickpixeliteratorexception.xml
+++ b/reference/imagick/imagickpixeliteratorexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <reference role="exception" xml:id="class.imagickpixeliteratorexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Исключение ImagickPixelIteratorException</title>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickpixeliteratorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelIteratorException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelIteratorException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->


### PR DESCRIPTION
Syncs the RU pages with php/doc-en#5700: drops the `xi:fallback` wrappers and the `&Methods;` block that pointed at a non-existent methodsynopsis, and inherits the `Exception` constructor and methods instead.

The class synopsis holds no translatable text, so the block is mirrored from EN as is.

Fixes: #1567
