### PR TITLE
[Sync-EN] Document named arguments support in the Reflection ...Args methods

### DIFF
--- a/reference/reflection/reflectionclass/newinstanceargs.xml
+++ b/reference/reflection/reflectionclass/newinstanceargs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: aur Status: ready -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: aur Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.newinstanceargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -27,9 +27,25 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Массив (<type>array</type>) аргументов, который затем передаётся в конструктор класса.
-      </para>
+      </simpara>
+      <simpara>
+       Если все ключи массива <parameter>args</parameter> числовые, ключи
+       игнорируются, и каждый элемент передаётся конструктору как позиционный
+       аргумент, по порядку.
+      </simpara>
+      <simpara>
+       Если среди ключей массива <parameter>args</parameter> есть строковые,
+       эти элементы передаются конструктору как именованные аргументы, где именем
+       выступает ключ.
+      </simpara>
+      <simpara>
+       Функция выбрасывает ошибку <exceptionname>Error</exceptionname>, если
+       числовой ключ в массиве <parameter>args</parameter> идёт после строкового
+       или если строковый ключ не совпадает с названием ни одного параметра
+       конструктора.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,6 +68,29 @@
    Если конструктор отсутствует, а параметр <parameter>args</parameter> имеет один и более аргументов,
    то это приведёт к генерации исключения <classname>ReflectionException</classname>.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Ключи массива <parameter>args</parameter> теперь интерпретируются
+       как названия параметров, а не игнорируются молча.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionfunction/invokeargs.xml
+++ b/reference/reflection/reflectionfunction/invokeargs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionfunction.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,10 +26,26 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Передаваемые функции аргументы в виде массива. Поведение функции аналогично
-       <function>call_user_func_array</function>.
-      </para>
+      <simpara>
+       Параметры, которые передают функции, в виде массива (<type>array</type>).
+       Поведение аналогично функции <function>call_user_func_array</function>.
+      </simpara>
+      <simpara>
+       Если все ключи массива <parameter>args</parameter> числовые, ключи
+       игнорируются, и каждый элемент передаётся функции как позиционный
+       аргумент, по порядку.
+      </simpara>
+      <simpara>
+       Если среди ключей массива <parameter>args</parameter> есть строковые,
+       эти элементы передаются функции как именованные аргументы, где именем
+       выступает ключ.
+      </simpara>
+      <simpara>
+       Функция выбрасывает ошибку <exceptionname>Error</exceptionname>, если
+       числовой ключ в массиве <parameter>args</parameter> идёт после строкового
+       или если строковый ключ не совпадает с названием ни одного параметра
+       функции.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/reflection/reflectionmethod/invokeargs.xml
+++ b/reference/reflection/reflectionmethod/invokeargs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionmethod.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -36,9 +36,25 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Массив (<type>array</type>), содержащий аргументы функции.
-      </para>
+      <simpara>
+       Параметры, которые передают методу, в виде массива (<type>array</type>).
+      </simpara>
+      <simpara>
+       Если все ключи массива <parameter>args</parameter> числовые, ключи
+       игнорируются, и каждый элемент передаётся методу как позиционный
+       аргумент, по порядку.
+      </simpara>
+      <simpara>
+       Если среди ключей массива <parameter>args</parameter> есть строковые,
+       эти элементы передаются методу как именованные аргументы, где именем
+       выступает ключ.
+      </simpara>
+      <simpara>
+       Функция выбрасывает ошибку <exceptionname>Error</exceptionname>, если
+       числовой ключ в массиве <parameter>args</parameter> идёт после строкового
+       или если строковый ключ не совпадает с названием ни одного параметра
+       метода.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs the three `reference/reflection/` pages with php/doc-en#5225.

`ReflectionClass::newInstanceArgs()`, `ReflectionFunction::invokeArgs()` and `ReflectionMethod::invokeArgs()` described `args` as a plain array of arguments. All three now state how the keys are interpreted:

- all-numeric keys are ignored and the elements are passed positionally, in order;
- string keys pass their element as a named argument under that name;
- an `Error` is thrown when a numeric key follows a string key, or when a string key matches no parameter name.

`ReflectionClass::newInstanceArgs()` also gains the 8.0.0 changelog row: the keys are now interpreted as parameter names instead of being silently ignored.

EN-Revision bumped to 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 on the three files.

Fixes: #1721
