### PR TITLE
[Sync-EN] Document the error handler stack

### DIFF
--- a/reference/errorfunc/functions/restore-error-handler.xml
+++ b/reference/errorfunc/functions/restore-error-handler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a6671fe697ead5b27603b56face01a2c4e7ebe5 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: cbfc5d5d55d682c185583561295462a6d5ca0ea1 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.restore-error-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,12 +15,19 @@
    <type>true</type><methodname>restore_error_handler</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Функцию вызывают после изменения обработчика ошибок функцией
-   <function>set_error_handler</function>, чтобы вернуться к предыдущему обработчику,
-   которым станет или пользовательская функция обработки ошибок, если такую определили,
-   или встроенный обработчик.
-  </para>
+  <simpara>
+   Функция снимает с внутреннего стека обработчиков ошибок тот обработчик,
+   который действовал до последнего вызова функции
+   <function>set_error_handler</function>, и снова делает его активным
+   вместе с маской <parameter>error_levels</parameter>, с которой обработчик
+   зарегистрировали. Восстановленным обработчиком станет или пользовательская
+   функция обработки ошибок, или встроенный обработчик.
+  </simpara>
+  <simpara>
+   Если эту функцию вызвали чаще, чем функцию
+   <function>set_error_handler</function>, активным остаётся встроенный
+   обработчик ошибок; ошибка при этом не возникает.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -74,15 +81,13 @@ restore_error_handler();
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>error_reporting</function></member>
-    <member><function>set_error_handler</function></member>
-    <member><function>get_error_handler</function></member>
-    <member><function>restore_exception_handler</function></member>
-    <member><function>trigger_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>error_reporting</function></member>
+   <member><function>set_error_handler</function></member>
+   <member><function>get_error_handler</function></member>
+   <member><function>restore_exception_handler</function></member>
+   <member><function>trigger_error</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 21ce7d7f4f9f6f241f3e09e7f0a5be5c504d90d2 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: cbfc5d5d55d682c185583561295462a6d5ca0ea1 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.set-error-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,10 +16,13 @@
    <methodparam><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>error_levels</parameter><initializer><constant>E_ALL</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция устанавливает пользовательскую <parameter>callback</parameter>-функцию
    обработки ошибок, которые возникают в скрипте.
-  </para>
+   Обработчик, который действовал до этого, сохраняется во внутреннем стеке
+   обработчиков ошибок, откуда его снимает функция
+   <function>restore_error_handler</function>.
+  </simpara>
   <para>
    Функция определяет пользовательские обработчики ошибок, которые возникают во время выполнения кода.
    Обработчики устанавливают в приложениях, которым требуется
@@ -65,10 +68,13 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
-       При передаче значения &null; обработчик сбрасывается в состояние по умолчанию,
-       иначе обработчиком становится callback-функция со следующей сигнатурой:
-      </para>
+      <simpara>
+       При передаче значения &null; активным не остаётся ни один пользовательский
+       обработчик, и ошибки обрабатывает встроенный обработчик.
+       Обработчик, который действовал до этого, остаётся в стеке, и его
+       возвращает функция <function>restore_error_handler</function>.
+       Иначе обработчиком становится callback-функция со следующей сигнатурой:
+      </simpara>
       <para>
        <methodsynopsis>
         <type>bool</type><methodname><replaceable>handler</replaceable></methodname>
@@ -351,20 +357,80 @@ vector d - fatal error
     </screen>
    </example>
   </para>
+  <para>
+   <example>
+    <title>Вызов предыдущего обработчика из нового</title>
+    <simpara>
+     Функция <function>set_error_handler</function> возвращает обработчик,
+     который действовал до вызова. Вызов этого обработчика из нового сохраняет
+     прежнее поведение и добавляет к нему новое. Приём работает, только если
+     прежним обработчиком была пользовательская функция: когда действовал
+     встроенный обработчик, функция возвращает &null;.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+function logging_handler(int $errno, string $errstr): bool
+{
+    echo "записано в журнал: $errstr\n";
+    return true;
+}
+
+set_error_handler('logging_handler');
+
+$previous = set_error_handler(function (int $errno, string $errstr) use (&$previous): bool {
+    echo "подсчитано: $errstr\n";
+    return $previous !== null ? $previous($errno, $errstr) : false;
+});
+
+trigger_error("что-то произошло", E_USER_WARNING);
+
+restore_error_handler();
+trigger_error("теперь только запись в журнал", E_USER_WARNING);
+
+restore_error_handler();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+подсчитано: что-то произошло
+записано в журнал: что-то произошло
+записано в журнал: теперь только запись в журнал
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <caution>
+   <simpara>
+    Не возвращаются к предыдущему обработчику, передавая функции
+    <function>set_error_handler</function> её же возвращаемое значение.
+    Такой вызов не снимает запись со стека, а добавляет ещё одну, поэтому
+    в циклах и долгоживущих процессах стек растёт без ограничений, а параметр
+    <parameter>error_levels</parameter> сбрасывается в значение
+    <constant>E_ALL</constant>, из-за чего восстановленный обработчик
+    незаметно начинает получать более широкий набор ошибок.
+    Для возврата к предыдущему обработчику предназначена функция
+    <function>restore_error_handler</function>.
+   </simpara>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><classname>ErrorException</classname></member>
-    <member><function>error_reporting</function></member>
-    <member><function>restore_error_handler</function></member>
-    <member><function>get_error_handler</function></member>
-    <member><function>trigger_error</function></member>
-    <member><link linkend="errorfunc.constants">Константы уровней ошибок</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><exceptionname>ErrorException</exceptionname></member>
+   <member><function>error_reporting</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>get_error_handler</function></member>
+   <member><function>trigger_error</function></member>
+   <member><link linkend="errorfunc.constants">Константы уровней ошибок</link></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Syncs `reference/errorfunc/functions/restore-error-handler.xml` and `reference/errorfunc/functions/set-error-handler.xml` with php/doc-en#5253.

`restore_error_handler()`:
- Described as popping the handler that was active before the last `set_error_handler()` call off the internal stack and reactivating it together with the `error_levels` mask it was registered with.
- Adds the note that calling it more often than `set_error_handler()` simply leaves the built-in handler active, without raising an error.

`set_error_handler()`:
- The description says the previous handler is saved on the internal stack, from which `restore_error_handler()` pops it back.
- Passing `&null;` is described accurately: no user handler stays active and errors fall back to the built-in one, while the previous handler remains on the stack.
- Adds the "calling the previous handler from the new one" example and its output.
- Adds the notes section cautioning against reverting by passing the return value of `set_error_handler()` back to it: that pushes another entry instead of removing one, so the stack grows without bound, and `error_levels` is reset to `E_ALL`, silently widening what the restored handler receives.
- `ErrorException` is marked up as `exceptionname`, and both see-also `simplelist`s are no longer wrapped in a `para`.

EN-Revision bumped to cbfc5d5d55d682c185583561295462a6d5ca0ea1 on both files.

Fixes: #1692
