### PR TITLE
[Sync-EN] Add the Alpine Linux and Arch Linux installation pages

### DIFF
--- a/install/unix/alpine.xml
+++ b/install/unix/alpine.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5a5899391ef91a4d42bca9495c8a1d323d38f23a Maintainer: shein Status: ready -->
+<!-- Reviewed: no -->
+<sect1 xml:id="install.unix.alpine" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Установка из пакетов в ОС Alpine Linux</title>
+ <simpara>
+  Хотя PHP доступен для установки из исходного кода, язык также доступен
+  для установки из пакетов в ОС Alpine Linux и производных дистрибутивах,
+  которые работают с пакетным менеджером <command>apk</command>.
+ </simpara>
+ &warn.install.third-party-support;
+ <simpara>
+  Пакеты устанавливают пакетным менеджером <command>apk</command>.
+ </simpara>
+ <sect2 xml:id="install.unix.alpine.packages">
+  <title>Установка пакетов</title>
+  <simpara>
+   Названия PHP-пакетов в ОС Alpine Linux содержат номер мажорной версии,
+   например <literal>php83</literal> для PHP 8.3. В примерах ниже
+   <literal>83</literal> заменяют номером версии PHP, которая доступна
+   в конкретном выпуске Alpine Linux.
+  </simpara>
+  <simpara>
+   Перед установкой пакета проверяют актуальность индекса пакетов
+   командой <command>apk update</command>.
+  </simpara>
+  <example xml:id="install.unix.alpine.example">
+   <title>Пример установки в ОС Alpine</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   ОС Alpine не настраивает PHP для веб-сервера автоматически.
+   Для конфигураций с FastCGI устанавливают пакет <literal>php83-fpm</literal>
+   и включают OpenRC-службу <literal>php-fpm83</literal>; обратите внимание,
+   что название пакета и название службы располагают суффикс версии
+   в разном порядке. Например:
+  </simpara>
+  <example xml:id="install.unix.alpine.example2">
+   <title>Включение и запуск PHP-FPM</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83-fpm
+# rc-update add php-fpm83 default
+# rc-service php-fpm83 start
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+ <sect2 xml:id="install.unix.alpine.config">
+  <title>Точная настройка конфигурации</title>
+  <para>
+   Базовый пакет устанавливает только модули ядра. Дополнительные модули,
+   например
+   <simplelist type="inline">
+    <member><link linkend="book.mysql">MySQL</link></member>
+    <member><link linkend="book.curl">cURL</link></member>
+    <member><link linkend="book.image">GD</link></member>
+    <member>и другие</member>
+   </simplelist>
+   устанавливают отдельными пакетами.
+  </para>
+  <example xml:id="install.unix.alpine.config.example">
+   <title>Поиск доступных PHP-пакетов</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk search php83
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Список пакетов включает CLI, FPM и множество модулей.
+   При установке модулей их зависимости разрешаются автоматически.
+  </simpara>
+  <example xml:id="install.unix.alpine.config.example2">
+   <title>Установка PHP с модулями MySQL и GD</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83-mysqli php83-gd
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Модули включаются автоматически при установке, править файл &php.ini;
+   вручную не требуется. Файлы конфигурации размещаются в каталоге
+   <filename>/etc/php83/conf.d/</filename>. После установки новых модулей
+   потребуется перезапустить PHP-FPM или веб-сервер, чтобы изменения
+   вступили в силу.
+  </simpara>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: shein Status: ready -->
+<!-- EN-Revision: 5a5899391ef91a4d42bca9495c8a1d323d38f23a Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
  <title>Установка в Unix-системы</title>
@@ -28,6 +28,8 @@
  <!-- distribution specific nodes -->
  &install.unix.debian;
  &install.unix.dnf;
+ &install.unix.alpine;
+ &install.unix.pacman;
  &install.unix.openbsd;
  <!-- general from-source instructions -->
  &install.unix.source;

