### PR TITLE
[Sync-EN] Document the mysqli wait-timeout error code change (8.4.0)

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d470f625f96a83d65464619297cccad7ce46e743 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: fa76e55f2ea8892e8898f20bb9467ace49b0e91e Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.query" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -127,6 +127,33 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        При подключении к MySQL 8.0.24 и новее для таймаута ожидания на стороне
+        сервера теперь сообщается код ошибки <literal>4031</literal>
+        (<literal>ER_CLIENT_INTERACTION_TIMEOUT</literal>) вместо
+        <literal>2006</literal> (<literal>CR_SERVER_GONE_ERROR</literal>).
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Syncs `reference/mysqli/mysqli/query.xml` with php/doc-en#5783.

Adds the changelog section: as of PHP 8.4.0, when connecting to MySQL 8.0.24 or later, a server wait timeout is reported as error code `4031` (`ER_CLIENT_INTERACTION_TIMEOUT`) instead of `2006` (`CR_SERVER_GONE_ERROR`).

EN-Revision bumped to fa76e55f2ea8892e8898f20bb9467ace49b0e91e.

Fixes: #1687
