### PR TITLE
[Sync-EN] Document the odbc fetch row default value change to null

### DIFF
--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.odbc-fetch-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,9 +34,13 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Необязательный параметр, который указывает номер строки для возврата.
-      </para>
+      <simpara>
+       Номер строки, которую требуется получить; отсчёт начинается с единицы.
+       Если параметр опустили или передали значение &null;, функция получает
+       следующую строку результирующего набора — так же, как это делает функция
+       <function>odbc_fetch_row</function>. Если драйвер не поддерживает выборку
+       строк по номеру, параметр игнорируется.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -66,7 +70,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Параметр <parameter>row</parameter> теперь принимает значение &null;.
+       Параметр <parameter>row</parameter> теперь принимает значение &null;,
+       а его значение по умолчанию изменилось с <literal>-1</literal> на &null;,
+       что согласуется с функцией <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.odbc-fetch-into" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -46,9 +46,13 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Номер строки.
-      </para>
+      <simpara>
+       Номер строки, которую требуется получить; отсчёт начинается с единицы.
+       Если параметр опустили или передали значение &null;, функция получает
+       следующую строку результирующего набора — так же, как это делает функция
+       <function>odbc_fetch_row</function>. Если драйвер не поддерживает выборку
+       строк по номеру, параметр игнорируется.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -78,7 +82,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Параметр <parameter>row</parameter> теперь принимает значение &null;.
+       Параметр <parameter>row</parameter> теперь принимает значение &null;,
+       а его значение по умолчанию изменилось с <literal>0</literal> на &null;,
+       что согласуется с функцией <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.odbc-fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,9 +34,13 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Необязательный параметр, который указывает номер строки для возврата.
-      </para>
+      <simpara>
+       Номер строки, которую требуется получить; отсчёт начинается с единицы.
+       Если параметр опустили или передали значение &null;, функция получает
+       следующую строку результирующего набора — так же, как это делает функция
+       <function>odbc_fetch_row</function>. Если драйвер не поддерживает выборку
+       строк по номеру, параметр игнорируется.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -66,7 +70,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Параметр <parameter>row</parameter> теперь принимает значение &null;.
+       Параметр <parameter>row</parameter> теперь принимает значение &null;,
+       а его значение по умолчанию изменилось с <literal>-1</literal> на &null;,
+       что согласуется с функцией <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Syncs the three `reference/uodbc/functions/odbc-fetch-*` pages with php/doc-en#5768.

- The `row` parameter is described properly on all three pages: it is a 1-based row number, omitting it or passing `null` fetches the next row as `odbc_fetch_row()` does, and drivers that cannot fetch by number ignore it. Previously it said only "the row number" or "optionally choose which row number to retrieve".
- The 8.4.0 changelog rows now also state the default value change, from `-1` (`odbc_fetch_array()`, `odbc_fetch_object()`) or `0` (`odbc_fetch_into()`) to `null`, consistent with `odbc_fetch_row()`.

EN-Revision bumped to 5035039fb951eac2330431bf47dc4a50e1ef9ee9 on the three files.

Fixes: #1632
