### PR TITLE
[Sync-EN] Revise the Yaconf extension documentation

### DIFF
--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -1,76 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a87d61dbfcaddeafeebe5fd9546c5d9c6bc9ea2 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <book xml:id="book.yaconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
- <title>Модуль ini-конфигураций Yaconf</title>
+ <title>Yaconf</title>
  <titleabbrev>Yaconf</titleabbrev>
 
  <preface xml:id="intro.yaconf">
   &reftitle.intro;
-  <para>
-   Модуль <literal>Yet Another Configurations Container</literal>,
-   или <acronym>Yaconf</acronym>, — ещё один контейнер конфигураций,
-   который разбирает <literal>INI</literal>-файлы и сохраняет результат
-   в PHP при запуске, результат сохраняется на протяжении жизненного цикла PHP.
-  </para>
-  <para>
-   Yaconf-контейнер сохраняет каждую конфигурацию
-   как интернированную строку или неизменяемый массив. Для таких данных не ведётся
-   подсчёт ссылок, как при работе механизма refcount. Поэтому <acronym>Yaconf</acronym>-конфигурации
-   извлекаются быстро — близко к механизму zero-copy по приросту производительности.
-  </para>
-  <para>
-   Yaconf поддерживает в <literal>INI</literal>-файлах разделы и наследование разделов конфигураций.
-   Модуль Yaconf поддерживает автоматическую перезагрузку конфигураций после изменений <literal>INI</literal>-файлов,
-   если PHP собрали в непотокобезопасном режиме — без поддержки ZTS.
-  </para>
-  <para>
+  <simpara>
+   Модуль <literal>Yet Another Configurations Container</literal>
+   (<acronym>Yaconf</acronym>) — контейнер конфигураций. Он разбирает
+   <literal>INI</literal>-файлы при запуске PHP и хранит результат
+   в постоянной памяти в течение всего жизненного цикла PHP, поэтому
+   каждое обращение — это быстрый поиск в хеш-таблице без обращений
+   к файлам и без разбора на каждый запрос.
+  </simpara>
+  <simpara>
+   Yaconf хранит каждую конфигурацию как интернированную строку или
+   неизменяемый массив. Для таких данных не ведётся подсчёт ссылок,
+   поэтому извлечение конфигурации из Yaconf фактически обходится
+   без копирования. Начиная с Yaconf 1.2.0 всё разобранное дерево
+   конфигураций вдобавок уплотняется в один непрерывный блок, что
+   снижает накладные расходы по памяти и улучшает локальность кеша.
+  </simpara>
+  <simpara>
+   Разобранная конфигурация находится в постоянной памяти, которую все
+   рабочие процессы PHP-FPM разделяют механизмом копирования при записи:
+   пока файл конфигурации не изменился, рабочие процессы делят одни
+   и те же физические страницы памяти, сколько бы их ни запустили.
+  </simpara>
+  <simpara>
+   Yaconf поддерживает в INI-файлах разделы и наследование разделов.
+   В сборках без ZTS модуль вдобавок автоматически перезагружает файлы
+   при их изменении; в потокобезопасных сборках (ZTS) конфигурации
+   загружаются при запуске, и чтобы подхватить изменения, требуется
+   перезапуск.
+  </simpara>
+  <simpara>
+   Начиная с Yaconf 1.2.0 подкаталоги настроенного каталога загружаются
+   рекурсивно, на глубину до 16 уровней, и адресуются с названием каталога
+   как уровнем ключа: например, вызов
+   <literal>Yaconf::get("users.database.master")</literal> читает ключ
+   <literal>master</literal> из файла <filename>database.ini</filename>,
+   который положили в подкаталог <filename>users/</filename>.
+  </simpara>
+  <simpara>
+   Хранение чувствительных конфигураций вне веб-дерева вдобавок снижает
+   поверхность атаки. Файлы конфигураций под корнем веб-сервера
+   злоумышленник может получить, например через уязвимость раскрытия
+   файлов. С модулем Yaconf файлы <filename>.ini</filename> вместо этого
+   размещают в каталоге, который доступен на чтение только root,
+   например <filename>/etc/yaconf</filename>: главный процесс PHP-FPM
+   загружает конфигурации при запуске службы, а порождённым рабочим
+   процессам, которые работают от непривилегированного пользователя
+   и обрабатывают веб-запросы, доступ к этому каталогу не нужен
+   и не предоставляется.
+  </simpara>
+  <simpara>
    Для работы модуля Yaconf требуется PHP 7.0 или выше.
