### PR TITLE
[Sync-EN] Clarify the Argon2 memory_cost and time_cost units

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66aff414be91c5a0446be585aa6ac78121de1e67 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="password.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -57,10 +57,14 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-     </para>
-     <para>
-     </para>
+     <simpara>
+      Алгоритмическая стоимость по умолчанию, которую функция
+      <function>password_hash</function> применяет при хешировании паролей
+      алгоритмом <constant>PASSWORD_BCRYPT</constant>.
+     </simpara>
+     <simpara>
+      Константа доступна с PHP 7.0.0.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2i">
@@ -85,11 +89,11 @@
        </para>
       </listitem>
       <listitem>
-       <para>
-        <literal>time_cost</literal> (<type>int</type>) — максимальное время,
-        которое функции разрешается потратить на вычисление хеша Argon2.
+       <simpara>
+        <literal>time_cost</literal> (<type>int</type>) — количество итераций
+        (проходов), которые выполняются для вычисления хеша Argon2.
         Значение по умолчанию равняется <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-       </para>
+       </simpara>
       </listitem>
       <listitem>
        <para>
@@ -127,13 +131,13 @@
      (тип <type>int</type>)
     </term>
     <listitem>
-     <para>
-      Объем памяти по умолчанию в байтах, который функция использует при попытке
-      вычислить хеш.
-     </para>
-     <para>
+     <simpara>
+      Объём памяти по умолчанию в кибибайтах (КиБ), который применяется
+      для вычисления хеша.
+     </simpara>
+     <simpara>
       Константа доступна с PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-time-cost">
@@ -142,12 +146,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Ограничение времени по умолчанию на вычисление хеша.
-     </para>
-     <para>
+     <simpara>
+      Количество итераций (проходов) по умолчанию, которые выполняются
+      для вычисления хеша.
+     </simpara>
+     <simpara>
       Константа доступна с PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-threads">

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5003a6ea92eb50ac92121782eedfc5ad3fe9d061 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.password-hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -104,11 +104,11 @@
      </para>
     </listitem>
     <listitem>
-     <para>
-      <literal>time_cost</literal> (<type>int</type>) — предельное количество раундов,
-      которые выполняет алгоритм Argon2 для вычисления хеша.
+     <simpara>
+      <literal>time_cost</literal> (<type>int</type>) — количество итераций
+      (проходов), которые выполняются для вычисления хеша Argon2.
       Значение по умолчанию: <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-     </para>
+     </simpara>
     </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
Syncs `reference/password/constants.xml` and `reference/password/functions/password-hash.xml` with php/doc-en#5219.

- `PASSWORD_ARGON2_DEFAULT_MEMORY_COST` is documented in kibibytes, not bytes.
- `time_cost` and `PASSWORD_ARGON2_DEFAULT_TIME_COST` are a number of iterations (passes), not a time limit. Both pages said "maximum amount of time", which described neither the unit nor the behaviour.
- `PASSWORD_BCRYPT_DEFAULT_COST` had two empty paragraphs; it is now described as the default algorithmic cost used by `password_hash()` with `PASSWORD_BCRYPT`, available as of PHP 7.0.0.

EN-Revision bumped to 6cc48aed6f887bdabf09c568f854099f9c74e017 on both files.

Fixes: #1620