--- a/install/unix/pacman.xml
+++ b/install/unix/pacman.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f0f5d8646b835280b44b1d95277e3881be931cd9 Maintainer: shein Status: ready -->
+<!-- Reviewed: no -->
+<sect1 xml:id="install.unix.pacman" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Установка из пакетов в ОС Arch Linux</title>
+ <simpara>
+  Хотя PHP доступен для установки из исходного кода, язык также доступен
+  для установки из пакетов в ОС Arch Linux и производных дистрибутивах,
+  которые работают с пакетным менеджером pacman.
+ </simpara>
+ &warn.install.third-party-support;
+ <simpara>
+  Пакеты устанавливают командой <command>pacman</command>.
+ </simpara>
+ <sect2 xml:id="install.unix.pacman.packages">
+  <title>Установка пакетов</title>
+  <simpara>
+   Во-первых, обратите внимание, что иногда требуются и другие связанные пакеты:
+   <literal>php-apache</literal> для веб-сервера
+   <link linkend="install.unix.apache2">Apache</link>
+   или <literal>php-fpm</literal> для конфигураций с FastCGI.
+  </simpara>
+  <simpara>
+   Перед установкой пакета рекомендуют убедиться, что система обновлена.
+   Обычно это делают командой <command>pacman -Syu</command>.
+  </simpara>
+  <example xml:id="install.unix.pacman.example">
+   <title>Пример установки командой pacman вместе с веб-сервером Apache</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -S php php-apache
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Пакетный менеджер pacman автоматически установит зависимости PHP.
+   Потребуется перезапустить веб-сервер, чтобы изменения вступили в силу.
+   Например:
+  </simpara>
+  <example xml:id="install.unix.pacman.example2">
+   <title>Перезапуск веб-сервера Apache после установки PHP</title>
+   <programlisting role="shell">
+<![CDATA[
+# systemctl restart httpd
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+ <sect2 xml:id="install.unix.pacman.config">
+  <title>Точная настройка конфигурации</title>
+  <para>
+   В предыдущем разделе PHP установили только с модулями ядра. Скорее всего,
+   потребуются и дополнительные модули, например
+   <simplelist type="inline">
+    <member><link linkend="book.mysql">MySQL</link></member>
+    <member><link linkend="book.curl">cURL</link></member>
+    <member><link linkend="book.image">GD</link></member>
+    <member>и другие</member>
+   </simplelist>
+   Их тоже устанавливают командой <command>pacman</command>.
+  </para>
+  <example xml:id="install.unix.pacman.config.example">
+   <title>Способы вывести список дополнительных PHP-пакетов</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -Ss php
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Список пакетов включает пакеты с PHP-модулями, например
+   <literal>php-gd</literal>, <literal>php-intl</literal>,
+   <literal>php-sqlite</literal> и другие.
+   При установке модулей дополнительные пакеты устанавливаются автоматически
+   по мере необходимости, чтобы удовлетворить зависимости этих пакетов.
+  </simpara>
+  <example xml:id="install.unix.pacman.config.example2">
+   <title>Установка PHP с модулем GD</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -S php-gd
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   После установки пакета с модулем требуется раскомментировать соответствующую
+   строку в файле <filename>/etc/php/php.ini</filename>, чтобы включить модуль.
+   Например, после установки пакета <literal>php-gd</literal> раскомментируют
+   строку <literal>extension=gd</literal> в файле
+   <filename>/etc/php/php.ini</filename>. Изменения вступят в силу после
+   перезапуска веб-сервера, того же Apache.
+  </simpara>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Syncs `install/unix/` with php/doc-en#5266 and php/doc-en#5259. Both upstream commits land on `install/unix/index.xml`, so they are ported together.

- Adds `install/unix/alpine.xml`, translating the new Alpine Linux page: `apk` package names carrying the major version, `apk update` before installing, the FPM package and OpenRC service naming difference, searching for packages, and the fact that extensions enable themselves with their config files under `/etc/php83/conf.d/`.
- Adds `install/unix/pacman.xml`, translating the new Arch Linux page: `php-apache` and `php-fpm` companions, `pacman -Syu` first, listing extension packages, and the need to uncomment the `extension=` line in `/etc/php/php.ini` after installing one.
- Both pages are included from `install/unix/index.xml`, between the dnf and OpenBSD entries, in the upstream order.

EN-Revision set per file to the commit that introduced it, and bumped to 5a5899391ef91a4d42bca9495c8a1d323d38f23a on the index.

Fixes: #1717
Fixes: #1718
