### PR TITLE
[Sync-EN] Correct the memory usage estimation in the range() generator example

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: a8c1fc582e4917898980533b90fab4a598aede0f Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.generators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Генераторы</title>
@@ -27,14 +27,14 @@
    Как и итераторы, генераторы не поддерживают произвольный доступ к элементам массива.
   </para>
 
-  <para>
+  <simpara>
    Простой пример этого — переопределение функции
    <function>range</function> как генератора. Стандартная функция
    <function>range</function> генерирует массив, который состоит из значений, и
    возвращает его, что приводит к генерации больших массивов: например,
-   вызов <command>range(0, 1000000)</command> займёт более 100 МБ
+   вызов <command>range(0, 1000000)</command> займёт более 10 МБ
    оперативной памяти.
-  </para>
+  </simpara>
 
   <para>
    В качестве альтернативы можно создать генератор <literal>xrange()</literal>,


### PR DESCRIPTION
Syncs `language/generators.xml` with php/doc-en#4680.

`range(0, 1000000)` uses well over 10 MB, not 100 MB. The paragraph also becomes a `simpara`, as upstream.

EN-Revision bumped to a8c1fc582e4917898980533b90fab4a598aede0f.

Fixes: #1638
