### PR TITLE
[Sync-EN] Turn the json_last_error() error code table into a list

### DIFF
--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 058ea1e8420b9c1b24402af52545e8313428e1d1 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 3733e082ad183251e0b63d08b52c448a243f9710 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.json-last-error" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -27,89 +27,113 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает целочисленное значение в виде следующих
    констант:
+  </simpara>
+  <para>
+   <variablelist>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NONE</constant></term>
+    <listitem>
+     <simpara>Без ошибок</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_DEPTH</constant></term>
+    <listitem>
+     <simpara>Достигнута максимальная глубина стека</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_STATE_MISMATCH</constant></term>
+    <listitem>
+     <simpara>Недопустимые или сформированные с нарушением формата JSON данные</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_CTRL_CHAR</constant></term>
+    <listitem>
+     <simpara>Ошибка управляющего символа, возможно, неверная кодировка</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_SYNTAX</constant></term>
+    <listitem>
+     <simpara>Синтаксическая ошибка</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF8</constant></term>
+    <listitem>
+     <simpara>Некорректные для кодировки UTF-8 символы, возможно, неверная кодировка</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_RECURSION</constant></term>
+    <listitem>
+     <simpara>Одна или несколько зацикленных ссылок в кодируемом значении</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INF_OR_NAN</constant></term>
+    <listitem>
+     <simpara>
+      Одно или несколько значений
+      <link linkend="language.types.float.nan"><constant>NAN</constant></link>
+      или <link linkend="function.is-infinite"><constant>INF</constant></link>
+      в кодируемом значении
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></term>
+    <listitem>
+     <simpara>Передали значение с неподдерживаемым типом</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></term>
+    <listitem>
+     <simpara>Название свойства невозможно закодировать</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF16</constant></term>
+    <listitem>
+     <simpara>Некорректный для кодировки UTF-16 символ, возможно, некорректно закодирован</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NON_BACKED_ENUM</constant></term>
+    <listitem>
+     <simpara>Значение содержит нетипизированное перечисление, которое невозможно сериализовать</simpara>
+    </listitem>
+   </varlistentry>
+   </variablelist>
   </para>
-  <table>
-   <title>Коды ошибок JSON</title>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Константа</entry>
-      <entry>Значение</entry>
-      <entry>Доступность</entry>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
      </row>
     </thead>
     <tbody>
      <row>
-      <entry><constant>JSON_ERROR_NONE</constant></entry>
-      <entry>Без ошибок</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_DEPTH</constant></entry>
-      <entry>Достигнута максимальная глубина стека</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_STATE_MISMATCH</constant></entry>
-      <entry>Недопустимые или сформированные с нарушением формата JSON данные</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_CTRL_CHAR</constant></entry>
-      <entry>Ошибка управляющего символа, возможно, неверная кодировка</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_SYNTAX</constant></entry>
-      <entry>Синтаксическая ошибка</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF8</constant></entry>
-      <entry>Некорректные для кодировки UTF-8 символы, возможно, неверная кодировка</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_RECURSION</constant></entry>
-      <entry>Одна или несколько зацикленных ссылок в кодируемом значении</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INF_OR_NAN</constant></entry>
+      <entry>8.1.0</entry>
       <entry>
-       Одно или несколько значений
-       <link linkend="language.types.float.nan"><constant>NAN</constant></link>
-       или <link linkend="function.is-infinite"><constant>INF</constant></link>
-       в кодируемом значении
+       Добавили константу <constant>JSON_ERROR_NON_BACKED_ENUM</constant>.
       </entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></entry>
-      <entry>Передали значение с неподдерживаемым типом</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></entry>
-      <entry>Название свойства невозможно закодировать</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF16</constant></entry>
-      <entry>Некорректный для кодировки UTF-16 символ, возможно, некорректно закодирован</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_NON_BACKED_ENUM</constant></entry>
-      <entry>Значение содержит нетипизированное перечисление, которое невозможно сериализовать</entry>
-      <entry>Константа доступна с PHP 8.1.0</entry>
      </row>
     </tbody>
    </tgroup>
-  </table>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Syncs `reference/json/functions/json-last-error.xml` with php/doc-en#5447.

- The JSON error codes table had a three-column header on a `cols="2"` tgroup, with an Availability column that was empty on every row. It becomes a `variablelist`, one entry per constant, with the same wording.
- The "available as of PHP 8.1.0" text that was glued to the `JSON_ERROR_NON_BACKED_ENUM` description moves to a proper changelog section.

EN-Revision bumped to 3733e082ad183251e0b63d08b52c448a243f9710.

Fixes: #1698
