### PR TITLE
[Sync-EN] Fix the assert(), dl() and getrusage() return docs and the E_ALL value

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2916fa4160bdf53bb316a5c7c018fc91df7cd951 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.assert" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,30 +14,30 @@
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Функция <function>assert</function> определяет ожидания: утверждения,
    которые проверяются в средах разработки и тестирования,
    но перед развёртыванием в производственной среде код оптимизируют — удаляют проверки утверждений, чтобы исключить накладные расходы.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Утверждения помогают отлаживать код.
    В одном случае утверждениями проверяют, выполняются ли предварительные условия:
    корректные условия вычисляются как значение &true;, а ложность условий
    указывает на ошибки программирования.
    В другом сценарии проверяют доступность конкретной функции модуля
    или не накладывает ли система конкретные ограничения.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Утверждения <emphasis>не</emphasis> включают в производственный код и не проверяют утверждениями стандартные операции времени выполнения
    наподобие проверки входных параметров, поскольку код с утверждениями сломается, когда проверку ожиданий отключат в конфигурации PHP.
    Поэтому в производственной среде разворачивают код, который работает правильно даже при отключении проверки утверждений.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Функция <function>assert</function> проверяет, выполняется ли ожидание,
    установленное в параметре <parameter>assertion</parameter>.
    Функция <function>assert</function> выполнит действие, которое сконфигурировали во втором параметре,
    если условие не выполнилось и поэтому вернуло значение &false;.
-  </para>
+  </simpara>
 
   <para>
    Поведение конструкции <function>assert</function> определяется следующими INI-настройками:
@@ -118,7 +118,7 @@
        <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
        <entry>&true;</entry>
        <entry>
-        Со значением &true; функция выбрасывает исключение <classname>AssertionError</classname>,
+        Со значением &true; функция выбрасывает исключение <exceptionname>AssertionError</exceptionname>,
         если ожидание не оправдалось.
        </entry>
        <entry>
@@ -180,7 +180,7 @@
      <listitem>
       <para>
        При передаче в параметр <parameter>description</parameter> значения
-       с типом <classname>Throwable</classname> функция выбрасывает исключение,
+       с типом <exceptionname>Throwable</exceptionname> функция выбрасывает исключение,
        но только если утверждение <parameter>assertion</parameter> не прошло проверку.
        <note>
         <para>
@@ -220,24 +220,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Функция <function>assert</function> возвращает значение &true;,
    если хотя бы одно из следующих утверждений истинно:
-  </para>
+  </simpara>
   <simplelist>
    <member><literal>zend.assertions=0</literal></member>
    <member><literal>zend.assertions=-1</literal></member>
    <member><literal>assert.active=0</literal></member>
-   <member><literal>assert.exception=1</literal></member>
-   <member><literal>assert.bail=1</literal></member>
-   <member>В параметр <parameter>description</parameter> передали объект пользовательского исключения.</member>
   </simplelist>
-  <para>
+  <simpara>
    Функция <function>assert</function> проверяет утверждения
    и возвращает &true; при истинности аргумента <parameter>assertion</parameter>,
    но только если ни одно из отключающих проверки условий не выполняется,
    иначе функция возвращает &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -271,7 +268,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        При передаче в параметр <parameter>description</parameter> экземпляра класса <classname>Throwable</classname>
+        При передаче в параметр <parameter>description</parameter> экземпляра класса <exceptionname>Throwable</exceptionname>
         исключение выбрасывается, если утверждение не прошло проверку,
         независимо от значения опции <link linkend="ini.assert.exception">assert.exception</link>.
        </entry>
@@ -279,7 +276,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        При передаче в параметр <parameter>description</parameter> экземпляра класса <classname>Throwable</classname>
+        При передаче в параметр <parameter>description</parameter> экземпляра класса <exceptionname>Throwable</exceptionname>
         пользовательская callback-функция не вызывается, даже если её установили.
        </entry>
       </row>
@@ -326,10 +323,10 @@ echo 'Привет!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее,
      если утверждения включили в директиве <link linkend="ini.zend.assertions"><literal>zend.assertions=1</literal></link>:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: assert(1 > 2) in example.php:2
