### PR TITLE
[Sync-EN] pdo, pgsql: add PHP 8.4.0 changelog entries

### DIFF
--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -80,6 +80,29 @@
    <exceptionname>PDOException</exceptionname>,
    когда базовый драйвер не поддерживает запрошенный в параметре <parameter>attribute</parameter> атрибут.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Теперь доступно получение значения атрибута
+       <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: mch Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -39,18 +39,14 @@
        Одна из констант <literal>PDO::ATTR_*</literal>. Список общих атрибутов,
        применяемых к подключениям к базе данных:
        <simplelist>
-        <member><literal>PDO::ATTR_AUTOCOMMIT</literal></member>
         <member><literal>PDO::ATTR_CASE</literal></member>
-        <member><literal>PDO::ATTR_CLIENT_VERSION</literal></member>
-        <member><literal>PDO::ATTR_CONNECTION_STATUS</literal></member>
+        <member><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal></member>
         <member><literal>PDO::ATTR_DRIVER_NAME</literal></member>
         <member><literal>PDO::ATTR_ERRMODE</literal></member>
         <member><literal>PDO::ATTR_ORACLE_NULLS</literal></member>
         <member><literal>PDO::ATTR_PERSISTENT</literal></member>
-        <member><literal>PDO::ATTR_PREFETCH</literal></member>
-        <member><literal>PDO::ATTR_SERVER_INFO</literal></member>
-        <member><literal>PDO::ATTR_SERVER_VERSION</literal></member>
-        <member><literal>PDO::ATTR_TIMEOUT</literal></member>
+        <member><literal>PDO::ATTR_STATEMENT_CLASS</literal></member>
+        <member><literal>PDO::ATTR_STRINGIFY_FETCHES</literal></member>
        </simplelist>
       </para>
       <simpara>

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -16,14 +16,14 @@
   </methodsynopsis>
 
   <para>
-   Эта функция возвращает значение атрибута соединения с базой данных. Чтобы
-   получить атрибуты объекта PDOStatement, обращаются
-   к методу <methodname>PDOStatement::getAttribute</methodname>.
+   Метод возвращает значение атрибута соединения с базой данных.
+   Атрибуты объекта PDOStatement получают
+   методом <methodname>PDOStatement::getAttribute</methodname>.
   </para>
 
   <para>
-   Обратите внимание, что не все комбинации «база данных/драйвер» поддерживают все
-   атрибуты соединения с базой данных.
+   Обратите внимание, что не каждая комбинация «база данных/драйвер» поддерживает
+   все атрибуты соединения с базой данных.
   </para>
 
  </refsect1>
@@ -36,8 +36,8 @@
      <term><parameter>attribute</parameter></term>
      <listitem>
       <para>
-       Одна из констант <literal>PDO::ATTR_*</literal>. Список общих атрибутов,
-       применяемых к подключениям к базе данных:
+       Константа семейства <literal>PDO::ATTR_*</literal>. Список общих атрибутов
+       для применения к подключениям к базе данных:
        <simplelist>
         <member><literal>PDO::ATTR_CASE</literal></member>
         <member><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal></member>
@@ -50,10 +50,10 @@
        </simplelist>
       </para>
       <simpara>
-       Некоторые драйверы могут использовать дополнительные,
-       характерные для этого драйвера, атрибуты.
-       Обратите внимание, что атрибуты драйвера <emphasis>не должны</emphasis>
-       быть использованы с другими драйверами.
+       Отдельные драйверы поддерживают дополнительные
+       специфичные для драйвера атрибуты.
+       Обратите внимание: специфичные для конкретного драйвера атрибуты <emphasis>нельзя</emphasis>
+       применять с другими драйверами.
       </simpara>
      </listitem>
      </varlistentry>
@@ -64,17 +64,17 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Возвращает значение атрибута запрошенного PDO (при успешном вызове).
-   Неудачный вызов возвращает <literal>null</literal>.
+   При успешном вызове метод возвращает значение PDO-атрибута
+   иначе возвращается <literal>null</literal>.
   </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Метод <methodname>PDO::getAttribute</methodname> может выбросить исключение
