### PR TITLE
[Sync-EN] Fix typos and update stale references in debian.xml

### DIFF
--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 2d91caad93e275542dfdc1a99a6fc8a0ed030108 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка из пакетов в ОС Debian GNU/Linux и родственных дистрибутивах</title>
@@ -19,7 +19,7 @@
   <title>Команда APT</title>
   <simpara>
    Во-первых, обратите внимание, что иногда требуются и другие связанные пакеты:
-   <literal>libapache-mod-php</literal> требуется для интеграции с веб-сервером Apache 2,
+   <literal>libapache2-mod-php</literal> требуется для интеграции с веб-сервером Apache httpd 2,
    а пакет <literal>php-pear</literal> для интеграции с репозиторием PEAR.
   </simpara>
   <simpara>
@@ -27,7 +27,7 @@
    Это часто делают командой <command>apt update</command>.
   </simpara>
   <example xml:id="install.unix.debian.apt.example">
-   <title>Пример установки Apache 2 в ОС Debian</title>
+   <title>Пример установки Apache httpd 2 в ОС Debian</title>
    <programlisting role="shell">
 <![CDATA[
 # apt install php-common libapache2-mod-php php-cli
@@ -35,16 +35,15 @@
    </programlisting>
   </example>
   <simpara>
-   Команда APT автоматически установит PHP-модуль для Apache 2 и зависимости,
-   а затем активирует их. Потребуется перезапустить веб-сервер Apache,
+   Команда APT автоматически установит PHP-модуль для Apache httpd 2 и зависимости,
+   а затем активирует их. Потребуется перезапустить веб-сервер Apache httpd,
    чтобы изменения вступили в силу. Например:
   </simpara>
   <example xml:id="install.unix.debian.apt.example2">
-   <title>Остановка и запуск веб-сервера Apache после установки PHP</title>
+   <title>Перезапуск веб-сервера Apache httpd после установки PHP</title>
    <programlisting role="shell">
 <![CDATA[
-# /etc/init.d/apache2 stop
-# /etc/init.d/apache2 start
+# systemctl restart apache2
 ]]>
    </programlisting>
   </example>
@@ -85,11 +84,12 @@
   </example>
   <simpara>
    APT автоматически добавит строки в файлы вроде
-   <filename>/etc/php/7.4/php.ini</filename>,
-   <filename>/etc/php/7.4/conf.d/*.ini</filename> и другие, которые связаны и соответствуют файлу &php.ini;,
+   <filename>/etc/php/8.x/apache2/php.ini</filename>,
+   <filename>/etc/php/8.x/cli/php.ini</filename>,
+   <filename>/etc/php/8.x/mods-available/*.ini</filename> и другие, которые связаны и соответствуют файлу &php.ini;,
    и в зависимости от модуля добавит записи наподобие
    <literal>extension=foo.so</literal>.
-   Потребуется перезапустить веб-сервер вроде того же Apache, чтобы изменения вступили в силу
+   Потребуется перезапустить веб-сервер, чтобы изменения вступили в силу.
   </simpara>
  </sect2>
  <sect2 xml:id="install.unix.debian.faq">


### PR DESCRIPTION
Syncs `install/unix/debian.xml` with php/doc-en#5744.

- `libapache-mod-php` becomes `libapache2-mod-php` (the package name was wrong; the example below already used the correct one).
- Apache is spelled Apache httpd throughout, including both example titles.
- The restart example now uses `systemctl restart apache2` instead of the `/etc/init.d/apache2` stop and start pair.
- The php.ini paths are refreshed: `/etc/php/8.x/apache2/php.ini`, `/etc/php/8.x/cli/php.ini` and `/etc/php/8.x/mods-available/*.ini` replace the 7.4 ones, and the sentence no longer names Apache as the web server to restart. A missing full stop was added at the end of it.

EN-Revision bumped to 2d91caad93e275542dfdc1a99a6fc8a0ed030108.

Fixes: #1626
