### PR TITLE
[Sync-EN] Document curl_errno() and curl_error() behavior with multi handles

### DIFF
--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: shein Status: ready -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.curl-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,6 +33,15 @@
    Функция возвращает номер ошибки или целочисленное значение <literal>0</literal>,
    если последняя операция выполнилась успешно.
   </para>
+  <note>
+   <simpara>
+    Когда дескриптор <type>CurlHandle</type> выполняют через функцию
+    <function>curl_multi_exec</function>, эта функция всегда возвращает
+    <literal>0</literal>. Код ошибки для каждого отдельного дескриптора
+    возвращает функция <function>curl_multi_info_read</function>
+    в элементе <literal>result</literal>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -85,6 +94,7 @@ if (curl_errno($ch)) {
   <para>
    <simplelist>
     <member><function>curl_error</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Коды ошибок cURL</link></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: shein Status: ready -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.curl-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,6 +33,16 @@
    Функция возвращает сообщение об ошибке или пустую строку — <literal>''</literal>,
    если последняя операция выполнилась успешно.
   </para>
+  <note>
+   <simpara>
+    Когда дескриптор <type>CurlHandle</type> выполняют через функцию
+    <function>curl_multi_exec</function>, эта функция всегда возвращает
+    пустую строку — <literal>''</literal>. Чтобы получить строку ошибки
+    для каждого отдельного дескриптора, элемент <literal>result</literal>,
+    который вернула функция <function>curl_multi_info_read</function>,
+    передают функции <function>curl_strerror</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -83,6 +93,8 @@ if (curl_exec($ch) === false) {
   <para>
    <simplelist>
     <member><function>curl_errno</function></member>
+    <member><function>curl_strerror</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Коды ошибок cURL</link></member>
    </simplelist>
   </para>


### PR DESCRIPTION
Syncs `reference/curl/functions/curl-errno.xml` and `reference/curl/functions/curl-error.xml` with php/doc-en#5233.

- `curl_errno()`: adds the note that a handle executed through `curl_multi_exec()` always reports 0, the per-handle error code being the `result` key returned by `curl_multi_info_read()`.
- `curl_error()`: adds the matching note, the empty string being returned, and points at passing that `result` key to `curl_strerror()`.
- The see-also lists gain `curl_multi_info_read()`, and `curl_strerror()` on the `curl_error()` page.

EN-Revision bumped to ff7a0054b19ab80290b365d1417550807f82755a on both files.

Fixes: #1689
