### PR TITLE
[Sync-EN] Version the FILTER_CALLBACK flags note

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 1900175b061e4de78f5ba3e79874e457d7e710a1 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -715,9 +715,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Фильтр проверяет значение как IP-адрес.
-    </para>
+    </simpara>
     <variablelist xml:id="filter.constants.validation.ip.options">
      <title>Available options</title>
      <varlistentry>
@@ -1226,12 +1226,21 @@ NULL
 ]]>
      </screen>
     </example>
-    <warning>
+    <note>
      <simpara>
-      Фильтр нельзя комбинировать с флагами,
-      включая флаг <constant>FILTER_NULL_ON_FAILURE</constant>.
+      Начиная с PHP 8.1.25 и 8.2.12 к этому фильтру применяются структурные
+      флаги <constant>FILTER_REQUIRE_ARRAY</constant>,
+      <constant>FILTER_FORCE_ARRAY</constant> и
+      <constant>FILTER_REQUIRE_SCALAR</constant>, а флаг
+      <constant>FILTER_NULL_ON_FAILURE</constant> меняет то, как сообщают
+      о такой структурной ошибке. В более ранних версиях все флаги
+      игнорировались. Флаги конкретных фильтров игнорируются всегда, а
+      поскольку результатом становится возвращаемое значение функции обратного
+      вызова, сама функция обратного вызова завершиться неудачей не может:
+      ни один флаг не превращает <literal>false</literal>, которое вернула
+      функция обратного вызова, в &null; или в исключение.
      </simpara>
-    </warning>
+    </note>
    </listitem>
   </varlistentry>
  </variablelist>


### PR DESCRIPTION
Syncs `reference/filter/constants.xml` with php/doc-en#5243.

The warning claiming `FILTER_CALLBACK` cannot be combined with any flag becomes a note describing what actually happens: as of PHP 8.1.25 and 8.2.12 the structural flags `FILTER_REQUIRE_ARRAY`, `FILTER_FORCE_ARRAY` and `FILTER_REQUIRE_SCALAR` do apply, and `FILTER_NULL_ON_FAILURE` changes how a structural failure is reported; in earlier versions every flag was ignored. Filter specific flags are always ignored, and since the callback's return value is the result, no flag turns a `false` returned by the callback into `&null;` or an exception.

The `FILTER_VALIDATE_IP` description also becomes a `simpara`, as upstream.

EN-Revision bumped to 1900175b061e4de78f5ba3e79874e457d7e710a1.

Fixes: #1674
