### PR TITLE
[Sync-EN] Fix the pcntl reference pages and document the 8.4 failure return

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71fa455c5670ea4a3a3a0c60e34d906d1061a6c8 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pcntl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -636,17 +636,6 @@
   <varlistentry xml:id="constant.si-timer">
    <term>
     <constant>SI_TIMER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.si-msggq">
-   <term>
-    <constant>SI_MSGGQ</constant>
     (<type>int</type>)
    </term>
    <listitem>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -58,9 +58,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Возвращает &false;.
-  </para>
+  <simpara>
+   Функция возвращает &false; в случае ошибки. В случае успешного выполнения
+   функция не возвращает управление, поскольку образ текущего процесса
+   заменяется исполняемой программой.
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigprocmask.xml
+++ b/reference/pcntl/functions/pcntl-sigprocmask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-sigprocmask" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -84,22 +84,24 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не задано,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если параметр <parameter>signals</parameter> пуст,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>,
+       кроме случая, когда значение параметра <parameter>mode</parameter> —
+       константа <constant>SIG_SETMASK</constant>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не целое число (<type>int</type>),
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если значение параметра <parameter>signals</parameter> не целое число (<type>int</type>),
+       выбрасывается ошибка <exceptionname>TypeError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> некорректно,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если значение параметра <parameter>signals</parameter> некорректно,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
@@ -107,7 +109,7 @@
       <entry>
        Если значение параметра <parameter>mode</parameter> не
        <constant>SIG_BLOCK</constant>, <constant>SIG_UNBLOCK</constant> или
-       <constant>SIG_SETMASK</constant>, выбрасывается ошибка <classname>ValueError</classname>.
+       <constant>SIG_SETMASK</constant>, выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
     </tbody>
@@ -135,12 +137,10 @@ pcntl_sigprocmask(SIG_UNBLOCK, array(SIGHUP), $oldset);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigwaitinfo</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigwaitinfo</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigtimedwait.xml
+++ b/reference/pcntl/functions/pcntl-sigtimedwait.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-sigtimedwait" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,43 +87,51 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не задано,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       В случае ошибки теперь возвращается &false;; раньше в ряде случаев
+       возвращалось значение <literal>-1</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не целое число (<type>int</type>),
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если параметр <parameter>signals</parameter> пуст,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> некорректно,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если значение параметра <parameter>signals</parameter> не целое число (<type>int</type>),
+       выбрасывается ошибка <exceptionname>TypeError</exceptionname>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Если значение параметра <parameter>signals</parameter> некорректно,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
        Если значение параметра <parameter>seconds</parameter> меньше <literal>0</literal>,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>nanoseconds</parameter> меньше <literal>0</literal>,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если значение параметра <parameter>nanoseconds</parameter> не находится
+       в диапазоне от <literal>0</literal> до <literal>1e9</literal>,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>seconds</parameter> и <parameter>nanoseconds</parameter>
-       меньше <literal>0</literal>, выбрасывается ошибка <classname>ValueError</classname>.
+       Если значения параметров <parameter>seconds</parameter> и <parameter>nanoseconds</parameter>
+       равны <literal>0</literal>, выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
     </tbody>
@@ -133,12 +141,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigwaitinfo</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigwaitinfo</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-sigwaitinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -100,22 +100,29 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не задано,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       В случае ошибки теперь возвращается &false;; раньше в ряде случаев
+       возвращалось значение <literal>-1</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> не целое число (<type>int</type>),
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если параметр <parameter>signals</parameter> пуст,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Если значение параметра <parameter>signal</parameter> некорректно,
-       выбрасывается ошибка <classname>ValueError</classname>.
+       Если значение параметра <parameter>signals</parameter> не целое число (<type>int</type>),
+       выбрасывается ошибка <exceptionname>TypeError</exceptionname>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Если значение параметра <parameter>signals</parameter> некорректно,
+       выбрасывается ошибка <exceptionname>ValueError</exceptionname>.
       </entry>
      </row>
     </tbody>
@@ -149,12 +156,10 @@ pcntl_sigwaitinfo(array(SIGHUP), $info);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-unshare.xml
+++ b/reference/pcntl/functions/pcntl-unshare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7c1097cca089f4571977b41855e63d3c3638433 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id='function.pcntl-unshare' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,21 +49,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Возвращает <literal>0</literal> в случае успешного выполнения, <literal>-1</literal> в противном случае.
+  <simpara>
+   Функция возвращает &true; в случае успешного выполнения или &false;
+   в случае ошибки.
    В случае возникновения ошибки устанавливается код ошибки,
    который можно получить с помощью функции <function>pcntl_get_last_error</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link linkend="pcntl.constants.clone">Константы PCNTL</link></member>
-    <member><function>pcntl_get_last_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link linkend="pcntl.constants.clone">Константы PCNTL</link></member>
+   <member><function>pcntl_get_last_error</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/versions.xml
+++ b/reference/pcntl/versions.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?do-not-translate?>
-<!-- EN-Revision: c2149ab44867d36166d750d5d8730a2ca7dd61e2 Credit: lacatoire -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Credit: lacatoire -->
 <versions>
  <function name="pcntl_alarm" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_async_signals" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
  <function name="pcntl_errno" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>
  <function name="pcntl_exec" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_fork" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_forkx" from="PHP 8 &gt;= 8.2.0"/>
+ <function name="pcntl_getcpu" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getcpuaffinity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getqos_class" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getpriority" from="PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_get_last_error" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>
  <function name="pcntl_rfork" from="PHP 8 &gt;= 8.1.0"/>
  <function name="pcntl_setcpuaffinity" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="pcntl_setns" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_setpriority" from="PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_setqos_class" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_signal" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
@@ -27,6 +30,7 @@
  <function name="pcntl_waitpid" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_waitid" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_wexitstatus" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_wifcontinued" from="PHP 7, PHP 8"/>
  <function name="pcntl_wifexited" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifsignaled" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifstopped" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
@@ -34,6 +38,7 @@
  <function name="pcntl_wtermsig" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl\qosclass" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Syncs seven `reference/pcntl/` files with php/doc-en#5767.

- `pcntl_exec()`: the return value said only "returns `false`". It now says `false` is returned on failure and that on success the function does not return at all, the process image being replaced.
- `pcntl_unshare()`: returns `true`/`false`, not `0`/`-1`.
- `pcntl_sigprocmask()`, `pcntl_sigtimedwait()`, `pcntl_sigwaitinfo()`: the changelog rows named a `signal` parameter that does not exist, the parameter is `signals`; the "not an int" row said `ValueError` where it is a `TypeError`; `pcntl_sigprocmask()` gains the `SIG_SETMASK` exemption for an empty array; `pcntl_sigtimedwait()` states `nanoseconds` must be between 0 and 1e9, and that the both-zero row is about both being `0`, not "less than 0". `pcntl_sigtimedwait()` and `pcntl_sigwaitinfo()` gain the row about `false` being returned on failure where `-1` was returned in some cases.
- `constants.xml`: the `SI_MSGGQ` entry, which had an empty description, is removed as upstream.
- `versions.xml` gains the missing `pcntl_forkx`, `pcntl_getcpu`, `pcntl_setns` and `pcntl_wifcontinued` entries.
- `ValueError`, `TypeError` and friends are marked up as `exceptionname`, and the four see-also `simplelist`s lose their `para` wrapper.

EN-Revision bumped to 253f4bdd29fc3938030dce22882611ceefa9f74a on the seven files.

Fixes: #1685