+   Метод <methodname>PDO::getAttribute</methodname> выбрасывает исключение
    <exceptionname>PDOException</exceptionname>,
-   когда базовый драйвер не поддерживает запрошенный в параметре <parameter>attribute</parameter> атрибут.
+   если базовый драйвер не поддерживает атрибут, который запросили в аргументе <parameter>attribute</parameter>.
   </para>
  </refsect1>
 
@@ -92,7 +92,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Теперь доступно получение значения атрибута
+       Метод теперь поддерживает получение значения атрибута
        <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>.
       </entry>
      </row>
@@ -105,11 +105,13 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Получение атрибутов соединения с базой данных</title>
+    <title>Пример получение атрибутов соединения с базой данных</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $conn = new PDO('odbc:sample', 'db2inst1', 'ibmdb2');
+
 $attributes = array(
     "AUTOCOMMIT", "ERRMODE", "CASE", "CLIENT_VERSION", "CONNECTION_STATUS",
     "ORACLE_NULLS", "PERSISTENT", "PREFETCH", "SERVER_INFO", "SERVER_VERSION",
@@ -120,7 +122,6 @@ foreach ($attributes as $val) {
     echo "PDO::ATTR_$val: ";
     echo $conn->getAttribute(constant("PDO::ATTR_$val")) . "\n";
 }
-?>
 ]]>
     </programlisting>
     <!--

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87c67b277e1772956eeb7906f04af18b0284ca7c Maintainer: mch Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-fetch-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,6 +87,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Сигнатура функции <function>pg_fetch_result</function> с двумя аргументами
+       (<parameter>result</parameter>,
+       <parameter>field</parameter>) объявлена устаревшей.
+       Вместо неё используют сигнатуру с тремя аргументами, передавая
+       параметру <parameter>row</parameter> значение &null;.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.pg-fetch-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_fetch_result</refname>
-  <refpurpose>Возвращает запись из результата запроса</refpurpose>
+  <refpurpose>Возвращает значение ячейки из результата запроса</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,8 +21,8 @@
    <methodparam><type>mixed</type><parameter>field</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Функция <function>pg_fetch_result</function> возвращает значение ячейки
-   таблицы экземпляра класса <classname>PgSql\Result</classname>.
+   Функция <function>pg_fetch_result</function> возвращает значение
+   конкретных строки и столбца из объекта <classname>PgSql\Result</classname>.
   </para>
   <note>
    <para>
@@ -90,11 +90,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Сигнатура функции <function>pg_fetch_result</function> с двумя аргументами
-       (<parameter>result</parameter>,
-       <parameter>field</parameter>) объявлена устаревшей.
-       Вместо неё используют сигнатуру с тремя аргументами, передавая
-       параметру <parameter>row</parameter> значение &null;.
+       Сигнатура функции <function>pg_fetch_result</function> с двумя аргументами —
+       <parameter>result</parameter> и <parameter>field</parameter> — устарела;
+       функцию вызывают с тремя аргументами
+       с передачей в параметр <parameter>row</parameter> значения &null;.
       </entry>
      </row>
      <row>
@@ -124,15 +123,13 @@ $res = pg_query($db, "SELECT 1 UNION ALL SELECT 2");
 
 $val = pg_fetch_result($res, 1, 0);
 
-echo "Первое поле во второй строчке результата это: ", $val, "\n";
-
-?>
+echo "Первое поле во второй строчке результата: ", $val, "\n";
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Первое поле во второй строчке результата это: 2
+Первое поле во второй строчке результата: 2
 ]]>
     </screen>
    </example>

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: mch Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-field-is-null" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -84,6 +84,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Сигнатура функции <function>pg_field_is_null</function> с двумя аргументами
+       (<parameter>result</parameter>,
+       <parameter>field</parameter>) объявлена устаревшей.
+       Вместо неё используют сигнатуру с тремя аргументами, передавая
+       параметру <parameter>row</parameter> значение &null;.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.pg-field-is-null" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_field_is_null</refname>
-  <refpurpose>Проверяет поля на значение SQL <literal>NULL</literal></refpurpose>
+  <refpurpose>Проверяет поле на SQL-значение <literal>NULL</literal></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,8 +22,8 @@
   </methodsynopsis>
   <para>
    Функция <function>pg_field_is_null</function> проверяет,
