### PR TITLE
[Sync-EN] Document environment variable expansion in the FPM configuration

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 7cd12cc82bc0a778241189596022acdda016d857 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Настройка</title>
@@ -1048,6 +1048,21 @@
     </listitem>
    </varlistentry>
   </variablelist>
+  <para>
+   Значения настроек задают через подстановку переменных окружения.
+   Начиная с PHP 8.3.0 поддерживаются также значения по умолчанию на случай,
+   когда переменная окружения не установлена или пуста. Например:
+   <example>
+    <title>Подстановка переменных окружения</title>
+    <programlisting role="ini">
+<![CDATA[
+listen = /var/run/php-fpm-${POOL_NAME}.sock
+user = ${USER_NAME:-www-data}
+group = ${USER_NAME:-www-data}
+]]>
+    </programlisting>
+   </example>
+  </para>
   <para>
    Передача дополнительных переменных окружения обновляет настройки
    PHP для конкретного пула. Для этого добавляют следующие параметры


### PR DESCRIPTION
Syncs `install/fpm/configuration.xml` with php/doc-en#5181.

Adds the paragraph and example on environment variable expansion in pool configuration values, including the default-value syntax (`\${USER_NAME:-www-data}`) supported as of PHP 8.3.0 when the variable is unset or null.

EN-Revision bumped to 7cd12cc82bc0a778241189596022acdda016d857.

Fixes: #1670
