### PR TITLE
[Sync-EN] Remove the 11 entities dropped from language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3,9 +3,6 @@
 <!-- Reviewed: no -->
 <!ENTITY installation.enabled.disable 'Модуль включён по умолчанию. Модуль отключается во время выполнения опцией:'>
 
-<!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook">
-<entry>4.2.0</entry><entry>Генератор случайных чисел инициализируется автоматически.</entry></row>'>
-
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -101,10 +98,6 @@ PHP зависнет до завершения выполнения програ
  </simpara>
 </note>
 '>
-
-<!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>В качестве
-аргумента вместо имени функции принимается массив, который содержит ссылку на объект
-и имя метода.</simpara></note>'>
 
 <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Callback-функции,
 которые зарегистрировали функцией <function>call_user_func</function>
@@ -285,12 +278,6 @@ PHP зависнет до завершения выполнения програ
 <!ENTITY deprecated.function 'Функция устарела.'>
 <!ENTITY removed.function 'Функцию удалили.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 функция <emphasis>УСТАРЕЛА</emphasis>, а в PHP 5.4.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
- </simpara>
-</warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Начиная с PHP 5.6.0 функция <emphasis>УСТАРЕЛА</emphasis>.
@@ -320,14 +307,6 @@ PHP зависнет до завершения выполнения програ
   Начиная с PHP 7.1.0 функция <emphasis>УСТАРЕЛА</emphasis>,
   а в PHP 7.2.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
   Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.feature-7-2-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.2.0 функциональность <emphasis>УСТАРЕЛА</emphasis>.
-  Полагаться на функциональность настоятельно не рекомендуют.
  </simpara>
 </warning>'>
 
@@ -362,14 +341,6 @@ PHP зависнет до завершения выполнения програ
  <simpara>
   Начиная с PHP 7.3.0 функция <emphasis>УСТАРЕЛА</emphasis>,
   а в PHP 8.0.0 функцию <emphasis>УДАЛИЛИ</emphasis>.
-  Полагаться на функцию настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.function-7-4-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 7.4.0 функция <emphasis>УСТАРЕЛА</emphasis>.
   Полагаться на функцию настоятельно не рекомендуют.
  </simpara>
 </warning>'>
@@ -475,14 +446,6 @@ PHP зависнет до завершения выполнения програ
  <simpara>
   Начиная с PHP 5.4.0 псевдоним <emphasis>УСТАРЕЛ</emphasis>.
   Полагаться на псевдоним настоятельно не рекомендуют.
- </simpara>
-</warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Начиная с PHP 5.3.0 псевдоним <emphasis>УСТАРЕЛ</emphasis>,
-  а в PHP 7.0.0 псевдоним <emphasis>УДАЛИЛИ</emphasis>.
  </simpara>
 </warning>'>
 
@@ -638,18 +601,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Функцию пока не за
 <!ENTITY example.outputs.5 '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Результат выполнения приведённого примера в PHP 5:
-</simpara>
-'>
-
-<!ENTITY example.outputs.53 '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Результат выполнения приведённого примера в PHP 5.3:
-</simpara>
-'>
-
-<!ENTITY example.outputs.54 '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Результат выполнения приведённого примера в PHP 5.4:
 </simpara>
 '>
 
@@ -1764,10 +1715,6 @@ Etc/GMT+n и Etc/GMT-n обратные общепринятым.
 </simpara>'
 >
 
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
-Ошибки, связанные с часовыми поясами, теперь генерируются на уровнях <constant>E_STRICT</constant> и <constant>E_NOTICE</constant>.
-</simpara></entry></row>'>
-
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
  Необязательный параметр <parameter>timestamp</parameter> —
@@ -2303,10 +2250,6 @@ Oracle сделает всё возможное, чтобы преобразов
 <!-- Common pieces in partintro-sections -->
 <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Файл &php.ini; не содержит директив
 для конфигурации модуля.</simpara>'>
-
-<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Модуль не содержит типов ресурсов.</simpara>'>
-
-<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Модуль не содержит констант.</simpara>'>
 
 <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">Модуль не требует внешних библиотек.</simpara>'>
 

--- a/reference/dbase/constants.xml
+++ b/reference/dbase/constants.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <appendix xml:id="dbase.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
- &no.constants;
+ &extension.constants;
  <variablelist>
   <varlistentry xml:id="constant.dbase-version">
    <term>


### PR DESCRIPTION
Syncs `language-snippets.ent` with php/doc-en#5628, which removed eleven entities that are no longer used in doc-en and listed them in `entities/entities.remove.ent`.

Removed here: `changelog.randomseed`, `date.timezone.errors.changelog`, `example.outputs.53`, `example.outputs.54`, `no.constants`, `no.resource`, `note.func-callback`, `warn.deprecated.alias-5-3-0.removed-7-0-0`, `warn.deprecated.feature-5-3-0.removed-5-4-0`, `warn.deprecated.feature-7-2-0` and `warn.deprecated.function-7-4-0`.

Ten of them had no reference left in the Russian tree. The eleventh, `no.constants`, was still used by `reference/dbase/constants.xml`, where it rendered "the extension defines no constants" above a list of five constants. That page now uses `&extension.constants;`, which is what the English page uses.

The EN-Revision of `language-snippets.ent` is left untouched: the file is still behind on seven other doc-en commits, each tracked by its own issue, so bumping it here would claim work that has not been done.

Fixes: #1659
