### PR TITLE
[Sync-EN] Document array_walk_recursive() object handling and in-place updates

### DIFF
--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cec5275f23d2db648df30a5702b378044431be97 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 0d8ee2131b4da66a4d274c576da9137c2a7963d5 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.array-walk-recursive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,6 +19,13 @@
    элементу массива <parameter>array</parameter>. Функция обрабатывает
    каждый элемент многомерного массива.
   </para>
+  <simpara>
+   Как аргумент <parameter>array</parameter> разрешается передать объект:
+   он обрабатывается так, как если бы его сначала
+   <link linkend="language.types.array.casting">привели</link> к массиву.
+   Независимо от того, начала ли функция обход с массива или с объекта,
+   во вложенные объекты она не заходит.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -127,6 +134,47 @@ array_walk_recursive($fruits, 'test_print');
      Ключи с <type>array</type>-значением
      не передаются в функцию обратного вызова.
     </para>
+   </example>
+  </para>
+  <simpara>
+   Функцию <function>array_walk_recursive</function> также применяют, чтобы
+   обновить значения на месте: для этого параметр функции обратного вызова
+   передают по ссылке.
+  </simpara>
+  <para>
+   <example>
+    <title>Обновление значений на месте</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$sweet = ['a' => 'apple', 'b' => 'banana'];
+$fruits = ['sweet' => $sweet, 'sour' => 'lemon'];
+
+function test_update(&$item)
+{
+    $item = strtoupper($item);
+}
+
+function test_print($item, $key)
+{
+    echo "Ключ '$key' содержит значение: $item\n";
+}
+
+array_walk_recursive($fruits, 'test_update');
+array_walk_recursive($fruits, 'test_print');
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Ключ 'a' содержит значение: APPLE
+Ключ 'b' содержит значение: BANANA
+Ключ 'sour' содержит значение: LEMON
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
Syncs `reference/array/functions/array-walk-recursive.xml` with php/doc-en#4935 and php/doc-en#3365. Both upstream commits touch this page, so they are ported together.

php/doc-en#4935: adds the paragraph stating that an object may be passed as `array` and is treated as if cast to an array first, and that the function never recurses into inner objects, whether it started from an array or an object.

php/doc-en#3365: adds the "updating values in place" paragraph and example, showing a callback taking its parameter by reference.

The new example keeps the Latin fruit names of the EN version instead of the Russian ones used in the first example: `strtoupper()` is byte-based and would leave Cyrillic text untouched, which would make the example show nothing. Only the `echo` string is translated, matching the wording of the first example.

EN-Revision bumped to 0d8ee2131b4da66a4d274c576da9137c2a7963d5, which covers both upstream commits.

Fixes: #1655
Fixes: #1697
