### PR TITLE
[Sync-EN] Revise the Taint extension documentation

### DIFF
--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -1,61 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cfe2c34143ab17e522b1594ae0902b7245f072d5 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
-
 <book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
- <title>Модуль определения «грязных» строк Taint</title>
+ <title>Taint</title>
  <titleabbrev>Taint</titleabbrev>
 
  <preface xml:id="intro.taint">
   &reftitle.intro;
-  <para>
-   Taint — модуль определения XSS-кодов — вредоносных, или «грязных» строк (англ. tainted strings).
-   Модуль также помогает выявлять попытки внедрения SQL-инъекций,
-   shell-инъекций и т. д.
-  </para>
-  <para>
-   Модуль выдаст предупреждение при передаче в отдельные функции подозрительной строки,
-   которую получили из суперглобальных переменных <varname>$_GET</varname>,
-   <varname>$_POST</varname> или <varname>$_COOKIE</varname>.
-  </para>
+  <simpara>
+   Taint — модуль для обнаружения XSS-кода, то есть заражённых строк.
+   Модулем также выявляют SQL-инъекции, инъекции команд, инъекции путей
+   к файлам и похожие уязвимости.
+  </simpara>
+  <simpara>
+   Когда модуль taint включили, строки, которые пришли из пользовательского
+   ввода — <varname>$_GET</varname>, <varname>$_POST</varname>
+   и <varname>$_COOKIE</varname>, — помечаются как заражённые при запуске
+   запроса, и метка отслеживается через строковые операции. Когда заражённая
+   строка попадает в опасный приёмник — вывод, SQL-запрос, команду оболочки,
+   путь к файлу и так далее, — taint поднимает предупреждение, которое
+   указывает на это место. Полные списки приводит раздел
+   «<link linkend="taint.detail">Распространение и проверяемые приёмники</link>».
+  </simpara>
+  <simpara>
+   Taint — инструмент разработки и аудита, а не средство защиты во время
+   выполнения: он только сообщает о возможных проблемах и никогда не блокирует
+   и не изменяет данные. Модуль намеренно осторожен и иногда сообщает лишнее,
+   поэтому чистый прогон означает лишь «taint ничего не увидел», но никогда —
+   «доказано безопасно». В производственной среде модуль не включают.
+  </simpara>
   <example>
-   <title>Пример определения вредоносных строк функцией <function>taint</function></title>
+   <title>Пример работы модуля Taint</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $a = trim($_GET['a']);
 
-$file_name = '/tmp' .  $a;
-
+$file_name = '/tmp/' . $a;
 $output    = "Welcome, {$a} !!!";
-
-$var       = "output";
-$sql       = "SELECT * FROM " . $a;
-$sql      .= "ooxx";
+$sql       = "SELECT * FROM users WHERE name = " . $a;
 
 echo $output;
-
-print $$var;
-
+print $output;
 include $file_name;
-
-mysql_query($sql);
-
+mysqli_query($link, $sql);
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Warning: main() [function.echo]: Attempt to echo a string that might be tainted
+Warning: main() [echo]: Attempt to echo a string that might be tainted in /path/to/script.php on line 9
 
-Warning: main() [function.echo]: Attempt to print a string that might be tainted
+Warning: main() [print]: Attempt to print a string that might be tainted in /path/to/script.php on line 10
 
-Warning: include() [function.include]: File path contains data that might be tainted
+Warning: main() [include]: File path contains data that might be tainted in /path/to/script.php on line 11
 
-Warning: mysql_query() [function.mysql-query]: SQL statement contains data that might be tainted
+Warning: main() [mysqli_query]: SQL statement contains data that might be tainted in /path/to/script.php on line 12
 ]]>
    </screen>
   </example>
@@ -66,6 +68,7 @@ Warning: mysql_query() [function.mysql-query]: SQL statement contains data that 
  &reference.taint.reference;
 
 </book>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/configure.xml
+++ b/reference/taint/configure.xml
@@ -1,16 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="taint.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
-  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>
+  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
+ </simpara>
+
+ <simpara>
+  Модуль устанавливают через <acronym>PECL</acronym>:
+ </simpara>
+ <para>
+  <screen>
+<![CDATA[
+$ pecl install taint
+]]>
+  </screen>
  </para>
 
+ <para>
+  Исходный код размещается на
+  <link xlink:href="&url.git.hub;laruence/taint">GitHub</link>. Чтобы собрать
+  модуль из исходного кода:
+  <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/taint.git
+$ cd taint
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+  </screen>
+ </para>
 
