### PR TITLE
[Sync-EN] Set the timezone and fix the length-of-day unit in date_sun_info() examples

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -202,6 +202,9 @@ astronomical_twilight_end: 18:02:51
 ]]>
     </screen>
    </example>
+  </para>
+
+  <para>
 
    <example>
     <title>Пример обработки результатов в дату внутри периода полярной ночи</title>
@@ -239,6 +242,9 @@ never: sunset
 ]]>
     </screen>
    </example>
+  </para>
+
+  <para>
    <example>
     <title>Пример результатов в дату внутри периода полярного дня в Тромсё, Норвегия</title>
     <programlisting role="php">
@@ -291,16 +297,6 @@ echo "Продолжительность дня: ",
 ]]>
     </screen>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>date_sunrise</function></member>
-    <member><function>date_sunset</function></member>
-   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: aac47e05048c3371bfc46d65247d7bf1c4505bf3 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -178,6 +178,8 @@
 <![CDATA[
 <?php
 
+date_default_timezone_set('Asia/Jerusalem');
+
 $sun_info = date_sun_info(strtotime("2006-12-12"), 31.7667, 35.2333);
 
 foreach ($sun_info as $key => $val) {
@@ -188,15 +190,15 @@ foreach ($sun_info as $key => $val) {
     &example.outputs;
     <screen>
 <![CDATA[
-sunrise: 05:52:11
-sunset: 15:41:21
-transit: 10:46:46
-civil_twilight_begin: 05:24:08
-civil_twilight_end: 16:09:24
-nautical_twilight_begin: 04:52:25
-nautical_twilight_end: 16:41:06
-astronomical_twilight_begin: 04:21:32
-astronomical_twilight_end: 17:12:00
+sunrise: 06:29:21
+sunset: 16:36:00
+transit: 11:32:41
+civil_twilight_begin: 06:02:36
+civil_twilight_end: 17:02:45
+nautical_twilight_begin: 05:32:14
+nautical_twilight_end: 17:33:08
+astronomical_twilight_begin: 05:02:31
+astronomical_twilight_end: 18:02:51
 ]]>
     </screen>
    </example>
@@ -279,13 +281,13 @@ $diff = $si['sunset'] - $si['sunrise'];
 
 echo "Продолжительность дня: ",
     floor($diff / 3600), " ч. ",
-    floor(($diff % 3600) / 60), " сек.\n";
+    floor(($diff % 3600) / 60), " мин.\n";
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Продолжительность дня: 13 ч. 56 сек.
+Продолжительность дня: 13 ч. 53 мин.
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Syncs `reference/datetime/functions/date-sun-info.xml` with php/doc-en#5740, php/doc-en#5730 and php/doc-en#5718.

- First example: adds `date_default_timezone_set('Asia/Jerusalem')` and updates the nine output lines accordingly, so the printed times match the coordinates used.
- Length-of-day example: the minutes were labelled as seconds. The code now prints ` мин.` and the output reads `13 ч. 53 мин.` (php/doc-en#5718 had already corrected 56 to 53 upstream).
- EN-Revision bumped to aac47e05048c3371bfc46d65247d7bf1c4505bf3, which covers the three upstream commits.

Fixes: #1609
Fixes: #1585
