### PR TITLE
[Sync-EN] Amend the Imagick::sigmoidalContrastImage() parameter names

### DIFF
--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="imagick.sigmoidalcontrastimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,17 +16,22 @@
    <methodparam><type>float</type><parameter>beta</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Метод регулирует контрастность изображения нелинейным сигмоидальным алгоритмом.
    Алгоритм увеличивает контрастность сигмоидальной передаточной функцией без насыщения светлых участков или теней.
-   Параметр <parameter>alpha</parameter> задаёт степень увеличения контрастности: 0 — без изменений, 3 — типичное значение, 20 — предельное.
-   Параметр <parameter>beta</parameter> определяет положение средних тонов в результирующем изображении: 0.00 — белый; 0.50 — средний серый; 1.00 — чёрный.
-   При установке параметру <parameter>sharpen</parameter> значения &true; контрастность изображения увеличивается, иначе контрастность уменьшается.
-  </para>
-  <para>
+   Параметр <parameter>alpha</parameter> задаёт степень увеличения контрастности:
+   <literal>0.00</literal> — без изменений, <literal>3.00</literal> — типичное значение,
+   <literal>20.00</literal> — предельное.
+   Параметр <parameter>beta</parameter> определяет положение средних тонов в результирующем
+   изображении как долю квантового диапазона: <literal>0.0</literal> — белый,
+   <literal>0.5</literal> — средний серый, <literal>1.0</literal> — чёрный
+   (чтобы получить значение для передачи, долю умножают на
+   <code>getQuantumRange()['quantumRangeLong']</code>).
+  </simpara>
+  <simpara>
    Подробнее об алгоритме рассказывает раздел
    <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">Примеры ImageMagick -- Изменения цвета — Сигмоидальная нелинейная контрастность</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,24 +41,26 @@
     <varlistentry>
      <term><parameter>sharpen</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        При передаче значения &true; контраст увеличивается, при &false; — уменьшается.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alpha</parameter></term>
      <listitem>
-      <para>
-       Степень изменения контрастности: 1.00 — незначительно, 5.00 — значительно, 20 — предельно.
-      </para>
+      <simpara>
+       Степень изменения контрастности: <literal>1.00</literal> — незначительно,
+       <literal>5.00</literal> — значительно, <literal>20.00</literal> — предельно.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>beta</parameter></term>
      <listitem>
       <simpara>
-       Точка перегиба градиента: произведение значения в диапазоне от 0 до 1
+       Точка перегиба градиента: произведение значения в диапазоне
+       от <literal>0.00</literal> до <literal>1.00</literal>
        и предельного для текущей сборки библиотеки ImageMagick значения квантового диапазона.
       </simpara>
      </listitem>
@@ -61,9 +68,9 @@
     <varlistentry>
      <term><parameter>channel</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Цветовые каналы, к которым требуется применить контраст.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -86,28 +93,28 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>
-     Пример создания градиентного изображения методом <function>Imagick::sigmoidalContrastImage</function>
-     для плавного смешивания двух изображений с заданным контрастом и центром градиента
-    </title>
-    <programlisting role="php">
+  <example>
+   <title>
+    Пример создания градиентного изображения методом <function>Imagick::sigmoidalContrastImage</function>
+    для плавного смешивания двух изображений, где смешивание задают параметры
+    <parameter>alpha</parameter> и <parameter>beta</parameter>
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
-function generateBlendImage($width, $height, $contrast = 10, $midpoint = 0.5) {
+function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
+{
     $imagick = new Imagick();
     $imagick->newPseudoImage($width, $height, 'gradient:black-white');
     $quanta = $imagick->getQuantumRange();
-    $imagick->sigmoidalContrastImage(true, $contrast, $midpoint * $quanta["quantumRangeLong"]);
+    $imagick->sigmoidalContrastImage(true, $alpha, $beta * $quanta["quantumRangeLong"]);
 
     return $imagick;
 }
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Syncs `reference/imagick/imagick/sigmoidalcontrastimage.xml` with php/doc-en#5751.

- The description says `beta` is a fraction of the quantum range and that the value to pass is that fraction multiplied by `getQuantumRange()['quantumRangeLong']`, and the numeric values are marked up as `literal`.
- `alpha` and `beta` use the same two-decimal values as EN.
- The example no longer sits inside a `para`, its title names `alpha` and `beta` instead of "contrast and midpoint", and the code uses `$alpha` / `$beta` with the brace on its own line.
- Five paragraphs become `simpara`, as upstream.

EN-Revision bumped to d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd.

Fixes: #1707