+ <simpara>
+  Затем модуль включают, добавив в файл &php.ini; строку
+  <literal>extension=taint.so</literal> (или
+  <literal>extension=php_taint.dll</literal> в ОС Windows) и установив
+  директиве <link linkend="ini.taint.enable">taint.enable</link>
+  значение <literal>1</literal>.
+ </simpara>
+
+ <warning>
+  <simpara>
+   Taint — инструмент разработки и аудита. Его не включают в производственной
+   среде: инструментирование замедляет каждый запрос и отключает JIT
+   в OPcache, а предупреждения переносят данные запроса в журналы.
+  </simpara>
+ </warning>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/taint/detail.xml
+++ b/reference/taint/detail.xml
@@ -1,321 +1,278 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6d12569dcee7ac2012400c439eee8a971b813 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="taint.detail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Дополнительные подробности</title>
+ <title>Распространение и проверяемые приёмники</title>
 
  <section xml:id="taint.detail.basic">
-  <title>Функции и операторы, которые могут распространять сомнительный символ
-   испорченной строки</title>
+  <title>Как распространяется метка заражённости</title>
+  <simpara>
+   Метка заражённости — один бит, который хранят на самой строке, а не
+   на переменной. Присваивание, передача и любое другое совместное
+   использование заражённой строки сохраняют метку. Конкатенация строк
+   и интерполяция тоже её распространяют:
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Функция/Оператор</entry>
-       <entry>Мин. версия</entry>
-      </row>
-     </thead>
+    <title>Операторы, которые распространяют метку заражённости</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry>= (присваивание)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>=</literal> (присваивание, включая <literal>list()</literal> и <literal>деструктуризацию массива</literal>)</entry>
       </row>
       <row>
-       <entry>. (конкатенация)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.</literal> (конкатенация)</entry>
       </row>
       <row>
-       <entry>"{$var}" (подстановка переменных)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.=</literal> (присваивание с конкатенацией)</entry>
       </row>
       <row>
-       <entry>.= (присваивание с конкатенацией)</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>strval</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>explode/split</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>implode/join</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>vsprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>trim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>rtrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>ltrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>strstr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_pad</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_replace</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>substr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtolower</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtoupper</entry>
-       <entry>0.5.0</entry>
+       <entry><literal>"{$var}"</literal> (интерполяция строк, включая быстрый путь <literal>ROPE</literal>)</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
- </section>
-
- <section xml:id="taint.detail.taint">
-  <title>Функции и операторы, которые проверяют испорченные строки</title>
+  <simpara>
+   Кроме того, taint знает фиксированный набор строковых функций: когда
+   какой-нибудь из значимых строковых аргументов заражён, возвращаемая строка
+   тоже помечается как заражённая. Охватываются и обычный вызов, и — начиная
+   с PHP 8.4 — вызов по быстрому безкадровому пути.
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Функция/Оператор</entry>
-       <entry>Мин. версия</entry>
-      </row>
-     </thead>
+    <title>Функции, которые распространяют метку заражённости</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry namest="name" nameend="version">Основные выражения</entry>
+       <entry><function>trim</function>, <function>rtrim</function>, <function>ltrim</function></entry>
       </row>
       <row>
-       <entry>eval</entry>
-       <entry>0.1.0</entry>
+       <entry><function>substr</function>, <function>strstr</function></entry>
       </row>
       <row>
-       <entry>include/include_once</entry>
-       <entry>0.1.0</entry>
+       <entry><function>str_replace</function>, <function>str_ireplace</function></entry>
       </row>
       <row>
-       <entry>require/require_once</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!--end basic -->
-
-      <row>
-       <entry namest="name" nameend="version">Функции вывода</entry>
+       <entry><function>str_pad</function>, <function>strtolower</function>, <function>strtoupper</function>, <function>strval</function></entry>
       </row>
       <row>
-       <entry>echo</entry>
-       <entry>0.1.0</entry>
+       <entry><function>explode</function> (каждый элемент получившегося массива)</entry>
       </row>
       <row>
-       <entry>print</entry>
-       <entry>0.1.0</entry>
+       <entry><function>implode</function>/<function>join</function> (заражённый разделитель тоже заражает результат)</entry>
       </row>
       <row>