-  </para>
-  <example>
-   <title>Пример INI-файла</title>
-   <programlisting role="ini">
-<![CDATA[
-;Простая пара ключ-значение
-key=val
-
-;Хеш
-hash.a=val
-
-;Массив
-arr.0=val
-;или так
-arr[]=val
-
-;PHP-константа
-version=PHP_VERSION
-
-;Переменная окружения
-env=${PATH}
-]]>
-   </programlisting>
-  </example>
-  <example>
-   <title>Пример INI-файла с разделами</title>
-   <programlisting role="ini">
-<![CDATA[
-[SectionA]
-key=val
-hash.a=val
-
-;Раздел SectionB наследует раздел SectionA
-[SectionB:SectionA]
-key=new_val ;переопределение параметра key из раздела SectionA
-]]>
-   </programlisting>
-  </example>
+  </simpara>
  </preface>
 
  &reference.yaconf.setup;
  &reference.yaconf.yaconf;
 
 </book>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: lex Status: ready -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="yaconf.configuration" xmlns="http://docbook.org/ns/docbook">
@@ -19,14 +19,14 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
-      <entry>300</entry>
+      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
-      <entry>/tmp/conf/</entry>
+      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
+      <entry><literal>300</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -39,30 +39,84 @@
 
  <para>
   <variablelist>
+   <varlistentry xml:id="ini.yaconf.directory">
+     <term>
+      <parameter>yaconf.directory</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       Каталог, в котором размещают все INI-файлы конфигураций. Загружаются
+       только файлы с расширением <filename>.ini</filename>.
+       Подкаталоги загружаются рекурсивно, на глубину до 16 уровней; каждый
+       из них выступает уровнем ключа, поэтому файл
+       <filename>database.ini</filename>, который положили в подкаталог
+       <filename>users/</filename>, адресуют как
+       <literal>"users.database"</literal>. Доступно начиная с Yaconf 1.2.0;
+       раньше загружались только файлы непосредственно в самом каталоге.
+      </simpara>
+      <simpara>
+       Примеры ниже предполагают, что в настроенном каталоге лежит следующий
+       файл <filename>database.ini</filename>, а рядом с ним —
+       файл <filename>features.ini</filename> с настройками отдельных
+       возможностей.
+      </simpara>
+      <example>
+       <title>Синтаксис INI-файла</title>
+       <programlisting role="ini">
+<![CDATA[
+; database.ini
+name=production                        ; скалярное значение
+version=PHP_VERSION                    ; PHP-константы раскрываются
+connection_string=${DATABASE_URL}      ; переменные окружения раскрываются
+options.max_connections=50             ; вложенный ключ хеша
+options.timeout=30
+
+; элементы массива, обе записи равнозначны
+replicas.0=replica-1.example.com
+replicas[]=replica-2.example.com
+]]>
+       </programlisting>
+      </example>
+      <example>
+       <title>Пример разделов INI-файла</title>
+       <programlisting role="ini">
+<![CDATA[
+; features.ini
+[default]
+cache_enabled=on
+rate_limit=100
+
+; раздел «premium» наследует каждый ключ раздела «default»
+; и переопределяет те, которые задаёт заново
+[premium:default]
+rate_limit=1000
+]]>
+       </programlisting>
+      </example>
+     </listitem>
+   </varlistentry>
    <varlistentry xml:id="ini.yaconf.check-delay">
      <term>
       <parameter>yaconf.check_delay</parameter>
       <type>int</type>
      </term>
      <listitem>
