### PR TITLE
[Sync-EN] Document the procedural style of IntlGregorianCalendar methods

### DIFF
--- a/reference/intl/intlgregoriancalendar/getgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/getgregorianchange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intlgregoriancalendar.getgregorianchange" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,21 +9,34 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>float</type><methodname>IntlGregorianCalendar::getGregorianChange</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>float</type><methodname>intlgregcal_get_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Метод получает дату перехода на григорианский календарь. Это момент,
+   когда календарь переключается с юлианских дат на григорианские; дата
+   выражается меткой времени Unix в миллисекундах. По умолчанию это полночь
+   по UTC 15 октября 1582 года.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &no.function.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>Объект класса <classname>IntlGregorianCalendar</classname>.</simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/intl/intlgregoriancalendar/isleapyear.xml
+++ b/reference/intl/intlgregoriancalendar/isleapyear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intlgregoriancalendar.isleapyear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,27 +9,36 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::isLeapYear</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlgregcal_is_leap_year</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Метод определяет, является ли год <parameter>year</parameter> високосным
+   в григорианском календаре.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>Объект класса <classname>IntlGregorianCalendar</classname>.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>year</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>Год, который требуется проверить.</simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="intlgregoriancalendar.setgregorianchange" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,27 +9,40 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::setGregorianChange</methodname>
    <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlgregcal_set_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Метод устанавливает дату перехода на григорианский календарь. Это момент,
+   когда календарь переключается с юлианских дат на григорианские; дата
+   выражается меткой времени Unix в миллисекундах.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>Объект класса <classname>IntlGregorianCalendar</classname>.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>timestamp</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Дата перехода на григорианский календарь, которую выражают меткой
+      времени Unix в миллисекундах.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Syncs the three `reference/intl/intlgregoriancalendar/` pages with php/doc-en#5619.

The three pages carried an empty description with `&warn.undocumented.func;`. They now document both styles and the behaviour:

- `getGregorianChange()` / `intlgregcal_get_gregorian_change()`: the Gregorian change date, the point at which the calendar switches from Julian to Gregorian dates, as a Unix timestamp in milliseconds, defaulting to midnight UTC on 15 October 1582.
- `isLeapYear()` / `intlgregcal_is_leap_year()`: whether the given year is a leap year in the Gregorian calendar, with the `year` parameter finally described.
- `setGregorianChange()` / `intlgregcal_set_gregorian_change()`: sets that date, with `timestamp` described.

Each page gains the `&style.oop;` and `&style.procedural;` markers and the `calendar` parameter of the procedural form.

EN-Revision bumped to a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 on the three files.

Fixes: #1656
