### PR TITLE
[Sync-EN] Document the GMP to bool cast (PHP 8.4.0)

### DIFF
--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 527966eb19d4bbf5f02d0fe82dcb57e417082e25 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 021351bd14ec5ce2e25b217d1c7e0ddefa0c3830 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.gmp" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -33,12 +33,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])"/>
    </classsynopsis>
   </section>
 
@@ -58,6 +54,16 @@
        <entry>
         Класс <classname>GMP</classname> пометили модификатором <modifier>final</modifier>
         как окончательный.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Объект класса <classname>GMP</classname> теперь приводится к типу
+        <type>bool</type>; объект, который представляет значение
+        <literal>0</literal>, приводится к &false;, а любое другое значение —
+        к &true;. Раньше приведение к типу <type>bool</type> поднимало
+        ошибку уровня <constant>E_RECOVERABLE_ERROR</constant>.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Syncs `reference/gmp/gmp.xml` with php/doc-en#5771 and php/doc-en#5699.

- Adds the 8.4.0 changelog row: a `GMP` object can now be cast to `bool`, an object representing 0 casting to `&false;` and any other value to `&true;`, where casting previously emitted an `E_RECOVERABLE_ERROR`.
- Mirrors the removal of the two empty `xi:fallback` elements in the class synopsis.

EN-Revision bumped to 021351bd14ec5ce2e25b217d1c7e0ddefa0c3830, which covers both upstream commits.

Fixes: #1640
