### PR TITLE
[Sync-EN] Add the auto_detect_line_endings deprecation notice

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -123,10 +123,11 @@ PHP зависнет до завершения выполнения програ
 Доступ к собранным неизвестным именованным аргументам получают только через параметр с переменным количеством аргументов.</simpara>
 </note>'>
 
-<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>Включение
-опции <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link> во время выполнения
-иногда помогает исправить неправильное распознавание языком PHP концов строк при чтении файлов
-на Macintosh-совместимом компьютере или файлов, которые создали на Макинтоше.</simpara></note>'>
+<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>До PHP 8.1.0 опцию
+<link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link> времени выполнения
+включали, чтобы PHP правильно распознавал концы строк при чтении файлов, которые создали
+в системах Macintosh. Начиная с PHP 8.1.0 опция объявлена устаревшей. При необходимости
+переводы строк <literal>"\r"</literal> обрабатывают вручную.</simpara></note>'>
 
 <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 36d8d80891c1dfc49dacecccc7d43b7fe6a6bb89 Maintainer: shein Status: ready -->
+<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="filesystem.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -150,19 +150,24 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       При включении директивы PHP будет проверять данные,
       которые считали функции <function>fgets</function> и <function>file</function>,
       чтобы определить, каким соглашениям о конце строк следуют функции — Unix, MS-Dos или Macintosh.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Директива разрешает PHP взаимодействовать с системами
       Macintosh, но по умолчанию для директивы установлено значение «Off»,
       поскольку когда PHP обнаруживает условное обозначение символов конца первой строки,
       незначительно снижается производительность,
       а ещё потому, что программисты, которые в Unix-системах пользуются символом возврата
       каретки как разделителем элементов, столкнутся с обратно-несовместимым поведением.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Начиная с PHP 8.1.0 директива объявлена устаревшей.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Syncs `language-snippets.ent` and `reference/filesystem/ini.xml` with php/doc-en#5238.

- `note.line-endings` no longer tells the reader to enable `auto_detect_line_endings`: it says the option could be enabled before PHP 8.1.0 to recognize line endings in files created on Macintosh systems, that it is deprecated as of 8.1.0, and that `"\\r"` line breaks should be handled manually if needed.
- The `auto_detect_line_endings` INI description gains the deprecation warning, and its two paragraphs become `simpara`, as upstream.

The EN-Revision of `language-snippets.ent` is left untouched: that file is still behind on several other doc-en commits, each tracked by its own issue.

Fixes: #1699
