### PR TITLE
[Sync-EN] Add POST examples to the cURL examples chapter

### DIFF
--- a/reference/curl/examples.xml
+++ b/reference/curl/examples.xml
@@ -1,17 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: shein Status: ready -->
+<!-- EN-Revision: e7c6a2f6847c3a8c9fec6ba588f235ccdcf6f3a5 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="curl.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="curl.examples-basic">
-  <title>Пример работы с модулем curl</title>
-  <para>
+  <title>Примеры работы с модулем curl</title>
+  <simpara>
    Функции модуля cURL становятся доступны для вызова сразу после сборки PHP
    с поддержкой cURL. Работа с модулем cURL начинается
    с инициализации сеанса сетевого обмена данными вызовом функции <function>curl_init</function>.
    Затем функцией <function>curl_setopt</function> устанавливают параметры сетевой передачи
    и выполняют сеанс обмена данными путём вызова функции <function>curl_exec</function>.
+  </simpara>
+  <para>
+   Простой пример, который отправляет POST-запрос функциями модуля cURL:
+   <example>
+    <title>Отправка POST-запроса функциями PHP-модуля cURL</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$data = ['foo' => 'bar', 'baz' => 48];
+$url = "http://www.example.com/handler.php";
+
+$ch = curl_init($url);
+
+// указываем cURL вернуть ответ, а не отправлять его в стандартный вывод
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+// задаём данные POST-запроса, соответствующий метод и заголовки
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+
+// отправляем запрос и получаем ответ
+$response = curl_exec($ch);
+
+if(curl_error($ch)) {
+    // обрабатываем ошибку или просто
+    throw new RuntimeException(curl_error($ch));
+}
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Ещё один пример, который отправляет POST-запрос с телом в формате JSON
+   функциями модуля cURL:
+   <example>
+    <title>Отправка POST-запроса с JSON функциями PHP-модуля cURL</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$post_data = ['foo' => 'bar', 'baz' => 48];
+$url = "http://www.example.com/api/endpoint";
+
+$ch = curl_init($url);
+
+// указываем cURL вернуть ответ, а не отправлять его в стандартный вывод
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+// задаём данные POST-запроса и соответствующий метод
+curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($post_data));
+
+// задаём требуемый заголовок
+curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+// отправляем запрос и получаем ответ
+$response = curl_exec($ch);
+
+if(curl_error($ch)) {
+    // обрабатываем ошибку или просто
+    throw new RuntimeException(curl_error($ch));
+}
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
    Следующий пример получает начальную страницу сайта example.com
    функциями модуля cURL и сохраняет результат в файл:
    <example>
@@ -32,8 +96,6 @@ if (curl_error($ch)) {
 }
 
 fclose($fp);
-
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Syncs `reference/curl/examples.xml` with php/doc-en#4612.

- Adds the two new examples: sending a form-encoded POST request and sending a raw JSON POST request, with their code comments translated.
- The chapter section is retitled to the plural form, and the intro paragraph is split so the fetch-homepage example gets its own lead-in.
- The homepage example drops its trailing `?>`, as upstream.

EN-Revision bumped to e7c6a2f6847c3a8c9fec6ba588f235ccdcf6f3a5.

Fixes: #1666
