### PR TITLE
[Sync-EN] Document the opcache JIT default change (PHP 8.4)

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f2cdcd5af4558c22db95463b6ccdd25e4cea3cf5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 36d18e7d4a32ecfdacc1eb086276ffb1baf0393c Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
@@ -1159,7 +1159,9 @@ function getA() { return A; }
      <member><literal>off</literal>: Выключен, но разрешается включить во время выполнения.</member>
      <member>
       <literal>tracing</literal>/<literal>on</literal>: Включить JIT с компиляцией трассировок.
-      Включён по умолчанию и рекомендуется для большей части пользователей.
+      Режим рекомендуют для большей части пользователей. До PHP 8.4.0 это было
+      значение по умолчанию; начиная с PHP 8.4.0 по умолчанию установлено
+      значение <literal>disable</literal>.
      </member>
      <member><literal>function</literal>: Включить JIT с компиляцией функций.</member>
     </simplelist>
@@ -1220,6 +1222,12 @@ function getA() { return A; }
      Режим <literal>tracing</literal> соответствует <code>CRTO = 1254</code>,
      Режим <literal>function</literal> соответствует <code>CRTO = 1205</code>.
     </para>
+    <note>
+     <simpara>
+      Начиная с PHP 8.4.0, если JIT включён, PHP завершает работу с фатальной
+      ошибкой во время запуска, когда инициализация JIT не удалась.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-buffer-size">


### PR DESCRIPTION
Syncs `reference/opcache/ini.xml` with php/doc-en#5738.

- The `tracing`/`on` entry no longer says the tracing JIT is enabled by default: it was the default before PHP 8.4.0, and as of 8.4.0 the default is `disable`.
- Adds the note that as of PHP 8.4.0, when JIT is enabled and its initialization fails, PHP exits with a fatal error during startup.

EN-Revision bumped to 36d18e7d4a32ecfdacc1eb086276ffb1baf0393c.

Fixes: #1625
