### PR TITLE
[Sync-EN] Warn that header_register_callback() callbacks are not stacked

### DIFF
--- a/reference/network/functions/header-register-callback.xml
+++ b/reference/network/functions/header-register-callback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5faa7a6747bca628b3bdcc9f93aec5603b65581f Maintainer: bfl Status: ready -->
+<!-- EN-Revision: abdc23836d3f42399028c1174961107e70ada52d Maintainer: bfl Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.header-register-callback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -20,6 +20,15 @@
   <para>
    Параметр <parameter>callback</parameter> запускается сразу после того, как PHP были подготовлены все отправляемые заголовки, и перед отправкой любого другого вывода, создавая возможность для управления исходящими заголовками перед отправкой.
   </para>
+  <warning>
+   <simpara>
+    Функции обратного вызова не складываются в стек. Каждый следующий вызов функции
+    <function>header_register_callback</function> молча отменяет регистрацию
+    ранее зарегистрированной функции <parameter>callback</parameter> независимо от того,
+    где её установили. Функцию обратного вызова могут перезаписать зависимости,
+    а такую ситуацию бывает трудно отследить.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Syncs `reference/network/functions/header-register-callback.xml` with php/doc-en#5760.

Adds the warning introduced upstream: callbacks are not stacked, a later call to `header_register_callback()` silently de-registers the previously registered callback wherever it was set, dependencies may overwrite it, and the situation is hard to troubleshoot.

EN-Revision bumped to abdc23836d3f42399028c1174961107e70ada52d.

Fixes: #1628
