### PR TITLE
[Sync-EN] Document the imagick legacy parameter and clarify bestfit

### DIFF
--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: alien Status: ready -->
+<!-- EN-Revision: 2fae40e40323696cab1d4108c8cfb3a424321a88 Maintainer: alien Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.adaptiveresizeimage">
+<refentry xml:id="imagick.adaptiveresizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::adaptiveResizeImage</refname>
   <refpurpose>Адаптивное изменение размера изображения с данными триангуляции</refpurpose>
@@ -49,9 +49,22 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-       Будет ли подгоняться изображение внутри ограничительной рамки.
-      </para>
+      <simpara>
+       Вписывать ли изображение в заданные размеры с сохранением
+       соотношения сторон.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Необязательный параметр с типом <type>bool</type>.
+       Если передали значение true, вычисления выполняются с небольшой ошибкой
+       округления, которая была в Imagick до версии 3.4.0. Если передали
+       значение false, вычисления должны давать те же результаты, что и утилиты
+       ImageMagick для командной строки.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -74,31 +87,35 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>Добавлен необязательный параметр подгонки.</entry>
-      </row>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-        Метод теперь поддерживает пропорциональное масштабирование.
-        Для этого нужно передать 0 одному из параметров.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>Добавлен необязательный параметр подгонки.</entry>
+     </row>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+       Метод теперь поддерживает пропорциональное масштабирование.
+       Для этого нужно передать 0 одному из параметров.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Добавили параметр <parameter>legacy</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 2fae40e40323696cab1d4108c8cfb3a424321a88 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.cropthumbnailimage">
+<refentry xml:id="imagick.cropthumbnailimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::cropThumbnailImage</refname>
   <refpurpose>Создаёт обрезанную миниатюру</refpurpose>
@@ -41,6 +41,18 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Необязательный параметр с типом <type>bool</type>.
+       Если передали значение true, вычисления выполняются с небольшой ошибкой
+       округления, которая была в Imagick до версии 3.4.0. Если передали
+       значение false, вычисления должны давать те же результаты, что и утилиты
+       ImageMagick для командной строки.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
 
@@ -57,6 +69,27 @@
   <para>
    &imagick.imagick.throws;
   </para>
+ </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Добавили параметр <parameter>legacy</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: zors1 Status: ready -->
+<!-- EN-Revision: 2fae40e40323696cab1d4108c8cfb3a424321a88 Maintainer: zors1 Status: ready -->
 <!-- Reviewed: no -->
 
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.resizeimage">
+<refentry xml:id="imagick.resizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::resizeImage</refname>
   <refpurpose>Масштабирует изображение</refpurpose>
@@ -66,9 +66,24 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-       Необязательный параметр подгонки.
-      </para>
+      <simpara>
+       Необязательный параметр с типом <type>bool</type>.
+       Если передали значение true, изображение вписывается в заданные размеры
+       с сохранением соотношения сторон.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Необязательный параметр с типом <type>bool</type>.
+       Если передали значение true, вычисления выполняются с небольшой ошибкой
+       округления, которая была в Imagick до версии 3.4.0. Если передали
+       значение false, вычисления должны давать те же результаты, что и утилиты
+       ImageMagick для командной строки.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -84,28 +99,32 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-        Добавлен необязательный параметр подгонки. Теперь метод поддерживает
-        пропорциональное масштабирование. Для пропорционального масштабирования
-        необходимо передать ноль в качестве любого параметра.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+       Добавлен необязательный параметр подгонки. Теперь метод поддерживает
+       пропорциональное масштабирование. Для пропорционального масштабирования
+       необходимо передать ноль в качестве любого параметра.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Добавили параметр <parameter>legacy</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dc4dddb02dc9ee0396a1b5399774fcf54c100c71 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 2fae40e40323696cab1d4108c8cfb3a424321a88 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.scaleimage">
+<refentry xml:id="imagick.scaleimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::scaleImage</refname>
   <refpurpose>Масштабирует размер изображения</refpurpose>
@@ -30,22 +30,38 @@
     <varlistentry>
      <term><parameter>columns</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Количество столбцов в масштабированном изображении.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>rows</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Количество строк в масштабированном изображении.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Вписывать ли изображение в заданные размеры с сохранением
+       соотношения сторон.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Необязательный параметр с типом <type>bool</type>.
+       Если передали значение true, вычисления выполняются с небольшой ошибкой
+       округления, которая была в Imagick до версии 3.4.0. Если передали
+       значение false, вычисления должны давать те же результаты, что и утилиты
+       ImageMagick для командной строки.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -68,27 +84,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-        Добавлен необязательный параметр fit. Метод теперь поддерживает пропорциональное масштабирование.
-        Передайте ноль в качестве любого параметра для пропорционального масштабирования.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+       Добавлен необязательный параметр fit. Метод теперь поддерживает пропорциональное масштабирование.
+       Передайте ноль в качестве любого параметра для пропорционального масштабирования.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Добавили параметр <parameter>legacy</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Syncs the four `reference/imagick/imagick/` resize pages with php/doc-en#5056.

- The `legacy` parameter is documented on `adaptiveResizeImage()`, `cropThumbnailImage()`, `resizeImage()` and `scaleImage()`: when true the calculations keep the small rounding bug Imagick had before 3.4.0, when false they match the ImageMagick command-line tools. Each page gains the matching "PECL imagick 3.4.0" changelog row, and `cropThumbnailImage()` gains a changelog section, which it had none.
- `bestfit` is described as fitting the image within the given dimensions while preserving the aspect ratio, instead of "whether to fit the image inside a bounding box" or "optional fit parameter".
- `scaleImage()` had three empty parameter descriptions (`columns`, `rows`, `bestfit`); they are filled in.
- The four `refentry` elements put `xml:id` before `xmlns`, and the three changelog `informaltable`s are no longer wrapped in a `para`, as upstream.

EN-Revision bumped to 2fae40e40323696cab1d4108c8cfb3a424321a88 on the four files.

Fixes: #1652
