### PR TITLE
[Sync-EN] Fix the mb_http_input() ValueError version in the changelog

### DIFF
--- a/reference/mbstring/functions/mb-http-input.xml
+++ b/reference/mbstring/functions/mb-http-input.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d553fa36940639b0889ec4358fa3bbb92f123b69 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 2fab26790083c132d6daeb0a0bfa41d5cc0894e0 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mb-http-input" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -72,16 +72,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.0.0</entry>
       <entry>
        Функция <function>mb_http_input</function> теперь выбрасывает ошибку
        <exceptionname>ValueError</exceptionname>, если значение параметра
        <parameter>type</parameter> некорректно.
-      </entry>
-     </row>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
        Параметр <parameter>type</parameter> теперь может принимать значение &null;.
       </entry>
      </row>


### PR DESCRIPTION
Syncs `reference/mbstring/functions/mb-http-input.xml` with php/doc-en#5252.

The changelog listed the `ValueError` on invalid `type` under 8.4.0 and the nullable `type` under 8.0.0. Upstream merged both into a single 8.0.0 row; the Russian rows are merged the same way, keeping the existing wording of each sentence.

EN-Revision bumped to 2fab26790083c132d6daeb0a0bfa41d5cc0894e0.

Fixes: #1637
