### PR TITLE
[Sync-EN] Note MYSQLI_TYPE_VECTOR availability

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: aur Status: ready -->
+<!-- EN-Revision: 59fd8de0f80a3e4b3d2bc40b91593f70b222a20a Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -456,9 +456,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Поле — часть многоколоночного индекса.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-group-flag">
@@ -816,9 +816,10 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Поле определили как <literal>VECTOR</literal>.
-    </para>
+     Доступна с PHP 8.4.0, для MySQL 9.0 и новее.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-need-data">


### PR DESCRIPTION
Syncs `reference/mysqli/constants.xml` with php/doc-en#5770 and php/doc-en#5712.

- `MYSQLI_TYPE_VECTOR` now states it is available as of PHP 8.4.0, for MySQL 9.0 and later.
- `MYSQLI_PART_KEY_FLAG` becomes a `simpara`, as upstream. The Russian wording ("часть многоколоночного индекса") already matched the corrected English sentence, so only the tag changes.

EN-Revision bumped to 59fd8de0f80a3e4b3d2bc40b91593f70b222a20a, which covers both upstream commits.

Fixes: #1641
