### PR TITLE
[Sync-EN] Clarify ob_get_status() buffer_size and ob_start() chunk_size

### DIFF
--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: mch Status: ready -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -111,7 +111,14 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Размер буфера вывода в байтах.
+      Текущий выделенный размер буфера вывода в байтах.
+      Он начинается с <literal>16384</literal> байтов при стандартном значении
+      параметра <parameter>chunk_size</parameter> либо со значения параметра
+      <parameter>chunk_size</parameter>, округлённого вверх до кратного
+      <literal>4096</literal>, когда параметр указали, и растёт кратно
+      <literal>4096</literal> по мере буферизации вывода.
+      Это не объём данных в буфере — его показывает элемент
+      <literal>buffer_used</literal>.
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -112,15 +112,23 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        При установке необязательного параметра <parameter>chunk_size</parameter>
-       буфер сбрасываться после каждого блока кода,
+       буфер сбрасывается после каждого блока кода,
        размер буфера которого достиг или превысил
        значение параметра <parameter>chunk_size</parameter>.
        Значение по умолчанию <literal>0</literal> означает,
        что вывод буферизуется до тех пор, пока буфер не выключится.
+       Значение <literal>1</literal> означает, что буфер сбрасывается после
+       каждой операции вывода, то есть буферизация фактически отключается.
+       Параметр <parameter>chunk_size</parameter> определяет также начальный
+       размер буфера, который показывает функция
+       <function>ob_get_status</function>: <literal>16384</literal> байта,
+       когда параметр равен <literal>0</literal>, и значение параметра
+       <parameter>chunk_size</parameter>, округлённое вверх до кратного
+       <literal>4096</literal>, в остальных случаях.
        Подробнее об этом рассказывает раздел «<xref linkend="outcontrol.buffer-size"/>».
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Syncs `reference/outcontrol/functions/ob-get-status.xml` and `reference/outcontrol/functions/ob-start.xml` with php/doc-en#5260.

- `buffer_size` is described as the currently allocated buffer size, starting at 16384 bytes with the default `chunk_size` or at `chunk_size` rounded up to the next multiple of 4096, growing in multiples of 4096, and explicitly not the amount of data held (that is `buffer_used`).
- `chunk_size` documents that 1 flushes after every output operation, effectively disabling buffering, and that it also sets the initial buffer size reported by `ob_get_status()`.

The Russian `chunk_size` sentence also had a grammar slip, "буфер сбрасываться", corrected to "буфер сбрасывается".

EN-Revision bumped to 1ebafd8a44786824396f95102576426462835869 on both files.

Fixes: #1690
