### PR TITLE
[Sync-EN] Document the potential Windows deadlock in flock()

### DIFF
--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75a76afb61d91f04feebc83931c5412b13682d2b Maintainer: shein Status: ready -->
+<!-- EN-Revision: f3112c43e303fcd63c0df89798b45bfef9d49e15 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.flock" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -199,12 +199,33 @@ fclose($fp);
     наподобие <literal>FAT</literal> и её производные, поэтому функцию будет
     возвращать &false; в этих окружениях.
    </para>
+   <para>
+    В Windows попытка выполнить файл с PHP-исходным кодом, который заблокировали
+    флагом <constant>LOCK_EX</constant>, приводит к зависанию до тех пор, пока
+    файл не разблокируют. Следующий пример приводит к взаимоблокировке:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+if ($argv[1] ?? null === 'child') { die(); }
+$fp = fopen(__FILE__, "rb");
+flock($fp, LOCK_EX);
+shell_exec("php " . escapeshellarg(__FILE__) . " child");
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
   </warning>
   <note>
    <para>
     Если в Windows процесс блокировки открывает файл во второй раз, он не может
     получить доступ к файлу через второй дескриптор, пока не разблокирует файл.
    </para>
+   <simpara>
+    В Windows попытка подключить файл, который заблокировали флагом LOCK_EX,
+    завершится ошибкой ErrorException: require(): Read of X bytes failed with errno=13 Permission denied
+   </simpara>
   </note>
  </refsect1>
 


### PR DESCRIPTION
Syncs `reference/filesystem/functions/flock.xml` with php/doc-en#4000.

- The warning gains the paragraph and example about Windows hanging when PHP tries to execute a source file that is `LOCK_EX`'ed, with the script that reproduces the deadlock.
- The note gains the sentence about `require`-ing a `LOCK_EX`'ed file failing with `ErrorException: require(): Read of X bytes failed with errno=13 Permission denied`. The error message is left in English, as it is the literal text PHP emits.

EN-Revision bumped to f3112c43e303fcd63c0df89798b45bfef9d49e15.

Fixes: #1680
