### PR TITLE
[Sync-EN] Note the SORT_REGULAR behaviour of array_unique() with numeric strings

### DIFF
--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 651fad6c6677036edd2871bb78199e17586a3acd Maintainer: shein Status: ready -->
+<!-- EN-Revision: 47cbf365f535be1517473eee446e94d096778ca8 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -60,6 +60,15 @@
           <constant>SORT_REGULAR</constant> — нормальное сравнение элементов,
           без изменения типов
          </simpara>
+         <note>
+          <simpara>
+           Когда флаг <constant>SORT_REGULAR</constant> применяют к массивам,
+           в которых смешаны числовые и нечисловые строки, алгоритм «сначала
+           отсортировать, потом сравнить» иногда не ставит равные элементы
+           рядом, поэтому в результате остаются дубликаты. Чтобы этого избежать,
+           применяют флаг <constant>SORT_STRING</constant>.
+          </simpara>
+         </note>
         </listitem>
         <listitem>
          <simpara><constant>SORT_NUMERIC</constant> — элементы сравниваются как числа</simpara>
@@ -164,8 +173,10 @@ var_dump($result);
     <screen role="php">
 <![CDATA[
 array(2) {
-  [0] => int(4)
-  [2] => string(1) "3"
+  [0]=>
+  int(4)
+  [2]=>
+  string(1) "3"
 }
 ]]>
     </screen>


### PR DESCRIPTION
Syncs `reference/array/functions/array-unique.xml` with php/doc-en#4958 and php/doc-en#5718.

php/doc-en#4958: adds the note under `SORT_REGULAR` explaining that on arrays mixing numeric and non-numeric strings the sort-then-compare algorithm may not place equal elements next to each other, leaving duplicates in the result, and that `SORT_STRING` avoids it.

php/doc-en#5718: the last example's output is written the way `var_dump()` actually prints it, with the key and value on separate lines.

EN-Revision bumped to 47cbf365f535be1517473eee446e94d096778ca8, which covers both upstream commits.

Fixes: #1691
