### PR TITLE
[Sync-EN] Use simpara for simple paragraphs in install/unix

### DIFF
--- a/install/unix/commandline.xml
+++ b/install/unix/commandline.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40a850f73df8e3c6c4f0d0aa4b9de62aa62fe445 Maintainer: shein Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: shein Status: ready -->
 <!-- Reviewed: no -->
   <sect1 xml:id="install.unix.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Установка с интерфейсами CGI и командной строки</title>
-   <para>
+   <simpara>
     По умолчанию, PHP собирается одновременно как <acronym>CLI</acronym> и
     <acronym>CGI</acronym> программа, которая может быть использована для обработки
     CGI-запросов. PHP как модуль сервера выигрывает в производительности,
     однако PHP CGI позволяет запускать PHP от пользователя, отличного
     от того, под которым исполняется сервер.
-   </para>
+   </simpara>
    &warn.install.cgi;
 
    <sect2 xml:id="install.unix.commandline.testing">

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.lighttpd-14" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка PHP на Lighttpd 1.4 на Unix-системах</title>
 
- <para>
+ <simpara>
   Этот раздел содержит информацию по установке PHP на Unix-системы
   с сервером Lighttpd 1.4.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Прочитайте, пожалуйста, инструкции по установке Lighttpd в
   <link xlink:href="&url.lighttpd.doc;">документации по Lighttpd</link>
   перед установкой PHP.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   FastCGI - предпочитаемый интерфейс для связи PHP и Lighttpd. FastCGI доступен
   по умолчанию в php-cgi.
- </para>
+ </simpara>
 
  <sect2 xml:id="install.unix.lighttpd-14.lighttpd-spawn">
   <title>Управление процессами php через Lighttpd</title>
 
-  <para>
+  <simpara>
    Для настройки Lighttpd на соединение с PHP и порождения процессов FastCGI
    необходимо отредактировать конфигурационный файл <filename>lighttpd.conf</filename>. Предпочтительнее
    подключаться к процессам FastCGI используя Unix-сокеты.
-  </para>
+  </simpara>
 
   <example>
    <title>Пример части файла lighttpd.conf</title>
