### PR TITLE
[Sync-EN] Remove the bundled expat text from the XML install section

### DIFF
--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cdab70215c31e34b90a5f941a33cdf47eeaa12e2 Maintainer: mch Status: ready -->
+<!-- EN-Revision: c1b9c92d863bd1b4f82b13b4d13b8ab27caa66f0 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="xml.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
@@ -7,18 +7,32 @@
   &installation.enabled.disable;
   <option role="configure">--disable-xml</option>
  </para>
- <!-- TODO the following needs researched and updated -->
- <para>
-  Эти функции включены по умолчанию при использовании стандартной библиотеки expat.
-  Вы можете отключить поддержку XML с помощью
-  <option role="configure">--disable-xml</option>.
-  Если вы собрали PHP как модуль для Apache 1.3.9 или более поздней версии, PHP
-  будет автоматически использовать стандартную библиотеку <productname>expat</productname>
-  из Apache. В случае, если вы не хотите использовать стандартную библиотеку expat,
-  то вам необходимо настроить PHP опцию <option role="configure">--with-expat-dir=DIR</option>,
-  где DIR - путь до установочной директории библиотеки expat.
- </para>
  &windows.builtin;
+ <simplesect role="changelog">
+ &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Параметр <option role="configure">--with-libexpat-dir</option> переименовали в
+        <option role="configure">--with-expat</option>, и он больше не принимает
+        аргумент с каталогом. Встроенную библиотеку expat удалили.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </simplesect>
 </section>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Syncs `reference/xml/configure.xml` with php/doc-en#4678.

The paragraph about the bundled expat library, Apache 1.3.9 and `--with-expat-dir=DIR` described a setup that no longer exists; upstream removed it, together with the `TODO` comment above it, and replaced it with a changelog section stating that `--with-libexpat-dir` was renamed to `--with-expat` in 7.4.0, no longer takes a directory argument, and that the bundled expat library was removed.

This also drops the last "вы"-style sentences on that page.

EN-Revision bumped to c1b9c92d863bd1b4f82b13b4d13b8ab27caa66f0.

Fixes: #1660
