### PR TITLE
[Sync-EN] Fix outdated ReflectionClass::setStaticPropertyValue visibility handling

### DIFF
--- a/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c4aabaa0b97ef1ecc00cf2cd539ea186c6a855ae Maintainer: aur Status: ready -->
+<!-- EN-Revision: c74adac363c4ad18bfb648b8962663b26de3828b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.setstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::setStaticPropertyValue</refname>
-  <refpurpose>Устанавливает значение общедоступного статического свойства</refpurpose>
+  <refpurpose>Устанавливает значение статического свойства</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,12 +15,12 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Устанавливает значение общедоступного статического свойства.
-   Если свойство является закрытым или защищённым, метод завершится с ошибкой.
+   Устанавливает значение статического свойства этого класса
+   независимо от видимости свойства.
   </simpara>
   <simpara>
-   Метод <methodname>ReflectionProperty::setValue</methodname> позволяет устанавливать
-   значение общедоступных, закрытых и защищённых свойств.
+   Метод <methodname>ReflectionProperty::setValue</methodname> также можно
+   использовать для установки значения статических свойств.
   </simpara>
  </refsect1>
 
@@ -67,11 +67,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>7.4.0</entry>
+      <entry>7.4.9, 8.0.0</entry>
       <entry>
-       Использование метода <methodname>ReflectionClass::setStaticPropertyValue</methodname>
-       для установки частного или защищённого свойства теперь приводит к фатальной ошибке.
-       Ранее выбрасывалось исключение <classname>ReflectionException</classname>.
+       Метод <methodname>ReflectionClass::setStaticPropertyValue</methodname> теперь
+       может устанавливать закрытые и защищённые статические свойства. Ранее
+       выбрасывалось исключение <exceptionname>ReflectionException</exceptionname>.
       </entry>
      </row>
     </tbody>

--- a/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
@@ -15,12 +15,12 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Устанавливает значение статического свойства этого класса
+   Устанавливает значение статического свойства класса
    независимо от видимости свойства.
   </simpara>
   <simpara>
-   Метод <methodname>ReflectionProperty::setValue</methodname> также можно
-   использовать для установки значения статических свойств.
+   Значения статических свойств также устанавливают
+   методом <methodname>ReflectionProperty::setValue</methodname>.
   </simpara>
  </refsect1>
 
@@ -32,7 +32,7 @@
      <term><parameter>name</parameter></term>
      <listitem>
       <para>
-       Имя свойства.
+       Название свойства.
       </para>
      </listitem>
     </varlistentry>
@@ -69,9 +69,9 @@
      <row>
       <entry>7.4.9, 8.0.0</entry>
       <entry>
-       Метод <methodname>ReflectionClass::setStaticPropertyValue</methodname> теперь
-       может устанавливать закрытые и защищённые статические свойства. Ранее
-       выбрасывалось исключение <exceptionname>ReflectionException</exceptionname>.
+       Метод <methodname>ReflectionClass::setStaticPropertyValue</methodname>
+       теперь поддерживает установку закрытых и защищённых статических свойств;
+       раньше выбрасывалось исключение <exceptionname>ReflectionException</exceptionname>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Syncs the RU page with php/doc-en#5057.

- `refpurpose` and the description no longer claim the method only sets public static properties: it sets a static property regardless of visibility.
- The second paragraph now presents `ReflectionProperty::setValue` as an alternative for static properties instead of listing visibilities.
- Changelog row: 7.4.0 becomes 7.4.9, 8.0.0, and the entry is reversed (private and protected static properties can now be set, a `ReflectionException` was thrown before). `classname` becomes `exceptionname` to match EN.
- EN-Revision bumped to c74adac363c4ad18bfb648b8962663b26de3828b.

Fixes: #1725