-      <para>
-        Интервал времени, в течение которого Yaconf будет определять изменение файла ini (по времени изменения директории),
-        если установлен ноль, требуется перезапуск PHP для перезагрузки конфигураций.
-      </para>
+      <simpara>
+       Интервал в секундах, с которым Yaconf проверяет, изменился ли какой-нибудь
+       из загруженных INI-файлов, и перезагружает изменившиеся; изменение
+       определяют сравнением времени изменения каталогов.
+       Значение <literal>0</literal> заставляет Yaconf проверять при каждом запросе.
+      </simpara>
+      <note>
+       <simpara>
+        Директиву регистрируют только в сборках без ZTS. В потокобезопасных
+        сборках (ZTS) конфигурации загружаются при запуске, автоматическая
+        перезагрузка недоступна; чтобы подхватить изменения, PHP перезапускают.
+       </simpara>
+      </note>
      </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yaconf.directory">
-     <term>
-      <parameter>yaconf.directory</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-        Путь к директории, в которой находятся все файлы конфигурации INI.
-      </para>
-     </listitem>
-    </varlistentry>
-
+   </varlistentry>
   </variablelist>
  </para>
 </section>

--- a/reference/yaconf/setup.xml
+++ b/reference/yaconf/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aebf045bfb7f4f2350db5e1e908cf290be334075 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="yaconf.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -13,6 +13,10 @@
 
  <section xml:id="yaconf.installation">
   &reftitle.install;
+  <simpara>
+   Модуль Yaconf устанавливают одним из трёх способов: через PECL, через PIE
+   или сборкой из исходного кода.
+  </simpara>
   <para>
    &pecl.moved;
   </para>
@@ -23,6 +27,42 @@
   <para>
    &pecl.windows.download.avail;
   </para>
+  <example>
+   <title>Установка Yaconf через PECL</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Начиная с Yaconf 1.2.0 модуль устанавливают установщиком PHP-модулей
+   &link.pie;, для чего выполняют в командной строке следующее.
+  </simpara>
+  <example>
+   <title>Установка Yaconf через PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Исходный код размещается на
+   <link xlink:href="&url.git.hub;laruence/yaconf">GitHub</link>. Чтобы собрать
+   модуль из исходного кода, выполняют в командной строке следующее, заменив
+   пути на пути локальной установки PHP.
+  </simpara>
+  <example>
+   <title>Сборка Yaconf из исходного кода</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
  </section>
 
  &reference.yaconf.ini;