@@ -71,23 +71,23 @@ fastcgi.server = ( ".php" =>
  <sect2 xml:id="install.unix.lighttpd-14.spawn-fcgi">
   <title>Управление процессами с помощью spawn-fcgi</title>
 
-  <para>
+  <simpara>
    Lighttpd предоставляет программу spawn-fcgi для облегчения управления
    дочерними процессами FastCGI.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="install.unix.lighttpd-14.spawn-php">
   <title>Управление процессами с помощью php-cgi</title>
 
-  <para>
+  <simpara>
    Управлять процессами можно и без spawn-fcgi, но это потребует некоторых
    доработок. Переменная окружения <envar>PHP_FCGI_CHILDREN</envar> указывает количество
    дочерних процессов, запускаемых PHP для обработки входящих запросов.
    Переменная <envar>PHP_FCGI_MAX_REQUESTS</envar> отвечает за количество запросов,
    которые обработает один процесс. Ниже приведён простой bash-скрипт,
    облегчающий создание дочерних процессов.
-  </para>
+  </simpara>
 
   <example>
    <title>Создание FastCGI-обработчиков</title>
@@ -123,10 +123,10 @@ echo $! > "$PHP_PID"
  <sect2 xml:id="install.unix.lighttpd-14.remote-fcgi">
   <title>Подключение к удалённым процессам FCGI</title>
 
-  <para>
+  <simpara>
    Обработчики FastCGI могут находиться на нескольких отдельных машинах
    для масштабирования нагрузки.
-  </para>
+  </simpara>
 
   <example>
    <title>Подключение к удалённым процессам fastcgi</title>

--- a/install/unix/litespeed.xml
+++ b/install/unix/litespeed.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.litespeed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Веб-серверы LiteSpeed и OpenLiteSpeed в системах Unix</title>
 
- <para>
+ <simpara>
   LiteSpeed PHP — оптимизированная сборка PHP для работы с продуктами LiteSpeed
   через SAPI-интерфейс LiteSpeed. LSPHP запускается как самостоятельный процесс из отдельного
   исполняемого файла, с которым также работают как со стандартной утилитой
   для выполнения PHP-скриптов в командной строке.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   LSAPI — высокопроизводительный API для взаимодействия веб-серверов LiteSpeed
   с веб-приложениями. Протоколы взаимодействия с интерфейсами LSAPI и FCGI архитектурно аналогичны,
   но с веб-серверами LiteSpeed интерфейс LSAPI работает эффективнее.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Документация описывает установку и настройку сборки
   PHP для работы с веб-серверами LiteSpeed (LSWS) и OpenLiteSpeed (OLS) через LSAPI.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Руководство предполагает, что веб-сервер LSWS или OLS установили по стандартным путям
   и со стандартными флагами. Директория установки по умолчанию для обоих
   веб-серверов — /usr/local/lsws, и оба сервера запускаются из подкаталога bin.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Обратите внимание: в документации номера версий заменили
   символом <literal>x</literal>, чтобы документация оставалась актуальной
   и в будущем, поэтому в командах подстановочный символ заменяют номером конкретной версии.
- </para>
+ </simpara>
 
  <orderedlist>
   <listitem>
-   <para>
+   <simpara>
     Скачайте исходный код веб-сервера с сайта документации:
     <link xlink:href="&url.litespeed.lsws;">страница с инструкциями по установке</link> веб-сервера LiteSpeed
     или <link xlink:href="&url.litespeed.install;">страница с инструкциями по установке</link> веб-сервера OpenLiteSpeed.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Скачайте и распакуйте исходный код PHP:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.litespeed.extract.php">
     <screen>
@@ -62,13 +62,13 @@ cd php-x.x.x
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Сконфигурируйте и соберите PHP. На этом этапе определяют параметры сборки —
     указывают опции компиляции, SAPI и модули, которые требуется включить в PHP-сборку.
     Команда ./configure --help выведет список доступных опций.
     Следующий пример показывает стандартные рекомендованные параметры конфигурации
     для LSWS:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.litespeed.build.php">
     <screen>
@@ -82,13 +82,13 @@ sudo make install
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Проверьте установку LSPHP
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Корректность установки PHP проверяют следующими командами:
-   </para>
+   </simpara>
 
    <informalexample>
     <screen>
@@ -99,9 +99,9 @@ cd /usr/local/lsws/fcgi-bin/
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Команда вернёт информацию о PHP-сборке:
-   </para>
+   </simpara>
 
    <informalexample>
     <screen>
@@ -113,47 +113,47 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Обратите внимание на маркер <literal>litespeed</literal> в скобках. Маркер указывает,
     что исполняемый файл PHP собрали с поддержкой LSAPI.
-   </para>
+   </simpara>
   </listitem>
  </orderedlist>
 
- <para>
+ <simpara>
   Выполнение приведённых шагов подготовит веб-сервер LiteSpeed или OpenLiteSpeed к запуску
   и добавит в PHP поддержку SAPI-интерфейса LiteSpeed.
   О дополнительных параметрах конфигурации связки веб-сервера LSWS или OLS с PHP
   рассказывает раздел <link xlink:href="&url.litespeed.php;">об управлении LSPHP</link>
   на сайте документации к веб-серверу LiteSpeed.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Работа с LSPHP в командной строке:
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   LSPHP — PHP-интерпретатор с поддержкой LSAPI-интерфейса.
   Двоичный файл lsphp запускают на удалённом хосте в режиме командной строки.
   LSPHP запустит и обработает PHP-скрипт автономно — устанавливать веб-сервер на удалённом узле не потребуется.
   В раздельной конфигурации локальный веб-сервер принимает запрос, а PHP-скрипт выполняется на удалённой машине.
   Раздельная установка повышает масштабируемость сервиса,
   поскольку обработка PHP-скриптов переносится на удалённый сервер.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Запустите исполняемый файл lsphp из командной строки на удалённом сервере:
   LSPHP — исполняемый файл, который поддерживает ручной запуск и привязку
   к IPv4-, IPv6- или Unix-сокету через опцию командной строки -b socket_address.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Пример:
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Привязка LSPHP к порту 3000 на всех IPv4- и IPv6-адресах:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -163,9 +163,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Привязка LSPHP к порту 3000 на всех IPv4-адресах:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -175,9 +175,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Привязка LSPHP к адресу 192.168.0.2:3000:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -187,9 +187,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Настройка LSPHP на приём запросов через сокет Unix-домена <literal>/tmp/lsphp_manual.sock</literal>:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -199,9 +199,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Перед запуском LSPHP поддерживается установка переменных окружения:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -211,41 +211,41 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   LiteSpeed PHP поддерживает работу с веб-серверами LiteSpeed,
   OpenLiteSpeed и модулем mod_lsapi веб-сервера Apache. Инструкции по настройке серверов
   доступны на страницах документации:
   <link xlink:href="&url.litespeed.web.server;">LiteSpeed</link>
   и <link xlink:href="&url.litespeed.open;">OpenLiteSpeed</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Другие способы установки LSPHP:
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   CentOS:
   компоненты LSPHP доступны для установки в виде <link xlink:href="&url.litespeed.packages;">RPM-пакетов</link>
   из репозиториев LiteSpeed или Remi.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Debian:
   компоненты LSPHP устанавливают из репозитория LiteSpeed
   командой <link xlink:href="&url.litespeed.packages;">apt</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   cPanel:
   об установке компонентов LSPHP на веб-серверах LSWS и OLS с панелью управления cPanel
   через инструмент EasyApache 4 рассказывает <link xlink:href="&url.litespeed.cpanel;">страница документации</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Plesk:
   об управлении компонентами LSPHP через панель Plesk на машинах под управлением операционных систем CentOS, CloudLinux, Debian и Ubuntu
   рассказывает <link xlink:href="&url.litespeed.plesk;">страница документации</link>.
- </para>
+ </simpara>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f0261e36dc250410f352fe33ad4c4e699cb18b02 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.nginx" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка Nginx 1.4.x на систему Unix</title>
 
- <para>
+ <simpara>
   Эта документация описывает установку и настройку PHP с
   менеджером процессов PHP-FPM для HTTP-сервера Nginx 1.4.x.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Это краткое руководство предполагает, что Nginx собран из исходного кода
   и поэтому бинарные файлы и файлы конфигурации лежат в директории
   <literal>/usr/local/nginx</literal>. Если нет, и вы получили Nginx другим способом, тогда,
   пожалуйста, обратитесь к <link xlink:href="&url.nginx;">Nginx Wiki</link>, чтобы получить
   похожее на это руководство для вашей установки.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   В этом кратком руководстве будут рассмотрены основы настройки Nginx-сервера для обработки PHP-приложений
   и их обслуживания на порту 80. Рекомендовано изучить документацию Nginx и PHP-FPM, если
   нужно оптимизировать установку за рамками этой документации.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Пожалуйста, обратите внимание, что в этой документации номера версий были
   заменены на символ «x», чтобы документация оставалась корректной в будущем.
   Пожалуйста, замените «x» на необходимый номер версии.
- </para>
+ </simpara>
 
  <orderedlist>
   <listitem>
-   <para>
+   <simpara>
     Рекомендовано зайти
     <link xlink:href="&url.nginx.wiki.install;">на страницу установки</link> Nginx Wiki,
     чтобы получить и установить HTTP-сервер Nginx на свою систему.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Распаковать полученный исходный код PHP:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.extract.php">
     <screen>
@@ -53,13 +53,13 @@ tar zxf php-x.x.x
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Настроить и собрать PHP. Здесь вы настраиваете PHP
     с нужными параметрами.
     Запустите команду ./configure --help, чтобы получить список доступных опций.
     В примере будут сделаны простые настройки для включения менеджера процессов PHP-FPM
     с поддержкой модуля MySQLi.
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.build.php">
     <screen>
@@ -74,9 +74,9 @@ sudo make install
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Переместить файлы конфигурации в правильные места
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.php">
     <screen>
@@ -90,18 +90,18 @@ cp sapi/fpm/php-fpm /usr/local/bin
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Важно запретить серверу Nginx передавать запросы в бэкенд менеджера PHP-FPM,
     если файл не существует, что помогает предотвратить атаки произвольного внедрения скрипта.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Это исправляют установкой для директивы
     <link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link>
     значения <literal>0</literal> в файле php.ini.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Отредактировать файл php.ini:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.ini">
     <screen>
@@ -111,9 +111,9 @@ vim /usr/local/php/php.ini
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Найти директиву <literal>cgi.fix_pathinfo=</literal> и изменить вот так:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.pathinfo">
     <screen>
@@ -125,10 +125,10 @@ cgi.fix_pathinfo=0
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Файл php-fpm.conf нужно изменить, чтобы указать, что модуль php-fpm должен
     работать от имени пользователя www-data и группы www-data, до того как мы запустим сервис:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.modify.phpfpm">
     <screen>
@@ -138,9 +138,9 @@ vim /usr/local/etc/php-fpm.d/www.conf
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Найти и изменить следующее:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.modify.phpfpm.usergroup">
     <screen>
@@ -154,9 +154,9 @@ group = www-data
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Теперь можно запускать сервис php-fpm:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.start.phpfpm">
     <screen>
@@ -166,16 +166,16 @@ group = www-data
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Это руководство не рассматривает другие настройки модуля php-fpm.
     Обратитесь к документации по php-fpm, если нужны дополнительные настройки.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Настроить Nginx на поддержку обработки PHP-приложений:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx">
     <programlisting>
@@ -185,10 +185,10 @@ vim /usr/local/nginx/conf/nginx.conf
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     Измените блок «location» по умолчанию так, чтобы HTTP-сервер знал,
     что он должен обслуживать файлы .php:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.location">
     <programlisting role="nginx-conf">
@@ -201,10 +201,10 @@ location / {
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     Следующий шаг — убедиться, что файлы .php передаются в бэкенд PHP-FPM.
     Введите следующее:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.php">
     <programlisting role="nginx-conf">
@@ -220,9 +220,9 @@ location ~* \.php$ {
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     Перезапустите Nginx.
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.restart.nginx">
     <screen>
@@ -235,9 +235,9 @@ sudo /usr/local/nginx/sbin/nginx
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Создайть тестовый файл
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.test.nginx.php">
     <screen>
@@ -248,20 +248,20 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Теперь откройте в браузере адрес http://localhost.
     Должна отобразиться информация, которую выводит функция phpinfo().
-   </para>
+   </simpara>
   </listitem>
  </orderedlist>
 
- <para>
+ <simpara>
   Выполнив описанные шаги, вы получите работающий Nginx-сервер с
   поддержкой PHP в качестве модуля интерфейса <literal>FPM</literal> <literal>SAPI</literal>.
   Конечно, для Nginx и PHP доступно больше параметров конфигурации.
   Наберите в директории с исходным кодом команду <command>./configure --help</command>,
   чтобы получить больше информации.
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.openbsd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Установка из пакетов или портов в ОС OpenBSD</title>
- <para>
+ <simpara>
   Cекция содержит замечания и советы, которые касаются установки
   PHP на ОС <link xlink:href="&url.openbsd;">OpenBSD</link>.
- </para>
+ </simpara>
  <sect2 xml:id="install.unix.openbsd.packages">
   <title>Работа с бинарными пакетами</title>
    <simpara>

--- a/install/unix/solaris.xml
+++ b/install/unix/solaris.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4eeb07225f615fcde68cbefb84df2fc9bf278f1f Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: c28836ede0597b3650fe6b5bf0a64e08f6e27626 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.unix.solaris" xmlns="http://docbook.org/ns/docbook">
  <title>Инструкции по инсталляции для ОС <productname>Solaris</productname></title>
- <para>
+ <simpara>
   Данный раздел содержит инструкции и советы для установки PHP на ОС
   <productname>Solaris</productname>.
- </para>
+ </simpara>
  <sect2 xml:id="install.unix.solaris.required">
   <title>Требования к программному обеспечению</title>
-  <para>
+  <simpara>
    Зачастую в составе операционной системы <productname>Solaris</productname> отсутствует компиляторы языка C и сопутствующие им утилиты.
    Ознакомьтесь <link linkend="faq.installation.needgnu">с этим FAQ</link>,
    чтобы узнать, почему необходимо использовать GNU-версии этих утилит.
-  </para>
+  </simpara>
   <para>
    Для распаковки дистрибутива PHP вам понадобится
    <itemizedlist>


### PR DESCRIPTION
Syncs the six `install/unix/` pages with php/doc-en#5748.

Pure markup change: the paragraphs that hold only inline content become `simpara`, matching the English pages element for element. No wording is touched.

EN-Revision bumped to c28836ede0597b3650fe6b5bf0a64e08f6e27626 on the six files.

Fixes: #1617
