### PR TITLE
[Sync-EN] reflection: link tentative return type to ReturnTypeWillChange

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionfunctionabstract.gettentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,10 @@
    <modifier>public</modifier> <type class="union"><type>ReflectionType</type><type>null</type></type><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Метод возвращает объект отражения предварительного типа возвращаемого значения метода.
-  </para>
+  <simpara>
+   Метод возвращает объект отражения <link linkend="class.returntypewillchange">предварительного
+   типа возвращаемого значения</link> метода.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionfunctionabstract.hastentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Метод определяет, относится ли тип возвращаемого значения метода к предварительным.
-  </para>
+  <simpara>
+   Метод определяет, относится ли тип возвращаемого значения метода
+   к <link linkend="class.returntypewillchange">предварительным</link>.
+  </simpara>
 
  </refsect1>
 

--- a/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    Метод определяет, относится ли тип возвращаемого значения метода
-   к <link linkend="class.returntypewillchange">предварительным</link>.
+   <link linkend="class.returntypewillchange">к предварительным</link>.
   </simpara>
 
  </refsect1>


### PR DESCRIPTION
Syncs the RU pages with php/doc-en#5614. The `returntypewillchange.xml` page was already at the target revision on the RU side, so only the two reflection pages change.

Fixes: #1566