--- a/reference/yaconf/yaconf/debuginfo.xml
+++ b/reference/yaconf/yaconf/debuginfo.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="yaconf.debug-info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::__debug_info</refname>
+  <refpurpose>Показывает, как хранится значение конфигурации</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Yaconf::__debug_info</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Метод возвращает отладочные сведения о значении, которое сохранили под
+   названием <parameter>name</parameter>: адрес значения в памяти и признак
+   того, находится ли значение по-прежнему внутри уплотнённого блока
+   хранилища Yaconf.
+  </simpara>
+  <warning>
+   <simpara>
+    Метод существует исключительно для собственного набора тестов Yaconf,
+    который проверяет им, что модуль работает корректно.
+    Метод не применяют в производственном коде и не полагаются на формат
+    его вывода: массив, который метод возвращает, изменяется в любой момент.
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      Название конфигурации, которую требуется исследовать; применяют ту же
+      точечную нотацию, что и в методе <methodname>Yaconf::get</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Массив (<type>array</type>) из четырёх элементов, когда конфигурация
+   существует, иначе — &null;:
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>key</literal> — название, которое искали.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>address</literal> — адрес сохранённого значения в памяти.
+     Значения хранятся как интернированные строки или неизменяемые массивы,
+     поэтому адрес остаётся постоянным, пока конфигурацию не перезагрузят.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>val</literal> — само сохранённое значение.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>changed</literal> — &false;, пока данные значения находятся
+     внутри уплотнённого блока хранилища, то есть операционной системе
+     не пришлось копировать страницу и копирование при записи ещё действует;
+     &true;, когда значение переразместили за пределами блока.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования метода <methodname>Yaconf::__debug_info</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// предполагаем, что файл app.ini содержит name="shop"
+var_dump(Yaconf::__debug_info("app.name"));
+/*
+array(4) {
+  ["key"]=>
+  string(8) "app.name"
+  ["address"]=>
+  string(14) "0x7f8b1c0a3d20"
+  ["val"]=>
+  string(4) "shop"
+  ["changed"]=>
+  bool(false)
+}
+*/
+
+var_dump(Yaconf::__debug_info("app.missing")); // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/get.xml
+++ b/reference/yaconf/yaconf/get.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a464df4c7d82ef16d94fff2582eeb8dd7579b894 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="yaconf.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::get</refname>
-  <refpurpose>Извлечь элемент</refpurpose>
+  <refpurpose>Получает значение конфигурации по названию</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -12,11 +12,19 @@
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Yaconf::get</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>default_value</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Метод получает значение конфигурации, которое сохранили под названием
+   <parameter>name</parameter>. В названиях применяют точечную нотацию, чтобы
+   обходить вложенные ключи: <literal>"app"</literal> адресует весь разобранный
+   файл <filename>app.ini</filename>, <literal>"app.name"</literal> — ключ
+   внутри него, а начиная с Yaconf 1.2.0
+   <literal>"users.database.master"</literal> — ключ в файле
+   <filename>database.ini</filename>, который положили в подкаталог
+   <filename>users/</filename>. Точечная нотация поддерживает до 64 уровней
+   вложенности.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +33,21 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      Ключ конфигурации, ключ может быть вида "filename.key" или "filename.sectionName,key".
-     </para>
+     <simpara>
+      Название конфигурации, которую требуется найти; вложенные ключи обходят
+      точечной нотацией, например <literal>"app.name"</literal>,
+      <literal>"app.features.1"</literal> или, начиная с Yaconf 1.2.0,
+      <literal>"users.database.master"</literal> для файлов в подкаталогах.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>default_value</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
-     <para>
-      Если ключа не существует, Yaconf::get вернёт значение этого параметра.
-     </para>
+     <simpara>
+      Значение, которое возвращают, когда название <parameter>name</parameter>
+      не нашли. Если параметр опустили, возвращается &null;.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,53 +55,73 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Возвращает результат конфигурации (строка или массив), если ключ существует,
-   возвращает default_value, если его нет.
-  </para>
+  <simpara>
+   Сохранённое значение конфигурации — строку (<type>string</type>) или массив
+   (<type>array</type>), — когда название <parameter>name</parameter>
+   существует; иначе значение параметра <parameter>default</parameter>
+   или &null;, если значение по умолчанию не задали.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title>Пример <function>INI</function></title>
-   <programlisting role="ini">
+  <simpara>
+   Примеры ниже предполагают, что в каталоге, который задали директивой
+   <literal>yaconf.directory</literal>, лежат следующие два файла.
+  </simpara>
+  <programlisting role="ini">
 <![CDATA[
-;файл foo.ini, находящийся в директории, заданной yaconf.directory
-[SectionA]
-;пара ключ-значение
-key=val
-;хеш
-hash.a=val
-;массив
-arr.0=val
-;или так
-arr[]=val
+; app.ini
+name="shop"                     ; скалярное значение
+debug=0                         ; число
+features[]="checkout"           ; элементы массива, обе записи
+features.1="wishlist"
+]]>
+  </programlisting>
+  <programlisting role="ini">
+<![CDATA[
+; users/database.ini, в подкаталоге (Yaconf 1.2.0+)
+master="192.168.0.10"
+replica="192.168.0.20"
+]]>
+  </programlisting>
+  <example>
+   <title>Пример использования метода <methodname>Yaconf::get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// получаем весь разобранный файл как массив
+var_dump(Yaconf::get("app"));
 
