### PR TITLE
[Sync-EN] Document boolean support for allowed_classes in unserialize()

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Изменения, которые ломают обратную совместимость</title>
@@ -403,9 +403,10 @@
    <simpara>
     Опция <literal>"allowed_classes"</literal> функции
     <function>unserialize</function> теперь выбрасывает
-    исключения <exceptionname>TypeError</exceptionname>
-    и <exceptionname>ValueError</exceptionname>, если в аргументе передали
-    не массив (<type>array</type>) имён классов.
+    ошибку <exceptionname>TypeError</exceptionname>
+    или <exceptionname>ValueError</exceptionname>, если в аргументе передали
+    не массив (<type>array</type>) имён классов и не логическое
+    значение (<type>bool</type>).
    </simpara>
   </sect3>
 
@@ -505,19 +506,20 @@
   <title>Модуль MBString</title>
 
   <simpara>
-   В недопустимых строках с ошибками кодировки функция
-   <function>mb_substr</function> теперь интерпретирует индексы символов
-   аналогично большей части других функций для работы с многобайтовыми строками.
+   Начиная с PHP 8.3.2 в недопустимых строках с ошибками кодировки функции
+   <function>mb_substr</function> и <function>mb_strstr</function> интерпретируют
+   индексы символов аналогично большей части других функций для работы
+   с многобайтовыми строками.
    Поэтому символьные индексы, которые возвращает функция <function>mb_strpos</function>,
    разрешили передавать в функцию <function>mb_substr</function>.
   </simpara>
 
   <simpara>
-   Для строк в кодировке SJIS-Mac, или её псевдониме MacJapanese, индексы символов,
-   которые передают в функцию <function>mb_substr</function>, теперь ссылаются на индексы
-   кодовых точек кодировки Unicode, которые получаются при преобразовании строки в Unicode.
-   Это важно, поскольку около 40 символов кодировки SJIS-Mac преобразовываются
-   в последовательность из нескольких кодовых точек Unicode.
+   Для строк в кодировке <literal>SJIS-mac</literal>, или её псевдониме MacJapanese,
+   эти индексы символов ссылаются на индексы кодовых точек кодировки Unicode,
+   которые получаются при преобразовании строки в Unicode, а они отличаются
+   от индексов символов кодировки <literal>SJIS-mac</literal>, которые
+   преобразовываются в последовательность из нескольких кодовых точек.
   </simpara>
  </sect2>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: shein Status: ready -->
+<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -153,9 +153,10 @@
   </simpara>
   <simpara>
    Начиная с PHP 8.4.0 функция <function>unserialize</function>
-   выбрасывает ошибки <exceptionname>TypeError</exceptionname> и <exceptionname>ValueError</exceptionname>,
+   выбрасывает ошибку <exceptionname>TypeError</exceptionname> или <exceptionname>ValueError</exceptionname>,
    если в элементе <literal>allowed_classes</literal> параметра <parameter>options</parameter>
-   передали не массив (<type>array</type>) с названиями классов.
+   передали не массив (<type>array</type>) с названиями классов и не логическое
+   значение (<type>bool</type>).
   </simpara>
  </refsect1>
 
@@ -174,9 +175,10 @@
       <row>
        <entry>8.4.0</entry>
        <entry>
-        Теперь выбрасывает исключения <exceptionname>TypeError</exceptionname> и
+        Теперь выбрасывает ошибку <exceptionname>TypeError</exceptionname> или
         <exceptionname>ValueError</exceptionname>, если элемент <literal>allowed_classes</literal>
-        параметра <parameter>options</parameter> не является массивом имён классов.
+        параметра <parameter>options</parameter> не является ни массивом имён классов,
+        ни логическим значением (<type>bool</type>).
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Syncs `appendices/migration84/incompatible.xml` and `reference/var/functions/unserialize.xml` with php/doc-en#4768 and php/doc-en#5797.

php/doc-en#4768: the 8.4.0 `allowed_classes` rule is stated correctly on both pages. It throws when the value is neither an array of class names **nor a bool**; the previous wording implied a bool was rejected too, while `true` and `false` are the documented ways to allow all or no classes.

php/doc-en#5797, on the migration page's MBString section:
- The character index change is dated: it shipped in PHP 8.3.2, and it covers `mb_strstr()` as well as `mb_substr()`.
- The `SJIS-mac` paragraph is rewritten to say those indices differ from the `SJIS-mac` character indices for characters converting to several codepoints, instead of the vaguer "about 40 characters" remark.

EN-Revision bumped per file to the last upstream commit touching it.

Fixes: #1639
