### PR TITLE
[Sync-EN] Document DEBUG_BACKTRACE_PROVIDE_OBJECT for debug_print_backtrace()

### DIFF
--- a/reference/errorfunc/functions/debug-print-backtrace.xml
+++ b/reference/errorfunc/functions/debug-print-backtrace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1fd69376c6c90066f086c99a32621f0b3fd47ba0 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 41911b489877ce67e1a9c47b43b1cc37aa21b6e2 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.debug-print-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,6 +42,15 @@
            <entry>
             Опция устанавливает бит, который определяет, исключать ли ключ "args" из выходного массива
             и вместе с ним аргументы функций и методов, чтобы уменьшить расход памяти.
+           </entry>
+          </row>
+          <row>
+           <entry>DEBUG_BACKTRACE_PROVIDE_OBJECT</entry>
+           <entry>
+            Опцию принимают для совместимости с функцией
+            <function>debug_backtrace</function>, но она ни на что не влияет:
+            стек вызовов формируется как строка, и элемент "object" никогда
+            не выводится.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
Syncs `reference/errorfunc/functions/debug-print-backtrace.xml` with php/doc-en#5217.

Adds the `DEBUG_BACKTRACE_PROVIDE_OBJECT` row to the options table: the option is accepted for compatibility with `debug_backtrace()` but has no effect here, since the backtrace is rendered as a string and the "object" entry is never printed.

EN-Revision bumped to 41911b489877ce67e1a9c47b43b1cc37aa21b6e2.

Fixes: #1668