-       <entry>printf</entry>
-       <entry>0.1.0</entry>
+       <entry><function>sprintf</function>, <function>vsprintf</function> (метку несёт только спецификатор <literal>%s</literal>; вызов <literal>sprintf("%d", $t)</literal> возвращает чистую строку)</entry>
       </row>
       <row>
-       <entry>file_put_contents</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!-- end outputing -->
-      <row>
-       <entry namest="name" nameend="version">Функции файловой системы</entry>
-      </row>
-      <row>
-       <entry>fopen</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>opendir</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>basename</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>dirname</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>file</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>pathinfo</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <!-- end file system -->
-      <row>
-       <entry namest="name" nameend="version">Соответствующие функции базы данных</entry>
-      </row>
-      <row>
-       <entry>mysql_query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_query/MySQLi::query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_query/SqliteDataBase::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_single_query/SqliteDataBase::singleQuery</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>oci_parse</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::prepare</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>SQLite3::query</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <row>
-       <entry>SQLite3::prepare</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <!-- end database -->
-      <row>
-       <entry namest="name" nameend="version">Соответствующие функции командной строки</entry>
-      </row>
-      <row>
-       <entry>system</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>exec</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>proc_open</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>passthru</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>shell_exec</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <!-- end command line -->
-
-     </tbody>
-    </tgroup>
-   </table>
-  </para>
- </section>
-
- <section xml:id="taint.detail.untaint">
-  <title>Функции, которые не будут обрабатывать испорченную строку</title>
-  <para>
-   <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Функция/Оператор</entry>
-       <entry>Мин. версия</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>addslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>addcslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlspecialchars</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlentities</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>escapeshellcmd</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_escape_string/MySQLi::escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_real_escape_string/MySQLi::real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_escape_string/SqliteDataBase::escapeString</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::quote</entry>
-       <entry>0.3.0</entry>
+       <entry><function>dirname</function>, <function>basename</function>, <function>pathinfo</function></entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
-
+  <simpara>
+   Каждая функция, которую taint не понимает явно, возвращает новую строку
+   без метки — включая вспомогательные функции экранирования вроде
+   <function>htmlspecialchars</function>, <function>htmlentities</function>
+   или <function>mysqli_real_escape_string</function>. Так сделали намеренно:
+   taint скорее сообщит лишнее, чем возьмётся решать, «безопасно» ли значение
+   для конкретного контекста вывода. Чтобы снять метку со значений, которые
+   проверили самостоятельно, вызывают функцию <function>untaint</function>.
+  </simpara>
  </section>
