### PR TITLE
[Sync-EN] Document the SOAP PHP 8.4 changes

### DIFF
--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: mch Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: mch Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.soapclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -74,7 +74,7 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>private</modifier>
-     <type class="union"><type>resource</type><type>null</type></type>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="soapclient.props.typemap">typemap</varname>
      <initializer>null</initializer>
     </fieldsynopsis>
@@ -246,12 +246,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])"/>
    </classsynopsis>
 <!-- }}} -->
 
@@ -494,8 +490,15 @@
     <varlistentry xml:id="soapclient.props.typemap">
      <term><varname>typemap</varname></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Массив сопоставлений типов, которые применяют для пользовательского
+       преобразования типов из XML в PHP, либо &null;, если сопоставления
+       типов не настроили.
+       Начиная с PHP 8.4.0 свойство имеет тип <type>array</type>; раньше оно
+       имело тип <type>resource</type>. Код, который проверяет это свойство
+       функцией <function>is_resource</function>, требуется соответственно
+       обновить.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="soapclient.props.uri">

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -358,6 +358,13 @@
            <link linkend="object.get">__get()</link> будут вызываться
            для отдельных свойств.
           </para>
+          <simpara>
+           Начиная с PHP 8.4.0 ключи разрешается задавать также в кларковской
+           нотации, в виде <literal>{namespace}type</literal>, чтобы сопоставить
+           тип из конкретного XML-пространства имён, например
+           <literal>'{http://example.com}foo'</literal>. Это удобно, когда одно
+           и то же название типа определили более чем в одном пространстве имён.
+          </simpara>
          </listitem>
         </varlistentry>
         <varlistentry xml:id="soapclient.construct.options.typemap">

--- a/reference/soap/soapserver/construct.xml
+++ b/reference/soap/soapserver/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapserver.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -42,11 +42,15 @@
        внутреннюю кодировку (<literal>encoding</literal>)
        и URI отправителя (<literal>actor</literal>).
       </para>
-      <para>
+      <simpara>
        Опцию <literal>classmap</literal> можно использовать для сопоставления
        некоторых типов WSDL с классами PHP. Данная опция должна быть массивом с
        ключами равными типам WSDL и значениям равными именам классов PHP.
-      </para>
+       Начиная с PHP 8.4.0 ключи разрешается задавать также в кларковской
+       нотации, в виде <literal>{namespace}type</literal>, чтобы сопоставить
+       тип из конкретного XML-пространства имён, например
+       <literal>'{http://example.com}foo'</literal>.
+      </simpara>
       <para>
        Опция <literal>typemap</literal> является массивом сопоставления типов.
        Массив с ключами <literal>type_name</literal>,

--- a/reference/soap/soapserver/setpersistence.xml
+++ b/reference/soap/soapserver/setpersistence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapserver.setpersistence" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -70,6 +70,34 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Константа <constant>SOAP_PERSISTENCE_SESSION</constant> теперь работает,
+       когда модуль session собрали как разделяемый; раньше вызов молча
+       завершался неудачей.
+       Метод <methodname>SoapServer::setPersistence</methodname> теперь также
+       выбрасывает ошибку <exceptionname>Error</exceptionname>, когда запросили
+       константу <constant>SOAP_PERSISTENCE_SESSION</constant>, а модуль session
+       недоступен.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/soap/soapvar/construct.xml
+++ b/reference/soap/soapvar/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapvar.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -90,6 +90,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Объект класса <classname>DateTimeInterface</classname>, который передали
+       как значение элемента <literal>xsd:dateTime</literal> или похожего типа
+       даты и времени, теперь сериализуется в представление ISO 8601, а не
+       в пустую строку.
+      </entry>
+     </row>
      <row>
       <entry>8.0.3</entry>
       <entry>


### PR DESCRIPTION
Syncs the five `reference/soap/` pages with php/doc-en#5735 and php/doc-en#5699.

php/doc-en#5735:
- `SoapClient::$typemap` is typed `array|null` instead of `resource|null`, and its description, which was an empty paragraph, explains what it holds and that code checking it with `is_resource()` needs updating for PHP 8.4.0.
- `SoapClient::__construct()` and `SoapServer::__construct()`: the `classmap` option documents the Clark notation keys, `{namespace}type`, added in PHP 8.4.0 for mapping a type from a specific XML namespace.
- `SoapServer::setPersistence()` gains a changelog section: as of 8.4.0 `SOAP_PERSISTENCE_SESSION` works with a shared session extension, where it previously failed silently, and the method throws an `Error` when that constant is requested while the session extension is unavailable.
- `SoapVar::__construct()` gains the 8.4.0 row about a `DateTimeInterface` value for an `xsd:dateTime` element now serializing to its ISO 8601 representation instead of an empty string.

php/doc-en#5699: mirrors the removal of the two empty `xi:fallback` elements in the `SoapClient` synopsis.

EN-Revision bumped to d20d66d9c76ff98dceb853aeb86794fe9d657669 on the five files.

Fixes: #1623
