### PR TITLE
[Sync-EN] Improve the gmp_export() documentation

### DIFF
--- a/reference/gmp/functions/gmp-export.xml
+++ b/reference/gmp/functions/gmp-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 548548299328e56739eb2832a5c22ba2de745038 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ba0a95ac9ad601e5ef05a0f3ab937d9749395982 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,16 @@
    <methodparam choice="opt"><type>int</type><parameter>word_size</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>GMP_MSW_FIRST | GMP_NATIVE_ENDIAN</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Экспортирует GMP-число в бинарную строку
-  </para>
+  <simpara>
+   Экспортирует GMP-число в бинарную строку. Функция работает с числами
+   произвольной величины, которые выходят за пределы диапазона встроенного
+   целочисленного типа PHP, и позволяет настроить размер слова и порядок
+   байтов — по духу похоже на функцию <function>pack</function>.
+  </simpara>
+  <simpara>
+   Знак числа не учитывается: экспорт отрицательного числа даёт тот же
+   результат, что и экспорт его абсолютного значения.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,26 +34,35 @@
     <varlistentry>
      <term><parameter>num</parameter></term>
      <listitem>
-      <para>
-       GMP-число для экспорта
-      </para>
+      <simpara>
+       GMP-число, которое экспортируют.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>word_size</parameter></term>
      <listitem>
-      <para>
-       По умолчанию равно 1. Количество байт в каждом блоке бинарных данных.
-       Обычно используется совместно с заданием параметра options.
-      </para>
+      <simpara>
+       Количество байтов в одном слове результата. Общая длина строки, которую
+       вернёт функция, будет кратна этому значению.
+       Значение по умолчанию: <literal>1</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
-       По умолчанию <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
-      </para>
+      <simpara>
+       Битовая маска, которая управляет порядком слов и порядком байтов.
+       Порядок слов: <constant>GMP_MSW_FIRST</constant> (сначала самое старшее
+       слово, по умолчанию) или <constant>GMP_LSW_FIRST</constant> (сначала
+       самое младшее слово). Порядок байтов внутри слова:
+       <constant>GMP_NATIVE_ENDIAN</constant> (по умолчанию),
+       <constant>GMP_BIG_ENDIAN</constant> или
+       <constant>GMP_LITTLE_ENDIAN</constant>.
+       Значение по умолчанию:
+       <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -55,9 +71,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Возвращает строку.
-  </para>
+  <simpara>
+   Возвращает строку с бинарным представлением GMP-числа. Строка пустая,
+   если число равно нулю.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Syncs `reference/gmp/functions/gmp-export.xml` with php/doc-en#5265.

- The description says what the function does beyond the one-line summary: it handles numbers beyond the native integer range with a configurable word size and byte order, in the spirit of `pack()`, and the sign is ignored, so exporting a negative number gives the same result as exporting its absolute value.
- `word_size` is described as bytes per word, with the returned string length being a multiple of it, instead of the vague "mainly used with the options parameter" (there is no `options` parameter).
- `flags` lists the actual constants for word order (`GMP_MSW_FIRST`, `GMP_LSW_FIRST`) and byte order (`GMP_NATIVE_ENDIAN`, `GMP_BIG_ENDIAN`, `GMP_LITTLE_ENDIAN`) instead of only naming the default.
- The return value says the string holds the binary representation and is empty when the number is zero.

EN-Revision bumped to ba0a95ac9ad601e5ef05a0f3ab937d9749395982.

Fixes: #1665