+
+ <section xml:id="taint.detail.sinks">
+  <title>Где taint поднимает предупреждения</title>
+  <simpara>
+   Когда заражённая строка попадает в один из приёмников ниже, taint поднимает
+   предупреждение — по умолчанию уровня <constant>E_USER_WARNING</constant>;
+   уровень настраивают директивой
+   <link linkend="ini.taint.error-level">taint.error_level</link>.
+   Проверяются только строковые аргументы верхнего уровня; вывод массива,
+   который лишь содержит заражённые значения, предупреждения не вызывает.
+  </simpara>
+  <para>
+   <table>
+    <title>Приёмники вывода</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><literal>echo</literal>, <literal>print</literal></entry>
+       <entry>выражение, которое выводят</entry>
+      </row>
+      <row>
+       <entry><function>printf</function>, <function>vprintf</function></entry>
+       <entry>строку формата и подставляемые значения</entry>
+      </row>
+      <row>
+       <entry><function>print_r</function>, <function>var_dump</function>, <function>var_export</function></entry>
+       <entry>значение, которое выводят, если это строка</entry>
+      </row>
+      <row>
+       <entry><literal>exit</literal>/<literal>die</literal> с сообщением</entry>
+       <entry>сообщение</entry>
+      </row>
+      <row>
+       <entry><function>file_put_contents</function>, <function>fwrite</function>, <function>fputs</function> в <literal>php://output</literal></entry>
+       <entry>данные, которые записывают</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Приёмники файловой системы</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>fopen</function>, <function>opendir</function>, <function>unlink</function></entry>
+       <entry>путь</entry>
+      </row>
+      <row>
+       <entry><function>file</function>, <function>readfile</function>, <function>file_get_contents</function>, <function>highlight_file</function>/<function>show_source</function></entry>
+       <entry>путь</entry>
+      </row>
+      <row>
+       <entry><function>copy</function>, <function>rename</function>, <function>move_uploaded_file</function></entry>
+       <entry>и исходный путь, и путь назначения</entry>
+      </row>
+      <row>
+       <entry><function>mkdir</function>, <function>rmdir</function>, <function>touch</function></entry>
+       <entry>путь</entry>
+      </row>
+      <row>
+       <entry><literal>include</literal>, <literal>include_once</literal>, <literal>require</literal>, <literal>require_once</literal></entry>
+       <entry>путь к файлу</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>SQL-приёмники</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>mysqli_query</function>, <function>mysqli_prepare</function>, <function>mysqli_real_query</function>, <function>mysqli_multi_query</function></entry>
+       <entry>строку запроса</entry>
+      </row>
+      <row>
+       <entry><function>mysql_query</function>, <function>sqlite_query</function>, <function>sqlite_single_query</function>, <function>oci_parse</function>, <function>pg_query</function>, <function>pg_send_query</function></entry>
+       <entry>строку запроса</entry>
+      </row>
+      <row>
+       <entry><methodname>mysqli::query</methodname>, <methodname>mysqli::prepare</methodname>, <methodname>mysqli::real_query</methodname>, <methodname>mysqli::multi_query</methodname></entry>
+       <entry>строку запроса</entry>
+      </row>
+      <row>
+       <entry><methodname>PDO::query</methodname>, <methodname>PDO::prepare</methodname>, <methodname>PDO::exec</methodname></entry>
+       <entry>строку запроса</entry>
+      </row>
+      <row>
+       <entry><methodname>SQLite3::query</methodname>, <methodname>SQLite3::prepare</methodname>, <methodname>SQLite3::exec</methodname>, <methodname>SQLiteDatabase::query</methodname>, <methodname>SQLiteDatabase::singleQuery</methodname></entry>
+       <entry>строку запроса</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Приёмники выполнения команд</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>exec</function>, <function>system</function>, <function>passthru</function>, <function>shell_exec</function> (включая оператор «обратный апостроф»)</entry>
+       <entry>строку команды</entry>
+      </row>
+      <row>
+       <entry><function>proc_open</function>, <function>popen</function></entry>
+       <entry>строку команды</entry>
+      </row>
+      <row>
+       <entry><literal>eval</literal></entry>
+       <entry>код, который выполняют</entry>
+      </row>
+      <row>
+       <entry>динамические вызовы вроде <literal>$func()</literal>, <literal>$obj-&gt;$method()</literal>, <function>call_user_func</function>, вызываемые массивы</entry>
+       <entry>название функции, метода или класса, которое разрешают</entry>
+      </row>
+      <row>
+       <entry><function>preg_match</function>, <function>preg_match_all</function>, <function>preg_replace</function>, <function>preg_split</function>, <function>preg_grep</function>, <function>preg_replace_callback</function></entry>
+       <entry>шаблон, а для функции <function>preg_replace_callback</function> ещё и название функции обратного вызова</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Приёмники заголовков и cookie</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>header</function></entry>
+       <entry>строку заголовка</entry>
+      </row>
+      <row>
+       <entry><function>setcookie</function>, <function>setrawcookie</function></entry>
+       <entry>название и значение cookie</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Прочие приёмники</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Приёмник</entry><entry>Что проверяют</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>unserialize</function></entry>
+       <entry>сериализованную строку</entry>
+      </row>
+      <row>
+       <entry><function>mail</function></entry>
+       <entry>получателя, тему, дополнительные параметры и дополнительные заголовки; тело письма — это содержимое, и его не проверяют</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   Предупреждения следуют формату
+   <literal>function_name() [sink]: message</literal>, где
+   <literal>sink</literal> определяет проверяемую операцию — например,
+   <literal>echo</literal>, <literal>include</literal> или название функции, —
+   а сообщение описывает, что признали возможно заражённым.
+  </simpara>
+ </section>
+
 </chapter>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>is_tainted</refname>
-  <refpurpose>Проверяет, испорчена ли строка</refpurpose>
+  <refpurpose>Проверяет, заражена ли строка</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,10 +14,11 @@
    <type>bool</type><methodname>is_tainted</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Проверяет, является ли строка испорченной
-  </para>
-
+  <simpara>
+   Функция проверяет, несёт ли переданное значение метку заражённости.
+   Заражёнными бывают только строки; для любого другого типа функция
+   возвращает &false;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +27,9 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Значение, которое требуется проверить.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,13 +37,46 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Функция возвращает &true;, если значение — заражённая строка,
+   иначе — &false;. Функция всегда возвращает &false;, когда директиву
+   <link linkend="ini.taint.enable">taint.enable</link> выключили.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования функции <function>is_tainted</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = $_GET['name'] ?? 'world';
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Возвращает &true;, если строка испорчена или &false; в противном случае.
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>untaint</function></member>
+   </simplelist>
   </para>
  </refsect1>
 
