### PR TITLE
[Sync-EN] Fix localeconv() function description

### DIFF
--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 715a125af5a86f0e6d6d5aa6cfa9c45257a433ac Maintainer: shein Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.localeconv">
  <refnamediv>
@@ -90,29 +90,29 @@
       <row>
        <entry>p_cs_precedes</entry>
        <entry>
-        &true;, если currency_symbol записывается перед положительным значением,
-        иначе &false;
+        1, если currency_symbol записывается перед положительным значением,
+        иначе 0
        </entry>
       </row>
       <row>
        <entry>p_sep_by_space</entry>
        <entry>
-        &true;, если currency_symbol отделяется от положительного
-        значения пробелом, иначе &false;
+        1, если currency_symbol отделяется от положительного
+        значения пробелом, иначе 0
        </entry>
       </row>
       <row>
        <entry>n_cs_precedes</entry>
        <entry>
-        &true;, если currency_symbol записывается перед отрицательным
-        значением, иначе &false;
+        1, если currency_symbol записывается перед отрицательным
+        значением, иначе 0
        </entry>
       </row>
       <row>
        <entry>n_sep_by_space</entry>
        <entry>
-        &true;, если currency_symbol отделяется от отрицательного
-        значения пробелом, иначе &false;
+        1, если currency_symbol отделяется от отрицательного
+        значения пробелом, иначе 0
        </entry>
       </row>
       <row valign="top">
@@ -143,11 +143,11 @@
     </tgroup>
    </informaltable>
   </para>
-  <para>
+  <simpara>
    <literal>p_sign_posn</literal> и <literal>n_sign_posn</literal> содержат
    строку с опциями форматирования. Каждое число представляет собой
    одно из вышеперечисленных условий.
-  </para>
+  </simpara>
   <para>
    Элементы группировки содержат массивы, которые описывают способ
    группировки цифр. Например, поле группировки денежных величин


### PR DESCRIPTION
Syncs `reference/strings/functions/localeconv.xml` with php/doc-en#5707 and php/doc-en#5726.

- The `p_cs_precedes`, `p_sep_by_space`, `n_cs_precedes` and `n_sep_by_space` rows now read 1 and 0 instead of `&true;` and `&false;`: the function returns integers there, not booleans.
- Mirrors the `para` to `simpara` change on the `p_sign_posn` / `n_sign_posn` paragraph. The Russian wording was already correct, only the tag changes.
- EN-Revision bumped to 46efd980535e8de6f6639a0015d2ad1e4bfe9d00, which covers both upstream commits.

Fixes: #1577
