### PR TITLE
[Sync-EN] Clarify the PECL deprecation in favour of PIE

### DIFF
--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1fa3096926b6cbaf9da1f831b6fe3302ae2e490 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка PECL-модулей</title>
+ &pecl.moving.to.pie;
 
  <sect1 xml:id="install.pecl.intro">
   <title>Введение в установку модулей из репозитория PECL</title>
@@ -111,6 +112,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
 
  <sect1 xml:id="install.pecl.windows">
   <title>Установка PHP-модуля в Windows</title>
+  &pecl.moving.to.pie;
   <para>
    В ОС Windows PHP-модули подключают двумя способами: либо компилируют PHP
    с модулем, либо загружают модуль как DLL-файл. Загрузка заранее
@@ -313,6 +315,7 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 
  <sect1 xml:id="install.pecl.pear">
   <title>Компиляция разделяемых модулей командой pecl</title>
+  &pecl.moving.to.pie;
   <simpara>
    PECL упрощает создание общедоступных модулей PHP. Выполните следующую
    <link xlink:href="&url.php.pear.cli;">команду pecl</link>:
@@ -357,6 +360,7 @@ $ pecl install extname-0.1
 
  <sect1 xml:id="install.pecl.phpize">
   <title>Компиляция разделяемых модулей командой phpize</title>
+  &pecl.moving.to.pie;
   <simpara>
    Иногда компиляция модулей через установщик <literal>pecl</literal> невозможна.
    Это связано с брандмауэром или с недоступностью устанавливаемого модуля
@@ -403,7 +407,7 @@ $ make
   <title>
    php-config
   </title>
-
+  &pecl.moving.to.pie;
   <para>
    <command>php-config</command> — простой скрипт командной строки для получения информации о конфигурации
    PHP-дистрибутива, который установили в систему.
@@ -509,6 +513,7 @@ Options:
 
  <sect1 xml:id="install.pecl.static">
   <title>Компиляция модулей PECL статически в PHP</title>
+  &pecl.moving.to.pie;
   <simpara>
    Возможно, потребуется собрать модуль PECL статично в бинарный файл PHP.
    Для этого исходный код модуля размещают в каталоге

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2393,13 +2393,13 @@ INI_* даёт раздел «<xref xmlns="http://docbook.org/ns/docbook" linken
 
 <!ENTITY pecl.moved-ver 'Модуль переместили в репозиторий &link.pecl; и он больше не поставляется с PHP '>
 
-<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  Установщик PHP-модулей (англ. PHP Installer for Extensions, <acronym>PIE</acronym>) — новый инструмент, который заменит репозиторий PECL после устаревания.
-  Рекомендуем устанавливать модули через PIE.
+  Репозиторий PECL объявлен устаревшим.
+  Установщик PHP-модулей (англ. PHP Installer for Extensions, <acronym>PIE</acronym>) заменяет PECL, и модули рекомендуют устанавливать через него.
   Дополнительная информация доступна на странице <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php/pie">https://github.com/php/pie</link>.
  </simpara>
-</note>'>
+</warning>'>
 
 <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>Модуль больше <emphasis>не поддерживается</emphasis>.</simpara>


### PR DESCRIPTION
Syncs `install/pecl.xml` and `language-snippets.ent` with php/doc-en#5622.

- The `pecl.moving.to.pie` entity becomes a `warning` instead of a `note`, and its wording changes from "PIE is a new tool that will deprecate PECL" to "PECL is deprecated; PIE replaces it and is recommended to install extensions".
- The notice now appears on the chapter itself and on the Windows, `pecl` command, `phpize`, `php-config` and static compilation sections, not only on the introduction and downloads sections.

The EN-Revision of `language-snippets.ent` is left untouched: that file is still behind on other doc-en commits, each tracked by its own issue.

Fixes: #1619