-
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>taint</refname>
-  <refpurpose>Испортить строку</refpurpose>
+  <refpurpose>Помечает строки как заражённые</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,21 @@
   <methodsynopsis>
    <type>bool</type><methodname>taint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Делает строку испорченной строку. Используется в целях отладки.
-  </para>
+  <simpara>
+   Функция вручную помечает переданные строки как заражённые, как если бы они
+   пришли из пользовательского ввода. Переменные передают по ссылке, но саму
+   метку хранят на строке, а не на переменной: заражёнными сразу становятся
+   все переменные, которые делят одну и ту же строку.
+  </simpara>
+  <simpara>
+   В основном функция пригождается для тестирования и для имитации
+   пользовательского ввода в CLI-скриптах, где суперглобальные переменные
+   <link linkend="reserved.variables.get">$_GET</link>,
+   <link linkend="reserved.variables.post">$_POST</link> и
+   <link linkend="reserved.variables.cookies">$_COOKIE</link> не заполняются.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,16 +36,17 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Переменная со строкой, которую требуется пометить.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-     </para>
+     <simpara>
+      Дополнительные переменные, которые требуется пометить.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,14 +54,63 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Функция всегда возвращает &true;. Когда директиву
+   <link linkend="ini.taint.enable">taint.enable</link> выключили, функция
+   ничего не делает и всё равно возвращает &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования функции <function>taint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = "world";
+taint($name);
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Помечаются только непустые строки; переменные с другими типами
+    и пустые строки молча пропускаются.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Интернированные, постоянные и неизменяемые строки — строковые литералы,
+    разделяемые строки OPcache — метку нести не могут и молча пропускаются.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Возвращает &true;, если преобразование строки выполнено.
-   Всегда возвращает &true;, если модуль taint не включён.
+   <simplelist>
+    <member><function>untaint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
   </para>
  </refsect1>
 
-
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>untaint</refname>
-  <refpurpose>Исправить строку</refpurpose>
+  <refpurpose>Снимает со строк метку заражённости</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,17 @@
   <methodsynopsis>
    <type>bool</type><methodname>untaint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Исправляет испорченную строку
-  </para>
+  <simpara>
+   Функция снимает метку заражённости с переданных строк.
+  </simpara>
+  <simpara>
+   Метку хранят на самой строке, а не на переменной, поэтому функция снимает
+   её сразу для всех переменных, которые делят одну и ту же строку. Функцию
+   применяют, чтобы занести в белый список значения, которые проверили
+   самостоятельно, например после строгой проверки по списку разрешённых.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +32,17 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Переменная со строкой, которую требуется очистить.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Дополнительные переменные, которые требуется очистить.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,13 +50,61 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
+   Функция всегда возвращает &true;. Когда директиву
+   <link linkend="ini.taint.enable">taint.enable</link> выключили, функция
+   ничего не делает и всё равно возвращает &true;.
+  </simpara>
+ </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Пример использования функции <function>untaint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$id = "42";
+taint($id);
+if (preg_match('/^\d+$/', $id)) {
+    // строго проверили, что это только цифры: значению можно доверять
+    untaint($id);
+}
+var_dump(is_tainted($id));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Метку могут нести только строковые значения; передача значения
+    другого типа ничего не делает.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
   </para>
  </refsect1>
 
-
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
@@ -26,7 +26,7 @@
      </row>
      <row>
       <entry><link linkend="ini.taint.error-level">taint.error_level</link></entry>
-      <entry>E_WARNING</entry>
+      <entry>512 (E_USER_WARNING)</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -40,32 +40,61 @@
  <para>
   <variablelist>
    <varlistentry xml:id="ini.taint.enable">