-   содержит ли ячейка экземпляра класса <classname>PgSql\Result</classname>
-   значение SQL <literal>NULL</literal>.
+   содержит ли ячейка в объекте <classname>PgSql\Result</classname>
+   SQL-значение <literal>NULL</literal>.
   </para>
   <note>
    <para>
@@ -46,7 +46,7 @@
      <term><parameter>row</parameter></term>
      <listitem>
       <para>
-       Номер строки результата запроса с нужным полем. Нумерация строк начинается с нуля.
+       Номер строки в результате, из которой требуется извлечь значение. Нумерация строк начинается с нуля.
        Функция выбирает текущую строку, если аргумент не задали.
       </para>
      </listitem>
@@ -67,9 +67,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Функция возвращает значение <literal>1</literal>, если выбранное значение SQL — <literal>NULL</literal>,
-   <literal>0</literal> для других значений. Функция вернёт значение &false;, если номер строки будет вне
-   допустимого диапазона, и при прочих ошибках.
+   Функция возвращает значение <literal>1</literal>, если выбранное SQL-значение — <literal>NULL</literal>,
+   <literal>0</literal> для других значений. Функция вернёт значение &false;, если номер строки выйдет
+   за пределы допустимого диапазона, и при прочих ошибках.
   </para>
  </refsect1>
 
@@ -87,11 +87,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Сигнатура функции <function>pg_field_is_null</function> с двумя аргументами
-       (<parameter>result</parameter>,
-       <parameter>field</parameter>) объявлена устаревшей.
-       Вместо неё используют сигнатуру с тремя аргументами, передавая
-       параметру <parameter>row</parameter> значение &null;.
+       Сигнатура функции <function>pg_field_is_null</function> с двумя аргументами —
+       <parameter>result</parameter> и <parameter>field</parameter> — устарела;
+       функцию вызывают с тремя аргументами
+       с передачей в параметр <parameter>row</parameter> значения &null;.
       </entry>
      </row>
      <row>
@@ -110,12 +109,12 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Пример использования функции <function>pg_field_is_null</function></title>
+    <title>Пример проверки значения поля функции <function>pg_field_is_null</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$dbconn = pg_connect("dbname=publisher") or die ("Не удалось соединиться с базой");
+$dbconn = pg_connect("dbname=publisher") or die ("Ошибка подключения к БД");
 $res = pg_query($dbconn, "SELECT * FROM authors WHERE author = 'Orwell'");
 
 if ($res) {
@@ -123,11 +122,9 @@ if ($res) {
         echo "Значение поля year — null.\n";
     }
     if (pg_field_is_null($res, 0, "year") == 0) {
-        echo "Значение поля year не null.\n";
+        echo "Значение поля year не равно null.\n";
     }
 }
-
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.pg-field-prtlen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_field_prtlen</refname>
-  <refpurpose>Возвращает количество печатаемых символов</refpurpose>
+  <refpurpose>Возвращает количество выводимых символов</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,18 +21,19 @@
    <methodparam><type>mixed</type><parameter>field_name_or_number</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Функция <function>pg_field_prtlen</function> возвращает длину строки,
-   количество символов, значения поля при выводе результата <parameter>result</parameter>.
-   Строки нумеруются с нуля. Функция вернёт &false; в случае возникновения ошибки.
+   Функция <function>pg_field_prtlen</function> возвращает количество символов,
+   которое займет при выводе значение поля из объекта <parameter>result</parameter>
+   с результатами запроса к СУБД PostgreSQL.
+   Строки нумеруются с нуля. Функция вернёт &false;, если возникнет ошибка.
   </para>
   <para>
-   <parameter>field_name_or_number</parameter> Номер или имя выбранного поля.
-   Может передаваться либо как <type>int</type>, либо как <type>string</type>.
-   Если передаётся значение типа <type>int</type>, PHP распознает его как
-   номер, в противном случае как наименование поля.
+   Параметр <parameter>field_name_or_number</parameter> поддерживает
+   значения <type>int</type> и <type>string</type>:
+   тип <type>int</type> PHP распознаёт
+   как номер поля, иначе аргумент интерпретируется как название поля.
   </para>
   <para>
