### PR TITLE
[Sync-EN] Add user and password to the PDO_MYSQL DSN

### DIFF
--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c1bec9d700807df36994cf368ba291214cd424d Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 57a2f4c34cc3c74a7040282dcd60b906738a523d Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="bundledexternal" ?>
@@ -106,6 +106,26 @@
        <para>
         Имя базы данных.
        </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term><literal>user</literal></term>
+      <listitem>
+       <simpara>
+        Имя пользователя для подключения. Имя пользователя, которое передали
+        вторым аргументом конструктору класса <classname>PDO</classname>,
+        имеет приоритет над именем, которое указали в DSN.
+       </simpara>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term><literal>password</literal></term>
+      <listitem>
+       <simpara>
+        Пароль пользователя для подключения. Пароль, который передали
+        третьим аргументом конструктору класса <classname>PDO</classname>,
+        имеет приоритет над паролем, который указали в DSN.
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry>


### PR DESCRIPTION
Syncs `reference/pdo_mysql/reference.xml` with php/doc-en#5706.

Documents the `user` and `password` DSN parameters, including the note that the second and third arguments of the `PDO` constructor take precedence over the DSN values. Inserted between `dbname` and `unix_socket`, matching the EN order.

EN-Revision bumped to 57a2f4c34cc3c74a7040282dcd60b906738a523d.

Fixes: #1615
