### PR TITLE
[Sync-EN] Document the --enable-zend-max-execution-timers configure option

### DIFF
--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: aur Status: ready -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
  <sect3 xml:id="configure.options.misc" xmlns="http://docbook.org/ns/docbook">
   <title>Различные опции</title>
@@ -48,6 +48,27 @@
     </listitem>
    </varlistentry>
 
+   <varlistentry xml:id="configure.enable-zend-max-execution-timers">
+    <term>
+     <option role="configure">--enable-zend-max-execution-timers</option>
+    </term>
+    <listitem>
+     <simpara>
+      Отслеживать директиву
+      <link linkend="ini.max-execution-time">max_execution_time</link>
+      потоковыми POSIX-таймерами вместо общесистемного для процесса
+      вызова <literal>setitimer()</literal>. Такие таймеры измеряют
+      прошедшее время (<literal>CLOCK_BOOTTIME</literal>, а во FreeBSD —
+      <literal>CLOCK_MONOTONIC</literal>), тогда как стандартный вызов
+      <literal>setitimer(ITIMER_PROF)</literal> измеряет процессорное время,
+      поэтому время в ожидании или на операциях ввода-вывода тоже засчитывается
+      в лимит. Требуется поддержка вызова <literal>timer_create()</literal>:
+      она доступна в Linux, а во FreeBSD — начиная с PHP 8.4.0.
+      Параметр доступен с PHP 8.1.0. Для ZTS-сборок включён по умолчанию
+      начиная с PHP 8.3.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="configure.enable-sigchild">
     <term>
      <option role="configure">--enable-sigchild</option>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="info.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -244,6 +244,15 @@
       операции и т.п. За дополнительной информацией обращайтесь к документации к
       функции <function>set_time_limit</function>.
      </para>
+     <simpara>
+      Когда PHP собрали с параметром
+      <link linkend="configure.enable-zend-max-execution-timers">--enable-zend-max-execution-timers</link>
+      (для ZTS-сборок он включён по умолчанию начиная с PHP 8.3.0), лимит
+      отслеживают потоковыми POSIX-таймерами, которые измеряют прошедшее время,
+      поэтому время в ожидании или на операциях ввода-вывода тоже засчитывается
+      в лимит. Стандартное отслеживание через вызов
+      <literal>setitimer(ITIMER_PROF)</literal> измеряет процессорное время.
+     </simpara>
      <para>
       Веб-серверы обычно имеют свои настройки времени ожидания, по превышении которого сами
       завершают выполнение скрипта PHP. В Apache есть директива


### PR DESCRIPTION
Syncs `appendices/configure/misc.xml` and `reference/info/ini.xml` with php/doc-en#5269.

- The configure appendix gains the `--enable-zend-max-execution-timers` entry: POSIX per-thread timers measuring elapsed time (`CLOCK_BOOTTIME`, `CLOCK_MONOTONIC` on FreeBSD) instead of the process-wide `setitimer(ITIMER_PROF)` which measures CPU time, so sleeping and I/O count towards the limit. It requires `timer_create()` (Linux, and FreeBSD as of PHP 8.4.0), is available since PHP 8.1.0 and is on by default for ZTS builds since PHP 8.3.0.
- The `max_execution_time` INI description points at that option and explains the difference between elapsed time and CPU time tracking.

EN-Revision bumped to 667093532547bcfe6224765f038c151c61f30f48 on both files.

Fixes: #1672
