### PR TITLE
[Sync-EN] Document the RFTSIGZMB and RFTHREAD flags of pcntl_rfork()

### DIFF
--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: e43fb30acb61e76ef50174ec84c2aa33674a3828 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-rfork" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,8 +50,21 @@
          Взаимоисключающий флаг с <constant>RFFDG</constant>.
         </member>
         <member>
-         <constant>RFLINUXTHPN</constant>: Если установлено, ядро будет возвращать SIGUSR1 вместо SIGCHILD при выходе из дочернего потока.
+         <constant>RFLINUXTHPN</constant>: Если установлено, ядро будет возвращать SIGUSR1 вместо SIGCHLD при выходе из дочернего потока.
          Предназначен для уведомления родительского процесса о выходе из Linux-клона.
+        </member>
+        <member>
+         <constant>RFTSIGZMB</constant>: Если установлено, при выходе дочернего процесса
+         ядро отправит родителю сигнал, который задали параметром
+         <parameter>signal</parameter>, вместо сигнала SIGCHLD по умолчанию.
+         Номер сигнала <literal>0</literal> отключает отправку сигнала при выходе
+         дочернего процесса.
+        </member>
+        <member>
+         <constant>RFTHREAD</constant>: Если установлено, новый процесс разделяет
+         с родителем таблицу соответствия дескрипторов файлов лидерам процессов.
+         Флаг действует, только когда не установили ни <constant>RFFDG</constant>,
+         ни <constant>RFCFDG</constant>.
         </member>
        </simplelist>
       </para>
@@ -60,9 +73,12 @@
     <varlistentry>
      <term><parameter>signal</parameter></term>
      <listitem>
-      <para>
-       Номер сигнала.
-      </para>
+      <simpara>
+       Номер сигнала, который отправят родителю при выходе дочернего процесса.
+       Параметр учитывается, только когда установили флаг
+       <constant>RFTSIGZMB</constant>. Значение <literal>0</literal> отключает
+       отправку сигнала при выходе дочернего процесса.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs `reference/pcntl/functions/pcntl-rfork.xml` with php/doc-en#5446.

- Adds the two missing `flags` members: `RFTSIGZMB`, which makes the kernel deliver the signal given by `signal` to the parent on child exit instead of SIGCHLD (0 disabling delivery), and `RFTHREAD`, which shares the file descriptor to process leaders table with the parent when neither `RFFDG` nor `RFCFDG` is set.
- The `signal` parameter is described instead of just "the signal number": it is only used with `RFTSIGZMB`, and 0 disables delivery.
- Fixes the SIGCHILD typo in the `RFLINUXTHPN` member: the signal is SIGCHLD.

EN-Revision bumped to e43fb30acb61e76ef50174ec84c2aa33674a3828.

Fixes: #1675
