### PR TITLE
[Sync-EN] Modernize the PDO installation documentation

### DIFF
--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78cd8f0ba32f4d9921bb8b7eca066de8de29924d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 6e58d11156926ea75109693d63306092320b63fe Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -10,13 +10,13 @@
  <procedure xml:id="pdo.install.unix51up">
   <title>Установка PDO на Unix-системах</title>
   <step>
-   <para>
+   <simpara>
     PDO и драйвер <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>
     включены по умолчанию в PHP. Чтобы
     включить PDO драйвер для произвольной базы данных, обратитесь
     к документации <link
     linkend="pdo.drivers">драйверы PDO баз данных</link>.
-   </para>
+   </simpara>
    <note>
     <para>
      Если PDO собирается, как подгружаемый модуль
@@ -48,9 +48,9 @@ extension=pdo
   <step>
    <para>
     Модуль PDO включён по умолчанию.
-    Выберите DLL конкретных баз данных и либо загружать их
-    во время выполнения функцией <function>dl</function>, либо включить их
-    в &php.ini;. Например, следующий код загружает драйвер <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>,
+    Драйверы конкретных баз данных включают в файле &php.ini; по мере
+    необходимости. Например, следующий код загружает драйвер
+    <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>,
     но оставляет закомментированным драйвер <link linkend="ref.pdo-odbc">PDO_ODBC</link>:
     <screen>
 <![CDATA[
@@ -59,10 +59,10 @@ extension=pdo_sqlite
 ]]>
     </screen>
    </para>
-   <para>
-    Эти DLL должны находиться в директории
+   <simpara>
+    Соответствующие файлы модулей должны находиться в директории
     <link linkend="ini.extension-dir">extension_dir</link>.
-   </para>
+   </simpara>
   </step>
  </procedure>
  <note>


### PR DESCRIPTION
Syncs `reference/pdo/configure.xml` with php/doc-en#5277 and php/doc-en#5712.

- The Windows step no longer tells the reader to pick DLLs and load them at runtime with `dl()`: it says the database-specific drivers are enabled in `php.ini` as needed. `dl()` has been unavailable in most SAPIs for a long time.
- "These DLLs should exist in extension_dir" becomes "the corresponding extension files", which is accurate on every platform.
- The Unix step's paragraph becomes a `simpara`, as upstream.

EN-Revision bumped to 6e58d11156926ea75109693d63306092320b63fe, which covers both upstream commits.

Fixes: #1720
