### PR TITLE
[Sync-EN] Bump EN-Revision of install/unix/source.xml

### DIFF
--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1c9fb12650addc936f5a0d5d1edc42cd32e9c765 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: e07f764c8e4234d1195536ffed2eaf19c849ce50 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка из исходного кода в системы Unix и macOS</title>


### PR DESCRIPTION
Syncs `install/unix/source.xml` with php/doc-en#5761.

The upstream change fixes an English grammar slip ("was been run" becomes "has been run"). The Russian sentence already reads correctly (`После запуска скрипта конфигурации PHP собирают командой make`), so only the EN-Revision is bumped, to e07f764c8e4234d1195536ffed2eaf19c849ce50.

Fixes: #1627