-;SectionB наследуется от SectionA
-[SectionB:SectionA]
-;переопределить конфигурацию key из раздела SectionA
-key=new_val
+// точечная нотация обходит вложенные ключи
+var_dump(Yaconf::get("app.name"));           // string(4) "shop"
+var_dump(Yaconf::get("app.features.1"));     // string(8) "wishlist"
+
+// начиная с 1.2.0: файлы в подкаталогах адресуют
+// с названием каталога как пространством имён
+var_dump(Yaconf::get("users.database.master")); // string(12) "192.168.0.10"
+
+// когда ключа нет, возвращается значение по умолчанию
+var_dump(Yaconf::get("app.missing"));             // NULL
+var_dump(Yaconf::get("app.missing", "fallback")); // string(8) "fallback"
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-php7 -r 'var_dump(Yaconf::get("foo.SectionA.key"));'
-//string(3) "val"
-
-php7 -r 'var_dump(Yaconf::get("foo.SectionB.key"));'
-//string(7) "new_val"
-
-php7 -r 'var_dump(Yaconf::get("foo")["SectionA"]["hash"]);'
-//array(1)
-
-]]>
-   </screen>
   </example>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::has</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/yaconf/yaconf/has.xml
+++ b/reference/yaconf/yaconf/has.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9cfadc46e7d5a27ae5cc17430f3aa5fc5dc27a04 Maintainer: lex Status: ready -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: lex Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="yaconf.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::has</refname>
-  <refpurpose>Определить, существует ли элемент</refpurpose>
+  <refpurpose>Проверяет, существует ли значение конфигурации</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,9 +13,13 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yaconf::has</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Метод определяет, существует ли значение конфигурации под названием
+   <parameter>name</parameter>, в котором применяют ту же точечную нотацию,
+   что и в методе <methodname>Yaconf::get</methodname>: например,
+   <literal>"app.name"</literal> или, начиная с Yaconf 1.2.0,
+   <literal>"users.database.master"</literal> для файлов в подкаталогах.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +28,11 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Название конфигурации, которую требуется найти; вложенные ключи обходят
+      точечной нотацией, например <literal>"app.name"</literal>
+      или <literal>"users.database.master"</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,13 +40,51 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
+   Функция возвращает &true;, если значение конфигурации под названием
+   <parameter>name</parameter> существует, иначе — &false;.
+  </simpara>
+ </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <simpara>
+   Примеры ниже предполагают, что в каталоге, который задали директивой
+   <literal>yaconf.directory</literal>, лежит файл
+   <filename>app.ini</filename> с ключами <literal>name="shop"</literal>
+   и <literal>debug=0</literal>.
+  </simpara>
+  <example>
+   <title>Пример использования метода <methodname>Yaconf::has</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(Yaconf::has("app.name"));     // bool(true)
+var_dump(Yaconf::has("app.missing"));  // bool(false)
+
+// удобно, чтобы отличить сохранённое пустое значение от отсутствующего ключа,
+// для которых метод Yaconf::get() вернул бы одно и то же значение по умолчанию
+if (Yaconf::has("app.debug")) {
+    $debug = (bool) Yaconf::get("app.debug");
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 
-
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Syncs the `reference/yaconf/` pages with php/doc-en#5801.

- `book.xml`: the introduction is rewritten around what the extension actually does: parsing at startup with no per-request I/O, zero-copy retrieval, the 1.2.0 compacted storage block, the copy-on-write sharing between PHP-FPM workers, the ZTS restriction on automatic reloading, the 1.2.0 recursive sub-directory loading, and the attack-surface argument for keeping the INI files outside the web tree.
- `setup.xml`: documents the three installation routes, PECL, PIE (`pie install laruence/yaconf`, since 1.2.0) and building from source, each with its own example.
- `ini.xml`: `yaconf.directory` comes first, with its real default (empty, not `/tmp/conf/`), the `.ini` extension requirement and the recursive sub-directory behaviour, plus the INI syntax and section inheritance examples moved here from the book. `yaconf.check_delay` explains that `0` means checking on every request, not that a restart is required, and gains the note that the directive only exists in non-ZTS builds.
- `Yaconf::get()` and `Yaconf::has()`: the dot notation is documented, including the 64 nesting levels and the sub-directory addressing, with worked examples; `Yaconf::get()` documents the `default` parameter and what is returned when the key is missing.
- Adds `Yaconf::__debug_info()`, translating the new page, with the warning that it exists only for the extension's own test suite.

`reference/yaconf/versions.xml` is not added: it is EN-only infrastructure with no Russian counterpart.

EN-Revision bumped to 3b052562d228be18fa6dce221df7e375469fb7ad on the six files.

Fixes: #1702
