### PR TITLE
[Sync-EN] Iterator::rewind: refer to this method instead of the rewind() function

### DIFF
--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fbb16f538011636999459326a55d5f153ef2c61 Maintainer: das Status: ready -->
+<!-- EN-Revision: f0a5e4f7d35f0af1a7e93b383445657bc459914b Maintainer: das Status: ready -->
 <!-- Reviewed: yes Maintainer: sergey -->
 <refentry xml:id="iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -23,7 +23,7 @@
     цикла &foreach;.
    </para>
    <simpara>
-    Поскольку &foreach; всегда вызывает метод <methodname>rewind</methodname> перед началом итерации,
+    Поскольку &foreach; всегда вызывает этот метод перед началом итерации,
     ручное перемещение позиции итератора (например, с помощью метода <methodname>SplFileObject::seek</methodname>)
     будет сброшено.
    </simpara>


### PR DESCRIPTION
Syncs `language/predefined/iterator/rewind.xml` with php/doc-en#5764.

`<methodname>rewind</methodname>` rendered as a link to the `rewind()` stream function, which is not the method being documented. The sentence now says "this method", as upstream.

EN-Revision bumped to f0a5e4f7d35f0af1a7e93b383445657bc459914b.

Fixes: #1646
