### PR TITLE
[Sync-EN] Fix the OPENSSL_RAW_DATA description for encrypt and decrypt

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6eadfc4332ac3ba482aef3ebf3eab10e02e007ca Maintainer: aur Status: ready -->
+<!-- EN-Revision: 7179e95e592583beae2f99ca71e6b326f559812b Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -865,10 +865,10 @@
     </term>
     <listitem>
      <simpara>
-      Если константа <constant>OPENSSL_RAW_DATA</constant> передана
-      в функции <function>openssl_encrypt</function> или <function>openssl_decrypt</function>,
-      данные возвращаются как есть.
-      Если константа не указана, вызывающей стороне возвращаются данные в кодировке Base64.
+      Константу применяют с функциями <function>openssl_encrypt</function>
+      и <function>openssl_decrypt</function>, чтобы указать, что данные должны
+      быть в сыром двоичном виде, а не в кодировке Base64.
+      Подробности приводят описания соответствующих функций.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5ab2937efd9b1d7184993e0fdfa957893f7f827 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 7179e95e592583beae2f99ca71e6b326f559812b Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -67,12 +67,19 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       <parameter>options</parameter> можно задать одной из констант:
+      <simpara>
+       Параметр <parameter>options</parameter> — побитовая дизъюнкция флагов
        <constant>OPENSSL_RAW_DATA</constant>,
        <constant>OPENSSL_ZERO_PADDING</constant>
-       или <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
-      </para>
+       и <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+      </simpara>
+      <simpara>
+       Когда установили флаг <constant>OPENSSL_RAW_DATA</constant>, функция
+       ожидает, что в параметре <parameter>data</parameter> передали сырой
+       двоичный шифротекст. Когда флаг не установили, функция ожидает,
+       что данные в параметре <parameter>data</parameter> закодированы
+       в Base64.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7a016103e0d568448f5985dfd945092d69d5d59c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 7179e95e592583beae2f99ca71e6b326f559812b Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,12 +68,17 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       <parameter>options</parameter> можно задать одной из констант:
+      <simpara>
+       Параметр <parameter>options</parameter> — побитовая дизъюнкция флагов
        <constant>OPENSSL_RAW_DATA</constant>,
        <constant>OPENSSL_ZERO_PADDING</constant>
-       или <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
-      </para>
+       и <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+      </simpara>
+      <simpara>
+       Когда установили флаг <constant>OPENSSL_RAW_DATA</constant>,
+       зашифрованный результат возвращается как сырые двоичные данные.
+       Когда флаг не установили, возвращаемое значение закодировано в Base64.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Syncs `reference/openssl/constants.xml`, `reference/openssl/functions/openssl-decrypt.xml` and `reference/openssl/functions/openssl-encrypt.xml` with php/doc-en#5268.

- The `OPENSSL_RAW_DATA` constant said the data "is returned as-is" and that base64 is "returned to the caller", which only describes `openssl_encrypt()`. For `openssl_decrypt()` the flag describes the *input* format. The constant now states the general meaning and points at the function pages.
- Both `options` descriptions say the parameter is a bitwise disjunction of the three flags, instead of "one of the constants", and each spells out its own direction: `openssl_decrypt()` expects raw binary ciphertext in `data` when the flag is set and base64 otherwise, while `openssl_encrypt()` returns raw binary output when set and base64 otherwise.

EN-Revision bumped to 7179e95e592583beae2f99ca71e6b326f559812b on the three files.

Fixes: #1653
