### PR TITLE
[Sync-EN] Document that SimpleXML get methods no longer implicitly rewind

### DIFF
--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mch Status: ready -->
+<!-- EN-Revision: 418ec505128707215c5c99ad4a66a88bfd84a0ff Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.simplexmlelement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Класс SimpleXMLElement</title>
@@ -39,12 +39,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 <!-- }}} -->
 
@@ -61,6 +57,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Методы получения данных, например
+        <methodname>SimpleXMLElement::asXML</methodname> или
+        <methodname>SimpleXMLElement::getName</methodname>, и приведение
+        объекта класса <classname>SimpleXMLElement</classname> к строке
+        (&string;) больше не перематывают итератор неявно.
+        Теперь итератор при необходимости перематывают явно — методом
+        <methodname>SimpleXMLElement::rewind</methodname>.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/simplexml/simplexmlelement/rewind.xml
+++ b/reference/simplexml/simplexmlelement/rewind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dcb657b7e9e4f7622ce3394ae1fa3c14538721e1 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 418ec505128707215c5c99ad4a66a88bfd84a0ff Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="simplexmlelement.rewind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,6 +23,17 @@
   <para>
    Метод перематывает <classname>SimpleXMLElement</classname> к первому элементу.
   </para>
+
+  <note>
+   <simpara>
+    Начиная с PHP 8.4.0 вызов методов получения данных, например
+    <methodname>SimpleXMLElement::asXML</methodname> или
+    <methodname>SimpleXMLElement::getName</methodname>, и приведение
+    объекта класса <classname>SimpleXMLElement</classname> к строке
+    (&string;) больше не перематывают итератор неявно. При необходимости
+    итератор перематывают явно вызовом этого метода.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Syncs `reference/simplexml/simplexmlelement.xml` and `reference/simplexml/simplexmlelement/rewind.xml` with php/doc-en#5737 and php/doc-en#5699.

php/doc-en#5737:
- The class changelog gains the 8.4.0 row: get methods such as `SimpleXMLElement::asXML()` or `SimpleXMLElement::getName()`, and casting a `SimpleXMLElement` to a string, no longer rewind the iterator implicitly; it has to be rewound explicitly with `SimpleXMLElement::rewind()`.
- `SimpleXMLElement::rewind()` gains the matching note.

php/doc-en#5699: mirrors the removal of the two empty `xi:fallback` elements in the class synopsis.

EN-Revision bumped to 418ec505128707215c5c99ad4a66a88bfd84a0ff on both files.

Fixes: #1604
