### PR TITLE
[Sync-EN] Clarify ldap_connect(), ldap_bind() and ldap_set_option() behavior

### DIFF
--- a/reference/ldap/functions/ldap-bind.xml
+++ b/reference/ldap/functions/ldap-bind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5bc68add3da3cd18c40f851e944b15095d3a26aa Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-bind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,18 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>dn</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция связывает LDAP-каталог с указанным RDN-именем и паролем.
-  </para>
+  </simpara>
+  <note>
+   <simpara>
+    Эта функция устанавливает фактическое сетевое соединение с LDAP-сервером,
+    поскольку функция <function>ldap_connect</function> только инициализирует
+    параметры соединения. Каждую опцию, которая влияет на соединение, например
+    <constant>LDAP_OPT_PROTOCOL_VERSION</constant> или опции, связанные с TLS,
+    требуется установить до вызова этой функции.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,15 +23,27 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>389</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Создаёт объект <classname>LDAP\Connection</classname> и проверяет правдоподобность
-   заданного в параметре <parameter>uri</parameter> значения.
-  </para>
+  <simpara>
+   Создаёт объект класса <classname>LDAP\Connection</classname> и проверяет
+   правдоподобность заданного в параметре <parameter>uri</parameter> значения.
+  </simpara>
   <note>
    <simpara>
-    Эта функция <emphasis>не</emphasis> открывает соединение.
-    Она проверяет, правдоподобны ли заданные параметры и можно
-    ли, указав их, установить соединение, когда оно необходимо.
+    Эта функция <emphasis>не</emphasis> открывает сетевое соединение.
+    Она только проверяет синтаксис URI и инициализирует параметры соединения.
+    Фактическое TCP-соединение устанавливается при вызове функции
+    <function>ldap_bind</function>.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Опции, которые влияют на установку соединения, например
+    <constant>LDAP_OPT_PROTOCOL_VERSION</constant> и опции, связанные с TLS
+    (<literal>LDAP_OPT_X_TLS_*</literal>), требуется установить функцией
+    <function>ldap_set_option</function> после вызова этой функции и до вызова
+    функции <function>ldap_bind</function>. Опции, связанные с TLS,
+    устанавливают глобально — первым аргументом функции
+    <function>ldap_set_option</function> передают значение &null;.
    </simpara>
   </note>
  </refsect1>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: mch Status: ready -->
+<!-- EN-Revision: 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-set-option" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +15,18 @@
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>string</type><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция устанавливает для опции значение <parameter>value</parameter>.
-  </para>
+  </simpara>
+  <note>
+   <simpara>
+    Опции, связанные с TLS (<literal>LDAP_OPT_X_TLS_*</literal>), устанавливают
+    глобально — в параметре <parameter>ldap</parameter> передают значение &null;,
+    поскольку контекст TLS инициализируется до того, как становится доступно
+    состояние конкретного соединения. Эти опции требуется установить также
+    до вызова функции <function>ldap_bind</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Syncs the three `reference/ldap/functions/` pages with php/doc-en#5275.

- `ldap_connect()`: says explicitly that it opens no network connection, only validating the URI and initializing connection parameters, the TCP connection being established by `ldap_bind()`. A second note states that connection-setup options, `LDAP_OPT_PROTOCOL_VERSION` and the `LDAP_OPT_X_TLS_*` family, must be set between `ldap_connect()` and `ldap_bind()`, the TLS ones globally.
- `ldap_bind()`: gains the matching note, that it is the call establishing the connection, so connection-affecting options must be set beforehand.
- `ldap_set_option()`: gains the note that `LDAP_OPT_X_TLS_*` options must be set globally by passing `null` as `ldap`, because the TLS context is initialized before the per-connection state exists, and before `ldap_bind()`.

EN-Revision bumped to 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 on the three files.

Fixes: #1651
