### PR TITLE
[Sync-EN] Clarify forward_static_call() and forward_static_call_array()

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c6fb604f39a0fa7bf1ae872064b2a3a24f23d855 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Вызов статического метода и передача параметров в виде массива</refpurpose>
+  <refpurpose>Вызывает функцию обратного вызова с массивом параметров, сохраняя
+  текущий вызванный класс</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,14 +15,25 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Вызывает пользовательскую функцию или метод, заданные в параметре
-   <parameter>callback</parameter>. Эта функция должна вызываться в контексте
-   метода и не может быть вызвана вне класса. Она использует
-   <link linkend="language.oop5.late-static-bindings">позднее статическое связывание</link>.
-   Все аргументы пересылаются в метод по значению и в виде массива, аналогично
-   <function>call_user_func_array</function>.
-  </para>
+   <parameter>callback</parameter>, и передаёт аргументы в виде массива,
+   аналогично функции <function>call_user_func_array</function>.
+   Когда функцию вызвали в контексте метода и вызывают метод, она выполняет
+   <link linkend="language.oop5.late-static-bindings">перенаправляющий вызов</link>,
+   поэтому <literal>static::</literal> внутри метода разрешается в тот же
+   вызванный класс, что и у вызывающей стороны. Это удобно для статических
+   методов обратного вызова, которые должны вести себя как
+   <literal>self::</literal> или <literal>parent::</literal>.
+  </simpara>
+  <note>
+   <simpara>
+    В отличие от функции <function>forward_static_call</function>, эта функция
+    не требует активной области видимости класса: вызов функции
+    <function>forward_static_call</function> вне класса выбрасывает ошибку
+    <exceptionname>Error</exceptionname>, а эта функция — нет.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,14 +52,14 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Массив, содержащий все аргументы вызова функции.
-      </para>
+      <simpara>
+       Параметры, которые передают функции обратного вызова, в виде массива.
+      </simpara>
       <note>
-       <para>
-        Помните, что аргументы <function>forward_static_call_array</function> не передаются
-        по ссылке.
-       </para>
+       <simpara>
+        Чтобы передать параметр по ссылке, соответствующий элемент массива
+        <parameter>args</parameter> должен быть ссылкой.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.forward-static-call" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call</refname>
-  <refpurpose>Вызов статического метода</refpurpose>
+  <refpurpose>Вызывает функцию обратного вызова, сохраняя текущий вызванный класс</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,12 +14,17 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Вызов пользовательской функции или метода, заданные в параметре
-   <parameter>callback</parameter> с последующими аргументами. Эта функция должна
-   вызываться в контексте метода и не может быть вызвана вне класса. Она использует
-   <link linkend="language.oop5.late-static-bindings">позднее статическое связывание</link>.
-  </para>
+  <simpara>
+   Вызывает пользовательскую функцию или метод, заданные в параметре
+   <parameter>callback</parameter>, с последующими аргументами. Эту функцию
+   вызывают в контексте метода, вне класса её вызвать нельзя.
+   Когда вызывают метод, функция выполняет
+   <link linkend="language.oop5.late-static-bindings">перенаправляющий вызов</link>,
+   поэтому <literal>static::</literal> внутри метода разрешается в тот же
+   вызванный класс, что и у вызывающей стороны. Это удобно для статических
+   методов обратного вызова, которые должны вести себя как
+   <literal>self::</literal> или <literal>parent::</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,9 +43,9 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Ноль или более параметров, которые будут переданы вызываемой функции.
-      </para>
+      <simpara>
+       Ноль или более параметров, которые передают функции обратного вызова.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs the two `reference/funchand/functions/forward-static-call*` pages with php/doc-en#5241 and php/doc-en#5784. Both upstream commits touch `forward-static-call-array.xml`, so they are ported together.

php/doc-en#5241: `forward_static_call_array()` no longer claims it must be called within a method context. A note states that, unlike `forward_static_call()`, it does not require an active class scope: calling `forward_static_call()` outside a class throws an `Error`, while this function does not.

php/doc-en#5784, on both pages:
- The `refpurpose` lines say what the functions actually do: call a callback while preserving the current called class, rather than "call a static method".
- The descriptions describe the forwarding call: `static::` inside the method resolves to the same called class as in the caller, which is useful for static method callbacks meant to behave like `self::` or `parent::`.
- `forward_static_call_array()`: the `args` note no longer says arguments are not passed by reference; it says that to pass a parameter by reference, the matching element of `args` must be a reference.

EN-Revision bumped to 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d on both files.

Fixes: #1658
Fixes: #1663
