### PR TITLE
CI: check the EN-Revision of the PR head, not of the merge commit

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -18,9 +18,15 @@ jobs:
     name: "Check EN-Revision"
     runs-on: ubuntu-latest
     steps:
+      # The explicit ref takes the real head of the pull request, not the merge
+      # commit actions/checkout builds by default: that one has master as its
+      # second parent, so the diff below would also list every file landed on
+      # master since the last push to the pull request.
+
       - name: "Checkout translation"
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"


### PR DESCRIPTION
On a `pull_request` event, `actions/checkout` defaults to `refs/pull/N/merge`, whose second parent is master. The `BASE...HEAD` diff therefore also lists every file landed on master since the last push to the pull request, so a translation PR can fail on EN-Revision drift it did not introduce.

Checking out the head sha restores the diff to the commits of the pull request.

Same change as #1605, which fixed `check-xml.yml`.
