### PR TITLE
[Sync-EN] Sync the oop5 pages: grammar pass, readonly notes, comparison recursion

### DIFF
--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.anonymous" xmlns="http://docbook.org/ns/docbook">
  <title>Анонимные классы</title>
@@ -161,11 +161,11 @@ if (get_class(anonymous_class()) === get_class(anonymous_class())) {
  </informalexample>
 
  <note>
-  <para>
+  <simpara>
    Обратите внимание, что движок присваивает анонимным классам названия,
    как показывает следующий пример. Это название рекомендуют рассматривать только как деталь
    реализации, и лучше на него не полагаться.
-  </para>
+  </simpara>
   <informalexample>
    <programlisting role="php">
 <![CDATA[

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: irker Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.autoload" xmlns="http://docbook.org/ns/docbook">
  <title>Автоматическая загрузка классов</title>
@@ -10,27 +10,27 @@
   писать длинный список включений, по одному для каждого файла,
   который требуется загрузить.
  </para>
- <para>
+ <simpara>
   Функция <function>spl_autoload_register</function>
   регистрирует нужное количество автозагрузчиков
   для автоматической загрузки классов и интерфейсов,
   которые пока не определили.
   Регистрация автозагрузчиков даёт PHP последний шанс загрузить класс
   или интерфейс, прежде чем скрипт завершит работу с ошибкой.
- </para>
+ </simpara>
  <para>
   Все классоподобные конструкции получится загрузить автоматически таким же способом,
   включая классы, интерфейсы, трейты и перечисления.
  </para>
  <caution>
-  <para>
+  <simpara>
    До PHP 8.0.0 классы и интерфейсы загружали автоматически
    функцией <function>__autoload</function>.
    Однако это менее гибкая альтернатива функции
    <function>spl_autoload_register</function>,
    а функцию <function>__autoload</function> объявили устаревшей в PHP 7.2.0
    и удалили в PHP 8.0.0.
-  </para>
+  </simpara>
  </caution>
  <note>
   <para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mch Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
  <title>Журнал изменений ООП</title>

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.cloning" xmlns="http://docbook.org/ns/docbook">
  <title>Клонирование объектов</title>
 
- <para>
+ <simpara>
   Создание копии объекта с абсолютно идентичными свойствами
   не всегда является приемлемым вариантом. Хорошим примером
   необходимости копирования конструкторов может послужить
@@ -18,7 +18,7 @@
   вам нужно также создать новый экземпляр этого другого объекта,
   так, чтобы копия объекта-контейнера содержала собственный отдельный
   экземпляр содержащегося объекта.
- </para>
+ </simpara>
 
  <para>
   Копия объекта создаётся с использованием ключевого слова <literal>clone</literal>
@@ -45,13 +45,13 @@ $copy_of_object = clone $object;
   <void/>
  </methodsynopsis>
 
- <para>
+ <simpara>
   После завершения клонирования, если метод
   <link linkend="object.clone">__clone()</link> определён, то
   будет вызван метод <link linkend="object.clone">__clone()</link>
   вновь созданного объекта для возможного
   изменения всех необходимых свойств.
- </para>
+ </simpara>
 
  <example>
   <title>Клонирование объекта</title>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 922b4b5aeb327d78ea1bb4b932e5db2e9a03ffc5 Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.constants" xmlns="http://docbook.org/ns/docbook">
  <title>Константы классов</title>
- <para>
+ <simpara>
   В PHP <link linkend="language.constants">константы</link> возможно объявлять отдельно для каждого класса.
   Константы класса сохраняют исходное значение даже при изменении объекта класса, поскольку константы принадлежат классу, а не конкретному экземпляру.
   Область видимости констант классов по умолчанию устанавливается открытой, как будто константу определили с модификатором <literal>public</literal>.
- </para>
+ </simpara>
  <note>
   <para>
    Дочерним классам разрешается переопределять константы родительского класса.

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82fc6a1c8670b96f1bd2b40932b6eb19929f4f6f Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.decon" xmlns="http://docbook.org/ns/docbook">
  <title>Конструкторы и деструкторы</title>
@@ -175,13 +175,13 @@ class Point
     </para>
    </note>
    <note>
-    <para>
+    <simpara>
      Нельзя указывать свойствам объекта тип <type>callable</type>.
      Это связано с неоднозначностью, которую представляют вызываемые значения для движка PHP.
      Поэтому и для параметров конструктора, которые устанавливают классу свойства,
      тоже нельзя указывать тип <type>callable</type>. Но остальные
      <link linkend="language.types.declarations">декларации типов</link> поддерживаются.
-    </para>
+    </simpara>
    </note>
    <note>
     <para>
@@ -394,7 +394,7 @@ $obj = new MyDestructableClass();
    Деструктор, который создаёт новые ссылки на свой объект, не вызовется второй раз,
    когда счётчик ссылок снова достигнет нуля или при завершении работы программы.
   </para>
-  <para>
+  <simpara>
    Начиная с PHP 8.4.0 при запуске <link linkend="features.gc.collecting-cycles">сборки циклических ссылок</link>
    внутри <link linkend="language.fibers">файбера</link>
    деструкторы объектов-кандидатов на уничтожение выполняются в отдельном файбере,
@@ -405,7 +405,7 @@ $obj = new MyDestructableClass();
    который станет доступен для сборки, если на него не останется других ссылок.
    Уничтожение объектов с приостановленным деструктором откладывается
    до завершения выполнения деструктора или уничтожения самого файбера.
-  </para>
+  </simpara>
   <note>
    <para>
     Движок отправляет HTTP-заголовки ещё до начала этапа завершения работы скрипта, на котором вызываются деструкторы.

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: mch Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
  <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
   <title>Наследование</title>
@@ -28,7 +28,7 @@
    единственное ограничение закрытого метода, которое применяется - это конструкторы <literal>private final</literal>,
    поскольку это обычный способ «отключить» конструктор при использовании вместо него статичных фабричных методов.
   </para>
-  <para>
+  <simpara>
    <link linkend="language.oop5.visibility">Видимость</link> методов,
    свойств и констант можно ослабить, например, <literal>защищённый</literal> метод
    может быть помечен как <literal>общедоступный</literal>, но нельзя ограничить видимость,
@@ -36,7 +36,7 @@
    Исключением являются конструкторы, видимость которых может быть ограничена,
    например, <literal>общедоступный</literal> конструктор может быть помечен
    как <literal>закрытый</literal> в дочернем классе.
- </para>
+ </simpara>
 
   <note>
    <para>

--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 565bd8b6cf2cae44ae2bc54ef6dbe6ee70ddfefd Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Интерфейсы объектов</title>

--- a/language/oop5/iterations.xml
+++ b/language/oop5/iterations.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1fb0ef23d7be0d8ecd9604fce16ee1e0842c6ef6 Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.iterations" xmlns="http://docbook.org/ns/docbook">
  <title>Итераторы объектов</title>
- <para>
+ <simpara>
 
   PHP предоставляет такой способ объявления объектов, который
   даёт возможность пройти по списку элементов данного объекта,
@@ -11,7 +11,7 @@
   в этом обходе (итерации) будут участвовать все
   <link linkend="language.oop5.visibility">видимые</link> свойства объекта.
 
- </para>
+ </simpara>
 
  <example>
   <title>Итерация простого объекта</title>

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: mch Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
  <title>Позднее статическое связывание</title>
- <para>
+ <simpara>
   Позднее статическое связывание в PHP — механизм, который разрешает ссылаться
   на класс вызова в контексте статического наследования.
- </para>
+ </simpara>
 
  <para>
   Точнее, позднее статическое связывание сохраняет класс,

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8f51247cb4631b29686f867bd904dfe5b2678074 Maintainer: irker Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
  <title>Магические методы</title>
- <para>
+ <simpara>
   Магические методы — методы, которые переопределяют действие PHP по умолчанию,
   когда над объектом выполняются отдельные действия.
- </para>
+ </simpara>
  <caution>
   <simpara>
    Названия методов, которые начинаются с двух символов подчёркивания <literal>__</literal>, зарезервировали в PHP,
@@ -175,6 +175,16 @@ class Connection
    Методы <link linkend="object.sleep">__sleep()</link>
    и <link linkend="object.wakeup">__wakeup()</link>
   </title>
+
+  <warning>
+   <simpara>
+    Начиная с PHP 8.5.0 этот механизм сериализации мягко объявлен устаревшим.
+    Его сохраняют ради обратной совместимости.
+    Однако новый и существующий код переводят на магические методы
+    <link linkend="object.serialize">__serialize()</link> и
+    <link linkend="object.unserialize">__unserialize()</link>.
+   </simpara>
+  </warning>
 
   <methodsynopsis xml:id="object.sleep">
    <modifier>public</modifier> <type>array</type><methodname>__sleep</methodname>
@@ -565,8 +575,9 @@ object(A)#2 (2) {
     если метод __set_state() не реализовали. В частности, это относится к ряду внутренних классов.
    </simpara>
    <simpara>
-    Программист несёт ответственность повторный
-    импорт только тех объектов, класс которых реализует метод __set_state().
+    Программист сам отвечает за то, чтобы повторно импортировали только те
+    объекты, класс которых реализует метод
+    <methodname>__set_state</methodname>.
    </simpara>
   </note>
  </sect2>

--- a/language/oop5/object-comparison.xml
+++ b/language/oop5/object-comparison.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.object-comparison" xmlns="http://docbook.org/ns/docbook">
  <title>Сравнение объектов</title>
@@ -98,10 +98,10 @@ o1 !== o2 : TRUE
     </example>
    </para>
    <note>
-    <para>
+    <simpara>
      Модули иногда определяют внутренние правила сравнения
      своих объектов через оператор <literal>==</literal>.
-    </para>
+    </simpara>
    </note>
 </sect1><!-- Keep this comment at the end of the file
 Local variables:

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: shein Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.paamayim-nekudotayim" xmlns="http://docbook.org/ns/docbook">
  <title>Оператор разрешения области действия ::</title>
@@ -87,7 +87,7 @@ OtherClass::doubleColon();
   </programlisting>
  </example>
 
- <para>
+ <simpara>
   PHP не вызывает метод родительского класса,
   когда дочерний класс переопределяет родительский метод.
   Дочерний класс сам решает, вызывать ли метод родительского класса.
@@ -95,7 +95,7 @@ OtherClass::doubleColon();
   linkend="language.oop5.decon">к конструкторам и деструкторам</link>,
   <link linkend="language.oop5.overloading">перегруженным</link>
   и «<link linkend="language.oop5.magic">магическим</link>» методам.
- </para>
+ </simpara>
 
  <example>
   <title>Пример вызова родительского метода</title>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 801e7a15e8c9ee2d16966487dc9058d992450b46 Maintainer: irker Status: ready -->
+<!-- EN-Revision: 4e77868e15fea65175b87a38d6d31b61d63f7f8e Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Свойства</title>
@@ -19,10 +19,10 @@
   как <link linkend="language.constants">постоянное значение</link>.
  </para>
  <note>
-  <para>
+  <simpara>
    Устаревший способ объявления свойств класса —
    ключевое слово <literal>var</literal> вместо модификатора.
-  </para>
+  </simpara>
  </note>
  <note>
   <simpara>
@@ -165,7 +165,7 @@ class Shape
 
 $triangle = new Shape();
 $triangle->setName("triangle");
-$triangle->setNumberofSides(3);
+$triangle->setNumberOfSides(3);
 var_dump($triangle->getName());
 var_dump($triangle->getNumberOfSides());
 
@@ -271,6 +271,36 @@ $test1->prop = "foobar";
     </programlisting>
    </example>
   </para>
+  <note>
+   <para>
+    Readonly-свойство инициализируют только прямым присваиванием.
+    Неинициализированное readonly-свойство нельзя инициализировать по ссылке,
+    даже из той области видимости, в которой свойство объявили: передача
+    свойства в параметр функции, который принимает значение по ссылке,
+    или присваивание свойства по ссылке выбрасывают исключение
+    <exceptionname>Error</exceptionname>.
+    <informalexample>
+     <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+
+class Test {
+    public readonly array $matches;
+
+    public function __construct(string $subject) {
+        // Недопустимая инициализация по ссылке.
+        preg_match('/\d+/', $subject, $this->matches);
+        // Error: Cannot indirectly modify readonly property Test::$matches
+    }
+}
+
+new Test('abc 42');
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </note>
   <note>
    <para>
     Нельзя явным образом указывать значение по умолчанию для readonly-свойств,
@@ -392,6 +422,14 @@ var_dump($test2->prop); // NULL
      </programlisting>
     </example>
    </para>
+   <note>
+    <simpara>
+     Начиная с PHP 8.4.0 косвенное изменение readonly-свойства внутри метода
+     <link linkend="object.clone">__clone()</link>, например получение ссылки
+     на свойство (<code>$ref = &amp;$this-&gt;prop</code>), больше не разрешено.
+     Во время инициализации readonly-свойства это запрещали и раньше.
+    </simpara>
+   </note>
  </sect2>
 
  <sect2 xml:id="language.oop5.properties.dynamic-properties">

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: malferov Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>Хуки свойств</title>

--- a/language/oop5/references.xml
+++ b/language/oop5/references.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: irker Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: irker Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.references" xmlns="http://docbook.org/ns/docbook">
  <title>Объекты и ссылки</title>
- <para>
+ <simpara>
   Разработчики при обсуждении объектно-ориентированного программирования на языке PHP
   часто утверждают, что «по умолчанию объекты передаются по ссылке».
   Это не совсем так. Этот раздел объясняет общую мысль утверждения на примерах.
- </para>
+ </simpara>
 
  <para>
   Ссылка в PHP — псевдоним, который разрешает присвоить двум переменным

--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 70f392045a26b176f206013f00fa14b86440efd1 Maintainer: mch Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.serialization" xmlns="http://docbook.org/ns/docbook">
  <title>Сериализация объектов — сохранение объектов между сессиями</title>
@@ -14,7 +14,7 @@
   только имя класса.
  </para>
 
- <para>
+ <simpara>
   Чтобы десериализовать объект функцией <function>unserialize</function>,
   необходимо заранее определить класс этого объекта. То есть, если
   есть экземпляр класса А, и он будет сериализован,
@@ -25,7 +25,7 @@
   Это можно сделать, например, путём сохранения определения класса A в отдельном файле
   и подключения этого файла или вызовом функции
   <function>spl_autoload_register</function> для автоматического подключения.
- </para>
+ </simpara>
 
  <informalexample>
   <programlisting role="php">
@@ -65,14 +65,14 @@
   </programlisting>
  </informalexample>
 
- <para>
+ <simpara>
   Если в приложении сериализуются объекты, которые будут использованы в приложении позже,
   следуют строгой рекомендации — подключать определение класса
   для этого объекта во всём приложении. При невыполнении этого требования десериализация объекта
   пройдёт и без определения класса, но PHP назначит этому объекту
   класс <classname>__PHP_Incomplete_Class_Name</classname>,
   у которого нет методов, и сделает объект бесполезным.
- </para>
+ </simpara>
 
  <para>
   Поэтому, как в примере выше, если переменная <varname>$a</varname> стала частью сессии

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: mch Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
  <title>Трейты</title>
@@ -240,11 +240,11 @@ Hello World!
   </para>
   <example xml:id="language.oop5.traits.conflict.ex1">
    <title>Пример разрешения конфликтов</title>
-   <para>
+   <simpara>
     В этом примере в класс Talker включили трейты A и B.
     Поскольку в трейтах A и B содержатся методы, которые вступают в конфликт,
     класс использует вариант метода smallTalk из трейта B, а вариант метода bigTalk из трейта A.
-   </para>
+   </simpara>
    <para>
     Оператор <literal>as</literal> в классе Aliased_Talker
     разрешает вызывать метод bigTalk трейта B

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e7c00fd314a708ecbd495ef7cc9ae8c8462c33c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
  <title>Ковариантность и контравариантность</title>
@@ -48,12 +48,12 @@
  <sect2 xml:id="language.oop5.variance.covariance">
   <title>Ковариантность</title>
 
-  <para>
+  <simpara>
    Создадим простой абстрактный родительский класс <varname>Animal</varname>,
    чтобы проиллюстрировать работу ковариантности.
    Класс <varname>Animal</varname> расширяется дочерними классами
    <varname>Cat</varname> и <varname>Dog</varname>.
-  </para>
+  </simpara>
 
   <informalexample>
    <programlisting role="php">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.comparison">
  <title>Операторы сравнения</title>
@@ -384,6 +384,15 @@ function standard_array_compare($op1, $op2)
    или целых чисел (&integer;) со строками (&string;).
    Поэтому лучше пользоваться операторами <literal>===</literal> и <literal>!==</literal>,
    а не <literal>==</literal> и <literal>!=</literal>.
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
+   Начиная с PHP 8.4.0 рекурсия, которая встретилась во время сравнения,
+   например при сравнении массива или объекта, который содержит ссылку
+   на самого себя, выбрасывает ошибку <exceptionname>Error</exceptionname>;
+   раньше это приводило к фатальной ошибке.
   </simpara>
  </note>
 


### PR DESCRIPTION
Syncs the `language/oop5/` pages and `language/operators/comparison.xml` with php/doc-en#5728, php/doc-en#5775 and php/doc-en#5226. The three upstream commits all land on `language/oop5/properties.xml`, so they have to be ported together.

php/doc-en#5728 (19 oop5 files): mostly `para` to `simpara` conversions, mirrored here. Two changes affect the Russian text:
- `properties.xml`: the example called `setNumberofSides()` while the class declares `setNumberOfSides()`.
- `magic.xml`: the `__set_state` sentence is rewritten and the method name is marked up as `methodname`.

php/doc-en#5775:
- `properties.xml`: adds the note that as of PHP 8.4.0 indirect modification of a readonly property inside `__clone()`, such as taking a reference to it, is no longer allowed.
- `comparison.xml`: adds the note that recursion encountered during comparison throws an `Error` as of PHP 8.4.0, where it previously caused a fatal error.

php/doc-en#5226: `properties.xml` gains the note and example showing that a readonly property can only be initialized by direct assignment, and that initializing it by reference throws an `Error`.

One more gap was found while aligning the structure: `magic.xml` was missing the warning that the `__sleep()` / `__wakeup()` serialization mechanism is soft-deprecated as of PHP 8.5.0. That warning already existed in the English page at the revision the file declared, so it was simply never translated; it is added here.

EN-Revision bumped to dff848b17dafaabfb7662ffb5fecfcb04e3b771d on the 18 grammar-only files, 4e77868e15fea65175b87a38d6d31b61d63f7f8e on `properties.xml` and 62e61e543c2d2b8519952efa246ed708026cfb16 on `comparison.xml`.

Fixes: #1603
Fixes: #1667
Fixes: #1719