-   Ознакомьтесь с примерами на странице с описанием функции <function>pg_field_name</function>.
+   Пример работы функции содержит страница с описанием функции <function>pg_field_name</function>.
   </para>
   <note>
    <para>
@@ -56,7 +57,7 @@
      <listitem>
       <para>
        Номер строки в результате. Нумерация строк начинается с нуля.
-       Функция выбирает текущую строку, если аргумент не задан.
+       При пропуске аргумента значение извлекается из текущей строки.
       </para>
      </listitem>
     </varlistentry>
@@ -67,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Функция возвращает длину строки при выводе значения поля.
+   Функция возвращает количество символов, которое занимает значение поля при выводе.
   </para>
  </refsect1>
 
@@ -85,11 +86,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Сигнатура функции <function>pg_field_prtlen</function> с двумя аргументами
-       (<parameter>result</parameter>,
-       <parameter>field_name_or_number</parameter>) объявлена устаревшей.
-       Вместо неё используют сигнатуру с тремя аргументами, передавая
-       параметру <parameter>row</parameter> значение &null;.
+       Сигнатура функции <function>pg_field_prtlen</function> с двумя аргументами —
+       <parameter>result</parameter> и <parameter>field</parameter> — устарела;
+       функцию вызывают с тремя аргументами
+       с передачей в параметр <parameter>row</parameter> значения &null;.
       </entry>
      </row>
      <row>
@@ -108,47 +108,45 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Получение информации о полях выборки</title>
+    <title>Пример получение информации о полях выборки</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$dbconn = pg_connect("dbname=publisher") or die("Не удалось соединиться с базой");
+$dbconn = pg_connect("dbname=publisher") or die("Ошибка подключения к БД");
 $res = pg_query($dbconn, "SELECT * FROM authors WHERE author = 'Orwell'");
 
 $i = pg_num_fields($res);
 for ($j = 0; $j < $i; $j++) {
-    echo "column $j\n";
+    echo "Столбец $j\n";
     $fieldname = pg_field_name($res, $j);
-    echo "fieldname: $fieldname\n";
-    echo "printed length: " . pg_field_prtlen($res, $fieldname) . " characters\n";
-    echo "storage length: " . pg_field_size($res, $j) . " bytes\n";
-    echo "field type: " . pg_field_type($res, $j) . " \n\n";
+    echo "Название поля: $fieldname\n";
+    echo "Количество: " . pg_field_prtlen($res, $fieldname) . " символов\n";
+    echo "Размер в хранилище в байтах: " . pg_field_size($res, $j) . "\n";
+    echo "Тип поля: " . pg_field_type($res, $j) . " \n\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-column 0
-fieldname: author
-printed length: 6 characters
-storage length: -1 bytes
-field type: varchar
+Столбец 0
+Название поля: author
+Количество: 6 символов
+Размер в хранилище в байтах: -1
+Тип поля: varchar
 
-column 1
-fieldname: year
-printed length: 4 characters
-storage length: 2 bytes
-field type: int2
+Столбец 1
+Название поля: year
+Количество: 4 символов
+Размер в хранилище в байтах: 2
+Тип поля: int2
 
-column 2
-fieldname: title
-printed length: 24 characters
-storage length: -1 bytes
-field type: varchar
+Столбец 2
+Название поля: title
+Количество: 24 символов
+Размер в хранилище в байтах: -1
+Тип поля: varchar
 ]]>
     </screen>
    </example>

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: mch Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-field-prtlen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -82,6 +82,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Сигнатура функции <function>pg_field_prtlen</function> с двумя аргументами
+       (<parameter>result</parameter>,
+       <parameter>field_name_or_number</parameter>) объявлена устаревшей.
+       Вместо неё используют сигнатуру с тремя аргументами, передавая
+       параметру <parameter>row</parameter> значение &null;.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Syncs the RU pages with php/doc-en#5364: the deprecated two argument signature of `pg_fetch_result()`, `pg_field_is_null()` and `pg_field_prtlen()`, and the new `PDO::ATTR_STRINGIFY_FETCHES` changelog entry on `PDO::getAttribute()`.

Fixes: #1563
