### PR TITLE
[Sync-EN] Fix naming and paths in the dnf installation page

### DIFF
--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 88d5409cd9668b28ecb879522750807322a816dd Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка из пакетов в дистрибутивы GNU/Linux с менеджером пакетов DNF</title>
@@ -29,7 +29,7 @@
    <title>Пример установки пакета через пакетный менеджер DNF</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php php-common
+# dnf install php php-common php-fpm
 ]]>
    </programlisting>
   </example>
@@ -39,7 +39,7 @@
    Например:
   </simpara>
   <example xml:id="install.unix.dnf.example2">
-   <title>Перезапуск веб-сервера Apache после установки PHP</title>
+   <title>Перезапуск веб-сервера Apache httpd после установки PHP</title>
    <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
@@ -85,10 +85,10 @@
   </example>
   <simpara>
    Пакетный менеджер DNF автоматически добавит строки конфигурации
-   в файлы наподобие <filename>/etc/php/8.3/php.ini</filename>,
-   <filename>/etc/php/8.3/conf.d/*.ini</filename> и другие файлы, которые связаны с файлом PHP-конфигурации &php.ini;,
+   в файлы наподобие <filename>/etc/php.ini</filename>,
+   <filename>/etc/php.d/*.ini</filename> и другие файлы, которые связаны с файлом PHP-конфигурации &php.ini;,
    и добавит для модулей записи вроде <literal>extension=foo.so</literal>.
-   Изменения вступят в силу после перезапуска веб-сервера, того же Apache.
+   Изменения вступят в силу после перезапуска веб-сервера и PHP-FPM.
   </simpara>
  </sect2>
 </sect1>


### PR DESCRIPTION
Syncs `install/unix/dnf.xml` with php/doc-en#5745.

- The install example installs `php-fpm` too.
- The restart example title says Apache httpd.
- The php.ini paths are the ones a dnf-based distribution actually uses: `/etc/php.ini` and `/etc/php.d/*.ini`, not the Debian-style `/etc/php/8.3/` layout.
- The last sentence says the web server and PHP-FPM must be restarted, without naming Apache.

EN-Revision bumped to 88d5409cd9668b28ecb879522750807322a816dd.

Fixes: #1671
