### PR TITLE
[Sync-EN] Avoid an undefined variable warning in the advanced escaping example

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fa67e21421448a20fe701a20897c30f93072e64b Maintainer: shein Status: ready -->
+<!-- EN-Revision: e7ec2928daf49d50796dfe74d106eb1068a1c72b Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Основы синтаксиса</title>
@@ -121,7 +121,7 @@ echo "Последняя инструкция\n";
     <title>Продвинутый выход из режима HTML-разметки с условиями</title>
     <programlisting role="php">
 <![CDATA[
-<?php if ($expression == true): ?>
+<?php if (true): ?>
   Это отобразится, если выражение истинно.
 <?php else: ?>
   Иначе отобразится это.


### PR DESCRIPTION
Syncs `language/basic-syntax.xml` with php/doc-en#5747.

The advanced escaping example used `$expression == true`, which emits an undefined variable warning unrelated to what the example demonstrates. It now reads `if (true)`. The surrounding Russian text is unchanged.

EN-Revision bumped to e7ec2928daf49d50796dfe74d106eb1068a1c72b.

Fixes: #1607