@@ -339,10 +336,10 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее,
      если утверждения отключили путём установки для директивы значений <literal>zend.assertions=0</literal> или <literal>zend.assertions=-1</literal>:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Привет!
@@ -361,9 +358,9 @@ echo 'Привет!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее, если утверждения включили:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: Ожидается, что один больше двух in example.php:2
@@ -373,9 +370,9 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее, если утверждения выключили:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Привет!
@@ -396,9 +393,9 @@ echo 'Hi!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее, если утверждения включили:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught ArithmeticAssertionError: Ожидается, что один больше двух in example.php:4
@@ -407,9 +404,9 @@ Stack trace:
   thrown in example.php on line 4
 ]]>
     </screen>
-    <para>
+    <simpara>
      Приведённый пример выведет следующее, если утверждения выключили:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Привет!

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a89c6d71c7b65e3de84f26230fbf72c9b8948adf Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,13 +90,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success; Если механизм загрузки модулей недоступен или отключён
-   (значение off настройки <link linkend="ini.enable-dl">enable_dl</link> в &php.ini;), будет выдана ошибка
-   <constant>E_ERROR</constant> и выполнение прекращается. Если
+   (значение off настройки <link linkend="ini.enable-dl">enable_dl</link> в &php.ini;), поднимается
+   ошибка уровня <constant>E_WARNING</constant> и возвращается &false;. Если
    <function>dl</function> не сможет загрузить заданную библиотеку, то в дополнение
    к &false; будет выдано сообщение <constant>E_WARNING</constant>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -60,7 +60,7 @@ Array
             [E_USER_ERROR] => 256
             [E_USER_WARNING] => 512
             [E_USER_NOTICE] => 1024
-            [E_ALL] => 2047
+            [E_ALL] => 30719
             [TRUE] => 1
         )
 
@@ -127,7 +127,7 @@ Array
     [E_USER_ERROR] => 256
     [E_USER_WARNING] => 512
     [E_USER_NOTICE] => 1024
-    [E_ALL] => 2047
+    [E_ALL] => 30719
     [TRUE] => 1
 )
 ]]>

--- a/reference/info/functions/getrusage.xml
+++ b/reference/info/functions/getrusage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a277389c9d2d5a940fcd6dbe62da7e109282379d Maintainer: tmn Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: tmn Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.getrusage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -102,12 +102,11 @@ echo $dat["ru_stime.tv_sec"];  // время на системные задач�
      </member>
     </simplelist>
    </para>
-   <para>
+   <simpara>
     Если <function>getrusage</function> вызвана с <parameter>mode</parameter> равным
     <literal>1</literal> (<constant>RUSAGE_CHILDREN</constant>), то будет
-    собираться информация по использованию ресурсов потоками  (что означает, что внутри
-    функция будет вызываться с <constant>RUSAGE_THREAD</constant>).
-   </para>
+    собираться информация по использованию ресурсов дочерними процессами.
+   </simpara>
   </note>
   <note>
    <para>


### PR DESCRIPTION
Syncs four `reference/info/` pages with php/doc-en#5650.

- `assert()`: the return-value list said the function always returns `true` when `assert.exception=1`, `assert.bail=1`, or a custom exception object is passed. Those three entries are removed: only `zend.assertions=0`, `zend.assertions=-1` and `assert.active=0` make it unconditionally return `true`. `AssertionError` and the three `Throwable` mentions are marked up as `exceptionname`.
- `dl()`: when module loading is unavailable or `enable_dl` is off, the function emits an `E_WARNING` and returns `false`; it does not emit `E_ERROR` and stop execution.
- `get_defined_constants()`: the two example outputs showed `[E_ALL] => 2047`, the pre-8.0 value; it is `30719`.
- `getrusage()`: with `mode` set to `1` (`RUSAGE_CHILDREN`) the function collects resource usage for **child processes**, not for threads via `RUSAGE_THREAD`.

`reference/info/versions.xml` is not part of this change: that file is EN-only infrastructure and has no Russian counterpart.

Several paragraphs become `simpara`, as upstream.

EN-Revision bumped to 5367d2fcdf4b710a81806aba52a71c522f082713 on the four files.

Fixes: #1688
