### PR TITLE
[Sync-EN] Document the padding constants for openssl_sign() and openssl_verify()

### DIFF
--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-sign" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
    <type>bool</type><methodname>openssl_sign</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
    <methodparam><type>string</type><parameter role="reference">signature</parameter></methodparam>
-   <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>int</type></type><parameter>algorithm</parameter><initializer><constant>OPENSSL_ALGO_SHA1</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -73,7 +73,13 @@
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <simpara>Схема дополнения PSS (англ. Probabilistic Signature Scheme — вероятностная схема подписи) алгоритма RSA.</simpara>
+      <simpara>
+       Схема дополнения RSA-PSS (англ. Probabilistic Signature Scheme —
+       вероятностная схема подписи), которую требуется применить. Значением
+       выступает либо константа <constant>OPENSSL_PKCS1_PADDING</constant>,
+       либо константа <constant>OPENSSL_PKCS1_PSS_PADDING</constant>,
+       либо <literal>0</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -74,7 +74,13 @@
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <simpara>Схема дополнения PSS (англ. Probabilistic Signature Scheme — вероятностная схема подписи) алгоритма RSA.</simpara>
+      <simpara>
+       Схема дополнения RSA-PSS (англ. Probabilistic Signature Scheme —
+       вероятностная схема подписи), которую требуется применить. Значением
+       выступает либо константа <constant>OPENSSL_PKCS1_PADDING</constant>,
+       либо константа <constant>OPENSSL_PKCS1_PSS_PADDING</constant>,
+       либо <literal>0</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs `reference/openssl/functions/openssl-sign.xml` and `reference/openssl/functions/openssl-verify.xml` with php/doc-en#5758.

The `padding` parameter said only "RSA PSS padding to use". It now names the accepted values: `OPENSSL_PKCS1_PADDING`, `OPENSSL_PKCS1_PSS_PADDING` or `0`.

While aligning the structure, one more gap turned up: the `private_key` parameter of `openssl_sign()` was missing the `#[\SensitiveParameter]` attribute that the English synopsis carries. It is added here.

EN-Revision bumped to ddcd63907372580151daf69458d6a8268232b703 on both files.

Fixes: #1613