### PR TITLE
[Sync-EN] Document the privateKey parameter of PharData::setSignatureAlgorithm()

### DIFF
--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="phar.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,6 +53,7 @@
        <programlisting role="php">
 <![CDATA[
 <?php
+$p = new Phar('archive.phar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="phardata.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -36,6 +36,27 @@
        Одна из констант: <literal>Phar::MD5</literal>,
        <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
        <literal>Phar::SHA512</literal> или <literal>Phar::OPENSSL</literal>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>privateKey</parameter></term>
+     <listitem>
+      <para>
+       Секретный ключ OpenSSL, извлечённый из сертификата, либо файл с ключом OpenSSL:
+       <programlisting role="php">
+<![CDATA[
+<?php
+$p = new PharData('archive.tar');
+$private = openssl_get_privatekey(file_get_contents('private.pem'));
+$pkey = '';
+openssl_pkey_export($private, $pkey);
+$p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
+?>
+]]>
+       </programlisting>
+       Подробности об именовании и размещении файла открытого ключа
+       смотрите в разделе <link linkend="phar.using">Введение в phar</link>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Syncs the two `setSignatureAlgorithm` pages with php/doc-en#5229.

- `PharData::setSignatureAlgorithm()` documented only `algo`; the `privateKey` parameter is added, with the same example and the pointer to the phar introduction as the `Phar` page, adapted to `new PharData('archive.tar')`.
- Both examples now start by creating the object, so `$p` is defined.

EN-Revision bumped to 2cbc37d710751c33862709e622d0e928c9015c45 on both files.

Fixes: #1706
