### PR TITLE
[Sync-EN] Clarify the purpose of $data in updateTimestamp()

### DIFF
--- a/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 8ea3e0884dcec1efce3afac0e3deef0ab4506770 Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="sessionupdatetimestamphandlerinterface.updatetimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,9 +34,10 @@
    <varlistentry>
     <term><parameter>data</parameter></term>
     <listitem>
-     <para>
-      Данные сессии.
-     </para>
+     <simpara>
+      Данные сессии. Сериализованные данные сессии помогают определить,
+      изменились ли данные сессии, а значит, требуется ли их обновить.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Syncs `reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml` with php/doc-en#4753.

The `data` parameter description now says what the serialized session data is for: determining whether the session data has changed and therefore needs updating. The paragraph becomes a `simpara`, as upstream.

EN-Revision bumped to 8ea3e0884dcec1efce3afac0e3deef0ab4506770.

Fixes: #1657
