### PR TITLE
[Sync-EN] Add INI_ALL to the .user.ini recognized modes

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ab074d32484672f93e5d822f42fb94ae9088207 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 5f0cb2451f24071abbfd5f42d96d9210605966b0 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Конфигурация времени выполнения</title>
@@ -220,7 +220,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
   </simpara>
   <simpara>
    Только INI-настройки
-   с режимами <constant>INI_PERDIR</constant>
+   с режимами <constant>INI_ALL</constant>, <constant>INI_PERDIR</constant>
    и <constant>INI_USER</constant> распознаются в INI-файлах в стиле .user.ini.
   </simpara>
 
@@ -273,7 +273,7 @@ once libxml2 gets XInclude 1.1 attribute copying support.
 The below <xi:include> will include the appropriate elements
 but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
 
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"/>
 -->
     <title>Константы INI-режима</title>
     <varlistentry>


### PR DESCRIPTION
Syncs `install/ini.xml` with php/doc-en#4779 and php/doc-en#5699.

- `INI_ALL` is now listed alongside `INI_PERDIR` and `INI_USER` as a mode recognized in .user.ini-style files.
- Mirrors the removal of the empty `xi:fallback` element in the commented-out XInclude sample.

EN-Revision bumped to 5f0cb2451f24071abbfd5f42d96d9210605966b0, which covers both upstream commits.

Fixes: #1616
