### PR TITLE
[Sync-EN] Fix the Uri\WhatWg\Url screens that ignore URL normalization

### DIFF
--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a00f03a6131b0b74c851b06879c528fc9537da8c Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: malferov Status: ready -->
 <refentry xml:id="uri-whatwg-url.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::getPort</refname>
@@ -37,15 +37,19 @@
 <![CDATA[
 <?php
 
-$url = new \Uri\WhatWg\Url("https://example.com:443");
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+var_dump($url->getPort());
 
-echo $url->getPort();
+// 443 — стандартный порт для схемы https, поэтому он не сохраняется.
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+var_dump($url->getPort());
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+int(8080)
+NULL
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: malferov Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -82,7 +82,7 @@ if ($url !== null) {
    &example.outputs;
    <screen>
 <![CDATA[
-Допустимый URL-адрес: https://example.com
+Допустимый URL-адрес: https://example.com/
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: malferov Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: malferov Status: ready -->
 <refentry xml:id="uri-whatwg-url.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::withPort</refname>
@@ -52,15 +52,20 @@
 <?php
 
 $url = new \Uri\WhatWg\Url("https://example.com:8080");
-$url = $url->withPort(443);
 
-echo $url->getPort();
+// 443 — стандартный порт для схемы https, поэтому он не сохраняется.
+$url = $url->withPort(443);
+var_dump($url->getPort());
+
+$url = $url->withPort(8443);
+var_dump($url->getPort());
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+NULL
+int(8443)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Syncs the three `reference/uri/uri/whatwg/url/` pages with php/doc-en#5721.

The example outputs did not match what the code actually prints, because they ignored WHATWG URL normalization:

- `getPort()`: the example used `https://example.com:443` and claimed it prints `443`. 443 is the default port for https, so it is not stored and `getPort()` returns `null`. The example now shows both cases, with `var_dump()`.
- `withPort()`: same problem; `withPort(443)` on an https URL yields `null`, and a second call with 8443 shows a non-default port being kept.
- `parse()`: `toAsciiString()` on `https://example.com` prints `https://example.com/`, with the normalized trailing slash.

EN-Revision bumped to 0e06411471a898974e114bd57f624781fe3a0b89 on the three files.

Fixes: #1610
