### PR TITLE
[Sync-EN] Fix the unresolved ZMQ exception entity references

### DIFF
--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a5b92a30888d6423db112f07a9b344cf6fc4891 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <!-- State: experimental -->
 <book xml:id="book.zmq" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -22,10 +22,19 @@
  &reference.zmq.setup;
 
  &reference.zmq.zmq;
+ &reference.zmq.zmqexception;
+
  &reference.zmq.zmqcontext;
+ &reference.zmq.zmqcontextexception;
+
  &reference.zmq.zmqsocket;
+ &reference.zmq.zmqsocketexception;
+
  &reference.zmq.zmqpoll;
+ &reference.zmq.zmqpollexception;
+
  &reference.zmq.zmqdevice;
+ &reference.zmq.zmqdeviceexception;
 
 </book>
 <!-- Keep this comment at the end of the file

--- a/reference/zmq/zmqcontextexception.xml
+++ b/reference/zmq/zmqcontextexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.zmqcontextexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontextexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -85,8 +81,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqcontextexception;
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/zmq/zmqdeviceexception.xml
+++ b/reference/zmq/zmqdeviceexception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Класс ZMQDeviceException</title>
  <titleabbrev>ZMQDeviceException</titleabbrev>
@@ -38,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdeviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -85,8 +81,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqdeviceexception;
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/zmq/zmqexception.xml
+++ b/reference/zmq/zmqexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.zmqexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -37,10 +37,6 @@
     </classsynopsisinfo>
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
@@ -85,8 +81,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqexception;
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/zmq/zmqpollexception.xml
+++ b/reference/zmq/zmqpollexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.zmqpollexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpollexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -85,8 +81,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqpollexception;
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/zmq/zmqsocketexception.xml
+++ b/reference/zmq/zmqsocketexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.zmqsocketexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocketexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -85,8 +81,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqsocketexception;
 
 </reference>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Syncs the six `reference/zmq/` files with php/doc-en#5776.

- `book.xml` now includes the five exception class pages, each after the class it belongs to. They existed but were never pulled into the book.
- Each exception page drops the `Methods` `xi:include` that pointed at its own `class.<name>` id, which resolved to nothing since these classes declare no methods.
- The `InheritedMethods` `xi:include` points at `class.exception` instead of `class.zmqexception` on the four subclasses.
- Each page drops the trailing `&reference.zmq.entities.<name>;` reference.
- `zmqdeviceexception.xml` drops the unused `xmlns:xlink` declaration.

EN-Revision bumped to c517a71287d79c65ea42dff4c6973e22ef5c3bee on the six files.

Fixes: #1676
