### PR TITLE
[Sync-EN] Document the multibyte string behavior of escapeshellarg() and escapeshellcmd()

### DIFF
--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 60c391265d2a51003e1ed0952e5a2413f81c7fc2 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 0600ff7ba94e3f491aeb246d8ddfedd98f0d7276 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.escapeshellarg" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
    <type>string</type><methodname>escapeshellarg</methodname>
    <methodparam><type>string</type><parameter>arg</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция <function>escapeshellarg</function> добавляет одинарные кавычки вокруг строки и кавычек
    и экранирует любые существующие одинарные кавычки, разрешая
    передать строку непосредственно в функцию оболочки и рассматривать её как один
@@ -21,14 +21,19 @@
    отдельные аргументы для функций оболочки, полученные из пользовательского ввода. Экранирование
    аргумента необходимо в таких функциях оболочки как <function>exec</function>,
    <function>system</function> и оператор <link linkend="language.operators.execution">"обратный апостроф"</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    В ОС Windows <function>escapeshellarg</function> заменяет восклицательный знак,
    знак процента (позднее связывание переменных) и двойные кавычки на пробелы и
    добавляет двойные кавычки вокруг строки.
    Кроме того, каждая серия последовательных обратных слешей (<literal>\</literal>)
    экранируется одним дополнительным обратным слешем.
-  </para>
+  </simpara>
+  <simpara>
+   Поведение функции с многобайтовыми строками зависит от текущей настройки
+   локали <constant>LC_CTYPE</constant>. Нераспознанные символы отбрасываются.
+   Подробности даёт описание функции <function>setlocale</function>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает экранированную строку.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -76,6 +81,7 @@ system('ls '.escapeshellarg($dir));
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>setlocale</function></member>
     <member><function>escapeshellcmd</function></member>
     <member><function>exec</function></member>
     <member><function>popen</function></member>

--- a/reference/exec/functions/escapeshellcmd.xml
+++ b/reference/exec/functions/escapeshellcmd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: mch Status: ready -->
+<!-- EN-Revision: 0600ff7ba94e3f491aeb246d8ddfedd98f0d7276 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.escapeshellcmd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
    <type>string</type><methodname>escapeshellcmd</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Команда <function>escapeshellcmd</function> экранирует любые символы в
    строке, которые могут быть использованы для обмана команды оболочки при выполнении
    произвольных команд. Эта функция должна быть использована, чтобы убедиться,
@@ -21,15 +21,20 @@
    функциям <function>exec</function> или
    <function>system</function> или оператору <link
    linkend="language.operators.execution">"обратный апостроф"</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Следующие символы будут экранированы при помощи обратного слеша:
    <literal>&amp;#;`|*?~&lt;&gt;^()[]{}$\</literal>, <literal>\x0A</literal>
    и <literal>\xFF</literal>. Символы <literal>'</literal> и <literal>"</literal>
    экранируются только в том случае, если они  встречаются не попарно. В Windows все
    этим символам, плюс <literal>!</literal> и <literal>%</literal> предшествует символ каретки
    (<literal>^</literal>).
-  </para>
+  </simpara>
+  <simpara>
+   Поведение функции с многобайтовыми строками зависит от текущей настройки
+   локали <constant>LC_CTYPE</constant>. Нераспознанные символы отбрасываются.
+   Подробности даёт описание функции <function>setlocale</function>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -50,9 +55,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция возвращает экранированную строку.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -81,12 +86,12 @@ system($escaped_command);
  <refsect1 role="notes">
   &reftitle.notes;
   <warning xmlns="http://docbook.org/ns/docbook">
-   <para>
+   <simpara>
     Функцию <function>escapeshellcmd</function> следует использовать над всей
     командной строкой, но она всё ещё позволяет атакующему передать
     произвольное количество аргументов. Для экранирования одного аргумента
     вместо неё необходимо использовать функцию <function>escapeshellarg</function>.
-   </para>
+   </simpara>
   </warning>
   <warning xmlns="http://docbook.org/ns/docbook">
     <para>
@@ -110,6 +115,7 @@ $cmd = preg_replace('`(?<!^) `', '^ ', escapeshellcmd($cmd));
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>setlocale</function></member>
     <member><function>escapeshellarg</function></member>
     <member><function>exec</function></member>
     <member><function>popen</function></member>


### PR DESCRIPTION
Syncs `reference/exec/functions/escapeshellarg.xml` and `reference/exec/functions/escapeshellcmd.xml` with php/doc-en#4924.

- Both descriptions gain the paragraph stating that the behavior with multibyte strings depends on the current `LC_CTYPE` locale and that unrecognized characters are discarded, pointing at `setlocale()`.
- `setlocale()` is added to both see-also lists.
- Several paragraphs become `simpara`, as upstream.

EN-Revision bumped to 0600ff7ba94e3f491aeb246d8ddfedd98f0d7276 on both files.

Fixes: #1669
