### PR TITLE
[Sync-EN] Clarify the executable lookup for proc_open() with an array command

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 5600a279c7904a92dca710222de2289613a47aad Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -56,6 +56,15 @@
        Тогда функция откроет процесс напрямую (не проходя через оболочку)
        и PHP позаботится об экранировании любого необходимого аргумента.
       </para>
+      <simpara>
+       Когда параметр <parameter>command</parameter> передали как массив и первый
+       элемент массива — простое имя файла без разделителей каталогов, исполняемый
+       файл ищут по текущему значению переменной окружения <envar>PATH</envar>.
+      </simpara>
+      <simpara>
+       Если переменную <envar>PATH</envar> не установили, поиск идёт по путям,
+       которые операционная система задаёт по умолчанию.
+      </simpara>
       <note>
        <para>
         В ОС Windows экранирование аргумента массива (&array;) элементов предполагает,


### PR DESCRIPTION
Syncs `reference/exec/functions/proc-open.xml` with php/doc-en#5220.

Adds the two paragraphs on how the executable is located when `command` is given as an array: if the first element is a plain filename with no directory separator, it is looked up through the current `PATH`, and when `PATH` is unset the operating system default search paths are used.

EN-Revision bumped to 5600a279c7904a92dca710222de2289613a47aad.

Fixes: #1664