-    <term>
-     <parameter>taint.enable</parameter>
-     <type>int</type>
-    </term>
-    <listitem>
-     <para>
-      Включён ли модуль.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="ini.taint.error-level">
-    <term>
-     <parameter>taint.error_level</parameter>
-     <type>int</type>
-    </term>
-    <listitem>
-     <para>
-      Тип ошибки, который будет возвращать модуль при обнаружении
-      подозрительной строки.
-     </para>
-    </listitem>
-   </varlistentry>
-
+     <term>
+      <parameter>taint.enable</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Главный переключатель. Когда директиву включили, taint перехватывает
+       исполнитель и помечает строки из <varname>$_GET</varname>,
+       <varname>$_POST</varname> и <varname>$_COOKIE</varname> как заражённые
+       при запуске запроса.
+      </simpara>
+      <simpara>
+       Директиву задают только в файле &php.ini;: её включение требует
+       перезапуска процесса, поэтому переключать её на каждый запрос
+       или на каждый каталог нельзя.
+      </simpara>
+      <note>
+       <simpara>
+        Директиву не включают в производственной среде: инструментирование
+        замедляет каждый запрос и несовместимо с JIT в OPcache.
+       </simpara>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.taint.error-level">
+     <term>
+      <parameter>taint.error_level</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Уровень ошибки, который taint применяет, когда сообщает о возможно
+       заражённой строке. Значение по умолчанию —
+       <constant>E_USER_WARNING</constant> (512).
+      </simpara>
+      <simpara>
+       Поскольку директива относится к режиму <constant>INI_ALL</constant>,
+       её изменяют во время выполнения. Например, чтобы заглушить
+       предупреждения taint для текущего скрипта:
+      </simpara>
+      <para>
+       <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('taint.error_level', 0);
+?>
+]]>
+       </programlisting>
+      </para>
+     </listitem>
+    </varlistentry>
   </variablelist>
  </para>
 </section>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/reference.xml
+++ b/reference/taint/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="ref.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/setup.xml
+++ b/reference/taint/setup.xml
@@ -1,25 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 307e7d78baacfcd228eef8f384e96659b67d9adb Maintainer: rjhdby Status: ready -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: rjhdby Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="taint.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <section xml:id="taint.installation">
-  &reftitle.install;
-  <para>
-   &pecl.moved;
-  </para>
-  <para>
-   &pecl.info;
-   <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
-  </para>
+ <section xml:id="taint.requirements">
+  &reftitle.required;
+  <simpara>
+   Для работы Taint 3.x требуется PHP 8.0 или новее. Для PHP 7.x берут
+   выпуски taint 2.1.x, а для PHP 5.x — выпуски taint 1.x.
+  </simpara>
  </section>
+
+ <!-- {{{ Installation -->
+ &reference.taint.configure;
+ <!-- }}} -->
 
  <!-- {{{ Configuration -->
  &reference.taint.ini;
  <!-- }}} -->
 
+ <section xml:id="taint.resources">
+  &reftitle.resources;
+  <simpara>
+   Модуль Taint не определяет типов ресурсов. Саму метку заражённости хранят
+   во внутренней структуре <literal>zend_string</literal>, а не в ресурсе,
+   который виден пользователю.
+  </simpara>
+ </section>
+
 </chapter>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Syncs the nine `reference/taint/` files with php/doc-en#5802.

- `book.xml`: the introduction explains what taint actually does, that the mark is applied to `$_GET`, `$_POST` and `$_COOKIE` at request startup and tracked through string operations, and states plainly that taint is a development and auditing tool that reports rather than blocks, may over-report, and must not be enabled in production. The example is replaced by one that shows all four warning kinds.
- `detail.xml` is rewritten as "Propagation and checked sinks": the operators and the fixed list of functions that carry the mark, the fact that unknown functions (including `htmlspecialchars()` and `mysqli_real_escape_string()`) return an unmarked string by design, and complete tables of the output, filesystem, SQL, command execution, header/cookie and other sinks, plus the warning format.
- `setup.xml`: adds the version requirements (taint 3.x needs PHP 8.0+, 2.1.x for PHP 7.x, 1.x for PHP 5.x) and a resources section stating the extension defines no resource types.
- `configure.xml`: documents installing from PECL and building from source, enabling `extension=taint.so` and `taint.enable`, plus the production warning.
- `ini.xml`: both directives are described, `taint.enable` as a php.ini-only master switch incompatible with the OPcache JIT, and `taint.error_level` with its default and the runtime `ini_set()` example.
- `is_tainted()`, `taint()` and `untaint()` get real descriptions, parameters, return values, examples and notes, including that the mark lives on the string rather than the variable and that interned strings can never carry it.
- `reference.xml`: EN-Revision bump only.

EN-Revision bumped to befe2b9fbe37b0925498f336632742651386b151 on the nine files.

Fixes: #1704
