### PR TITLE
[Sync-EN] Describe PREG_UNMATCHED_AS_NULL for trailing groups in the constants table

### DIFF
--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e62b1e3989a5049c052bc547bb6bf175ada8e48d Maintainer: shein Status: ready -->
+<!-- EN-Revision: cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pcre.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -102,6 +102,10 @@
       несовпадающие подмаски отображаются как пустые строки, как если бы функция
       не нашла совпадений.
       Установка этого флага разрешает проводить различие между двумя этими случаями.
+      В функции <function>preg_match</function> конечные несовпадающие подмаски
+      без этого флага не попадают в переменную <varname>$matches</varname> вовсе;
+      начиная с PHP 7.4.0 флаг возвращает их как значения &null;, поэтому размер
+      массива <varname>$matches</varname> всегда одинаковый.
      </entry>
      <entry>7.2.0</entry>
     </row>


### PR DESCRIPTION
Syncs `reference/pcre/constants.xml` with php/doc-en#5272.

The `PREG_UNMATCHED_AS_NULL` entry now states that with `preg_match()` trailing unmatched subpatterns are left out of `$matches` entirely unless the flag is used, and that as of PHP 7.4.0 the flag reports them as `&null;` so `$matches` always has the same size.

The other file of that upstream commit, `reference/pcre/functions/preg-match.xml`, was already synced.

EN-Revision bumped to cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551.

Fixes: #1673
